### PR TITLE
[finance_report_audit] Migration closeout 2.10+2.11: distribute reporting and portfolio EPIC AC rows into package roadmaps

### DIFF
--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -73,7 +73,7 @@ def patch_database_connection():
 
 
 def test_AC5_9_1_package_contract_endpoint_defines_required_sections():
-    """AC5.9.1: Package contract endpoint defines stable required sections."""
+    """AC-reporting.package-contract.1: AC5.9.1: Package contract endpoint defines stable required sections."""
     response = personal_report_package_contract()
     payload = response.model_dump(mode="json")
     assert payload["package_id"] == "personal-financial-report-package"
@@ -100,7 +100,7 @@ def test_AC5_9_1_package_contract_endpoint_defines_required_sections():
 
 
 def test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics():
-    """AC5.9.2: Contract exposes Decimal-safe totals and date semantics."""
+    """AC-reporting.package-contract.2: AC5.9.2: Contract exposes Decimal-safe totals and date semantics."""
     response = personal_report_package_contract()
     payload = response.model_dump(mode="json")
     assert payload["period_semantics"] == {
@@ -141,7 +141,7 @@ def test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics():
 
 
 def test_AC5_11_1_package_contract_marks_annualized_schedule_ready():
-    """AC5.11.1: Annualized income package section points to the ready schedule endpoint."""
+    """AC-reporting.package-annualized.1: AC5.11.1: Annualized income package section points to the ready schedule endpoint."""
     response = personal_report_package_contract()
     payload = response.model_dump(mode="json")
 
@@ -153,7 +153,7 @@ def test_AC5_11_1_package_contract_marks_annualized_schedule_ready():
 
 
 def test_AC5_12_1_package_notes_endpoint_returns_required_note_taxonomy():
-    """AC5.12.1: Package notes endpoint returns standards-inspired disclosure notes."""
+    """AC-reporting.package-notes.1: AC5.12.1: Package notes endpoint returns standards-inspired disclosure notes."""
     response = personal_report_package_notes()
     payload = response.model_dump(mode="json")
 
@@ -183,7 +183,7 @@ def test_AC5_12_1_package_notes_endpoint_returns_required_note_taxonomy():
 
 
 def test_AC5_12_2_package_contract_marks_notes_ready():
-    """AC5.12.2: Package contract marks notes ready and points to the notes endpoint."""
+    """AC-reporting.package-notes.2: AC5.12.2: Package contract marks notes ready and points to the notes endpoint."""
     response = personal_report_package_contract()
     payload = response.model_dump(mode="json")
 
@@ -370,7 +370,7 @@ async def test_AC5_19_1_package_generate_creates_draft_or_trusted_snapshot(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC5.19.1: Package generation freezes context and gates draft/trusted state by readiness."""
+    """AC-reporting.package-snapshot.1: AC5.19.1: Package generation freezes context and gates draft/trusted state by readiness."""
     await _patch_package_snapshot_inputs(monkeypatch, readiness_state="blocked", blocking_count=1)
 
     draft = await generate_personal_report_package_snapshot(
@@ -426,7 +426,7 @@ async def test_AC5_19_2_package_snapshot_get_is_user_scoped_and_immutable(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC5.19.2: Package snapshots list/get by user and reopen the frozen payload."""
+    """AC-reporting.package-snapshot.2: AC5.19.2: Package snapshots list/get by user and reopen the frozen payload."""
     await _patch_package_snapshot_inputs(monkeypatch, readiness_state="ready", blocking_count=0, section_label="Frozen")
     snapshot = await generate_personal_report_package_snapshot(
         framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
@@ -478,7 +478,7 @@ async def test_AC5_19_3_package_snapshot_exports_are_snapshot_derived(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC5.19.3: Package JSON and CSV exports stream saved snapshot data only."""
+    """AC-reporting.package-snapshot.3: AC5.19.3: Package JSON and CSV exports stream saved snapshot data only."""
     await _patch_package_snapshot_inputs(
         monkeypatch, readiness_state="ready", blocking_count=0, section_label="Frozen CSV"
     )
@@ -592,7 +592,7 @@ async def test_AC19_5_1_package_readiness_returns_draft_for_empty_user(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.5.1: Package readiness endpoint returns deterministic draft state for empty users."""
+    """AC-reporting.readiness.1: AC19.5.1: Package readiness endpoint returns deterministic draft state for empty users."""
     response = await personal_report_package_readiness(db=db, user_id=test_user.id)
     payload = response.model_dump(mode="json")
 
@@ -666,7 +666,7 @@ async def test_AC19_5_2_package_readiness_lists_actionable_blockers(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.5.2: Blocked readiness lists exact blocker categories and action links."""
+    """AC-reporting.readiness.2: AC19.5.2: Blocked readiness lists exact blocker categories and action links."""
     covered_account = Account(user_id=test_user.id, name="Covered Cash", type=AccountType.ASSET, currency="SGD")
     uncovered_account = Account(user_id=test_user.id, name="Uncovered Card", type=AccountType.LIABILITY, currency="SGD")
     processing_account = Account(
@@ -769,7 +769,7 @@ async def test_AC19_5_6_package_readiness_rejects_duplicate_processing_accounts(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.5.6: Duplicate Processing system accounts are data corruption, not arbitrary readiness input."""
+    """AC-reporting.readiness.4: AC19.5.6: Duplicate Processing system accounts are data corruption, not arbitrary readiness input."""
     db.add_all(
         [
             Account(
@@ -800,7 +800,7 @@ async def test_AC19_5_7_package_readiness_converts_processing_balance_before_zer
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.5.7: Processing readiness cannot net unlike currencies at raw nominal amount."""
+    """AC-reporting.readiness.5: AC19.5.7: Processing readiness cannot net unlike currencies at raw nominal amount."""
     processing_account = Account(
         user_id=test_user.id,
         name="Processing",
@@ -932,7 +932,7 @@ async def test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.5.3: Readiness states are deterministic across processing, ready, generated, and stale."""
+    """AC-reporting.readiness.3: AC19.5.3: Readiness states are deterministic across processing, ready, generated, and stale."""
     processing = _statement(
         test_user.id,
         status=BankStatementStatus.PARSING,
@@ -989,7 +989,7 @@ async def test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness(
 
 @ac_proof(
     "personal-package-source-trust-pr",
-    ac_ids=["AC19.9.1", "AC-testing.trust-mirrors.3"],
+    ac_ids=["AC-reporting.source-trust.1", "AC-testing.trust-mirrors.3"],
     scope="behavioral",
     ci_tier="pr_ci",
     trust_mode="deterministic_pr",
@@ -1008,7 +1008,7 @@ async def test_AC19_9_1_package_readiness_reports_source_trust_summary(
     db: AsyncSession,
     test_user: User,
 ):
-    """AC19.9.1 AC-testing.trust-mirrors.3: Package readiness reports deterministic source trust coverage."""
+    """AC-reporting.source-trust.1 AC-testing.trust-mirrors.3: AC19.9.1 AC8.14.3: Package readiness reports deterministic source trust coverage."""
     report_date = date(2026, 5, 31)
     await _ready_source_account(db, test_user.id)
     db.add(
@@ -1107,7 +1107,7 @@ async def test_AC19_9_1_package_readiness_reports_source_trust_summary(
 
 
 async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
-    """AC5.13.1: Package traceability endpoint returns source-to-ledger anchors per report line."""
+    """AC-reporting.package-traceability.1 · AC-reporting.trust-signals.3: AC5.13.1: Package traceability endpoint returns source-to-ledger anchors per report line."""
     response = await personal_report_package_traceability()
     payload = response.model_dump(mode="json")
 
@@ -1135,7 +1135,7 @@ async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_ancho
 
 
 async def test_AC5_13_2_package_traceability_declares_completeness_warnings():
-    """AC5.13.2: Traceability appendix exposes explicit completeness states where anchors are unavailable."""
+    """AC-reporting.package-traceability.2: AC5.13.2: Traceability appendix exposes explicit completeness states where anchors are unavailable."""
     response = await personal_report_package_traceability()
     payload = response.model_dump(mode="json")
 
@@ -1167,7 +1167,7 @@ async def test_AC5_13_5_package_traceability_returns_dynamic_current_user_identi
     db: AsyncSession,
     test_user: User,
 ):
-    """AC5.13.5: Traceability returns current-user dynamic identifiers without cross-user leakage."""
+    """AC-reporting.package-traceability.4: AC5.13.5: Traceability returns current-user dynamic identifiers without cross-user leakage."""
     report_date = date(2026, 5, 31)
     statement_txn_id = uuid4()
     other_user = User(email=f"other-trace-{uuid4()}@example.com", hashed_password="hashed")
@@ -1713,7 +1713,7 @@ async def test_AC19_10_1_unknown_journal_source_ids_are_not_reported_as_statemen
     db: AsyncSession,
     test_user: User,
 ):
-    """AC-extraction.1808.5: AC18.8.5 AC19.10.1: Unknown journal source IDs remain explicit blockers, not fake statement anchors."""
+    """AC-reporting.source-anchors.1: AC-extraction.1808.5: AC18.8.5 AC19.10.1: Unknown journal source IDs remain explicit blockers, not fake statement anchors."""
     report_date = date(2026, 5, 31)
     bank = Account(user_id=test_user.id, name="Unknown Source Bank", type=AccountType.ASSET, currency="SGD")
     income = Account(user_id=test_user.id, name="Unknown Source Income", type=AccountType.INCOME, currency="SGD")

--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -189,7 +189,7 @@ class TestReportsEndpoints:
         assert mock_service.called
 
     async def test_account_trend_with_period(self, client: AsyncClient, db, test_user: User):
-        """AC5.3.3: Test getting account trend with different period."""
+        """AC-reporting.cash-flow.3: AC5.3.3: Test getting account trend with different period."""
         # GIVEN existing account
         account = Account(
             id=uuid4(),
@@ -209,7 +209,7 @@ class TestReportsEndpoints:
 
     @patch("src.routers.reports.get_category_breakdown")
     async def test_category_breakdown_success(self, mock_service: AsyncMock, client: AsyncClient, db, test_user: User):
-        """AC5.3.4: Test getting category breakdown."""
+        """AC-reporting.cash-flow.4: AC5.3.4: Test getting category breakdown."""
         # GIVEN mocked service
         from src.models.account import AccountType
 
@@ -234,7 +234,7 @@ class TestReportsEndpoints:
         assert mock_service.called
 
     async def test_category_breakdown_with_period(self, client: AsyncClient, db, test_user: User):
-        """AC5.3.5: Test getting category breakdown with different period."""
+        """AC-reporting.cash-flow.5: AC5.3.5: Test getting category breakdown with different period."""
         # WHEN calling breakdown endpoint with quarterly period
         response = await client.get("/reports/breakdown?type=expense&period=quarterly")
 
@@ -315,7 +315,7 @@ class TestReportsEndpoints:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     async def test_unauthenticated_access(self, public_client: AsyncClient, test_user: User):
-        """AC5.5.3: Test that unauthenticated clients cannot access reports endpoints."""
+        """AC-reporting.errors.3: AC5.5.3: Test that unauthenticated clients cannot access reports endpoints."""
         # GIVEN unauthenticated client
         # WHEN calling any reports endpoint
         response = await public_client.get("/reports/balance-sheet")
@@ -348,7 +348,7 @@ class TestReportsEndpoints:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     async def test_list_report_snapshots_returns_created_snapshots(self, client: AsyncClient, db, test_user: User):
-        """AC5.5.5: GET /reports/{type}/snapshots returns persisted snapshots."""
+        """AC-reporting.errors.5 · AC-reporting.layer3.2: AC5.5.5: GET /reports/{type}/snapshots returns persisted snapshots."""
         # GIVEN a classification rule (FK target) and a balance-sheet snapshot
         rule = ClassificationRule(
             user_id=test_user.id,

--- a/apps/backend/tests/api/test_typed_contract_sweep.py
+++ b/apps/backend/tests/api/test_typed_contract_sweep.py
@@ -67,14 +67,14 @@ async def test_AC4_12_2_create_entry_malformed_uuid_returns_422(client: AsyncCli
 
 
 async def test_AC5_36_1_report_snapshots_unknown_type_returns_422(client: AsyncClient) -> None:
-    """AC5.36.1: an unknown ``report_type`` is rejected with 422 instead of
+    """AC-reporting.snapshots-typed.1: AC5.36.1: an unknown ``report_type`` is rejected with 422 instead of
     silently returning an empty list."""
     response = await client.get("/reports/not-a-report-type/snapshots")
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 async def test_AC5_36_2_report_snapshots_valid_type_returns_typed_list(client: AsyncClient) -> None:
-    """AC5.36.2: a valid ``report_type`` returns a (possibly empty) typed list."""
+    """AC-reporting.snapshots-typed.2: AC5.36.2: a valid ``report_type`` returns a (possibly empty) typed list."""
     response = await client.get("/reports/balance_sheet/snapshots")
     assert response.status_code == status.HTTP_200_OK
     assert isinstance(response.json(), list)
@@ -84,7 +84,7 @@ async def test_AC5_36_2_report_snapshots_valid_type_returns_typed_list(client: A
 
 
 async def test_AC17_31_1_prices_update_returns_typed_batch_response(client: AsyncClient) -> None:
-    """AC17.31.1: ``POST /portfolio/prices/update`` returns the typed
+    """AC-portfolio.typed-responses.1: AC17.31.1: ``POST /portfolio/prices/update`` returns the typed
     ``{updated_count, results}`` shape, not an ad-hoc dict."""
     response = await client.post("/portfolio/prices/update", json={"updates": []})
     assert response.status_code == status.HTTP_200_OK
@@ -94,7 +94,7 @@ async def test_AC17_31_1_prices_update_returns_typed_batch_response(client: Asyn
 
 
 async def test_AC17_31_2_patch_unknown_holding_returns_404(client: AsyncClient) -> None:
-    """AC17.31.2: ``PATCH /portfolio/{ticker}`` for an unknown holding returns a
+    """AC-portfolio.typed-responses.2: AC17.31.2: ``PATCH /portfolio/{ticker}`` for an unknown holding returns a
     structured 404 (no raw ``dict`` success path)."""
     response = await client.patch("/portfolio/NOPE", json={"cost_basis_method": "FIFO"})
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/backend/tests/assets/test_asset_service.py
+++ b/apps/backend/tests/assets/test_asset_service.py
@@ -17,7 +17,7 @@ class TestPositionService:
     """Tests for asset reconciliation."""
 
     async def test_reconcile_creates_position(self, db, test_user):
-        """AC11.1.1: Test that reconciling creates a new managed position."""
+        """AC-portfolio.reconcile.1: AC11.1.1: Test that reconciling creates a new managed position."""
         service = PositionService()
 
         # 1. Create Atomic Position
@@ -49,7 +49,7 @@ class TestPositionService:
         assert pos.account.name == "Moomoo"
 
     async def test_reconcile_updates_position(self, db, test_user):
-        """AC11.1.2: Test that reconciling updates existing position quantity."""
+        """AC-portfolio.reconcile.2: AC11.1.2: Test that reconciling updates existing position quantity."""
         service = PositionService()
 
         # 1. Create Initial Atomic Position
@@ -92,7 +92,7 @@ class TestPositionService:
         assert pos.quantity == Decimal("15.0")
 
     async def test_reconcile_disposes_position(self, db, test_user):
-        """AC11.1.3: Test that 0 quantity marks position as disposed."""
+        """AC-portfolio.reconcile.3: AC11.1.3: Test that 0 quantity marks position as disposed."""
         service = PositionService()
 
         # 1. Create Initial Atomic Position
@@ -142,7 +142,7 @@ class TestPositionService:
         assert pos.disposal_date == date(2024, 1, 17)
 
     async def test_reconcile_cost_basis_uses_market_value(self, db, test_user):
-        """AC11.1.4: Test that cost_basis is set from market_value."""
+        """AC-portfolio.reconcile.4: AC11.1.4: Test that cost_basis is set from market_value."""
         service = PositionService()
 
         snap = AtomicPosition(
@@ -166,7 +166,7 @@ class TestPositionService:
         assert positions[0].cost_basis == Decimal("1250.00")
 
     async def test_reconcile_multiple_assets(self, db, test_user):
-        """AC11.1.5: Test reconciling multiple different assets."""
+        """AC-portfolio.reconcile.5: AC11.1.5: Test reconciling multiple different assets."""
         service = PositionService()
 
         snap1 = AtomicPosition(
@@ -202,7 +202,7 @@ class TestPositionService:
         assert identifiers == {"AAPL", "GOOGL"}
 
     async def test_reconcile_multiple_brokers_same_asset(self, db, test_user):
-        """AC11.1.6: Test same asset at different brokers creates separate positions."""
+        """AC-portfolio.reconcile.6: AC11.1.6: Test same asset at different brokers creates separate positions."""
         service = PositionService()
 
         snap1 = AtomicPosition(
@@ -238,7 +238,7 @@ class TestPositionService:
         assert brokers == {"Moomoo", "Interactive Brokers"}
 
     async def test_reconcile_with_null_broker(self, db, test_user):
-        """AC11.1.7: Test handling of null broker name."""
+        """AC-portfolio.reconcile.7: AC11.1.7: Test handling of null broker name."""
         service = PositionService()
 
         snap = AtomicPosition(
@@ -262,7 +262,7 @@ class TestPositionService:
         assert positions[0].account.name == "Unknown Broker"
 
     async def test_reconcile_reactivates_disposed_position(self, db, test_user):
-        """AC11.1.8: Test that disposed position can be reactivated."""
+        """AC-portfolio.reconcile.8: AC11.1.8: Test that disposed position can be reactivated."""
         service = PositionService()
 
         # 1. Create Initial Atomic Position
@@ -320,7 +320,7 @@ class TestPositionService:
         assert pos.disposal_date is None
 
     async def test_get_positions_empty(self, db, test_user):
-        """AC11.1.9: Test get_positions returns empty list when no positions exist."""
+        """AC-portfolio.reconcile.9: AC11.1.9: Test get_positions returns empty list when no positions exist."""
         service = PositionService()
 
         positions, total = await service.get_positions(db, test_user.id)
@@ -328,7 +328,7 @@ class TestPositionService:
         assert total == 0
 
     async def test_reconcile_no_snapshots(self, db, test_user):
-        """AC11.1.10: Test reconcile with no atomic snapshots does nothing."""
+        """AC-portfolio.reconcile.10: AC11.1.10: Test reconcile with no atomic snapshots does nothing."""
         service = PositionService()
 
         await service.reconcile_positions(db, test_user.id)
@@ -338,7 +338,7 @@ class TestPositionService:
         assert total == 0
 
     async def test_reconcile_negative_quantity_short_position(self, db, test_user):
-        """AC11.1.11: Test that negative quantities (short positions) are handled correctly."""
+        """AC-portfolio.reconcile.11: AC11.1.11: Test that negative quantities (short positions) are handled correctly."""
         service = PositionService()
 
         snap = AtomicPosition(
@@ -365,7 +365,7 @@ class TestPositionService:
         assert pos.status == PositionStatus.ACTIVE
 
     async def test_reconcile_result_counts_are_mutually_exclusive(self, db, test_user):
-        """AC11.1.12: Test that updated and disposed counts don't double-count."""
+        """AC-portfolio.reconcile.12: AC11.1.12: Test that updated and disposed counts don't double-count."""
         service = PositionService()
 
         snap1 = AtomicPosition(

--- a/apps/backend/tests/assets/test_assets_router.py
+++ b/apps/backend/tests/assets/test_assets_router.py
@@ -18,7 +18,7 @@ class TestAssetsRouter:
     """Tests for /api/assets endpoints."""
 
     async def test_list_positions_empty(self, client):
-        """AC11.2.1: GET /assets/positions returns empty list when no positions."""
+        """AC-portfolio.router.1: AC11.2.1: GET /assets/positions returns empty list when no positions."""
         response = await client.get("/assets/positions")
         assert response.status_code == 200
         data = response.json()
@@ -26,7 +26,7 @@ class TestAssetsRouter:
         assert data["total"] == 0
 
     async def test_list_positions_with_data(self, client, db, test_user):
-        """AC11.2.2: GET /assets/positions returns positions."""
+        """AC-portfolio.router.2: AC11.2.2: GET /assets/positions returns positions."""
         account = Account(
             user_id=test_user.id,
             name="Test Broker",
@@ -59,7 +59,7 @@ class TestAssetsRouter:
         assert data["items"][0]["account_name"] == "Test Broker"
 
     async def test_list_positions_filter_by_status(self, client, db, test_user):
-        """AC11.2.3: GET /assets/positions?status_filter=active filters correctly."""
+        """AC-portfolio.router.3: AC11.2.3: GET /assets/positions?status_filter=active filters correctly."""
         account = Account(
             user_id=test_user.id,
             name="Test Broker",
@@ -106,7 +106,7 @@ class TestAssetsRouter:
         assert data["items"][0]["asset_identifier"] == "GOOGL"
 
     async def test_get_position_success(self, client, db, test_user):
-        """AC11.3.1: GET /assets/positions/{id} returns position details."""
+        """AC-portfolio.router.4: AC11.3.1: GET /assets/positions/{id} returns position details."""
         account = Account(
             user_id=test_user.id,
             name="Moomoo",
@@ -138,13 +138,13 @@ class TestAssetsRouter:
         assert data["account_name"] == "Moomoo"
 
     async def test_get_position_not_found(self, client):
-        """AC11.3.2: GET /assets/positions/{id} returns 404 for non-existent position."""
+        """AC-portfolio.router.5: AC11.3.2: GET /assets/positions/{id} returns 404 for non-existent position."""
         fake_id = uuid4()
         response = await client.get(f"/assets/positions/{fake_id}")
         assert response.status_code == 404
 
     async def test_get_position_wrong_user(self, client, db):
-        """AC11.3.3: GET /assets/positions/{id} returns 404 for other user's position."""
+        """AC-portfolio.router.6: AC11.3.3: GET /assets/positions/{id} returns 404 for other user's position."""
         other_user_id = (await UserFactory.create_async(db)).id
         account = Account(
             user_id=other_user_id,
@@ -173,7 +173,7 @@ class TestAssetsRouter:
         assert response.status_code == 404
 
     async def test_reconcile_positions_success(self, client, db, test_user):
-        """AC11.4.1: POST /assets/reconcile creates positions from snapshots."""
+        """AC-portfolio.router.7: AC11.4.1: POST /assets/reconcile creates positions from snapshots."""
         snap = AtomicPosition(
             user_id=test_user.id,
             snapshot_date=date(2024, 1, 15),
@@ -202,7 +202,7 @@ class TestAssetsRouter:
         assert positions["items"][0]["asset_identifier"] == "NVDA"
 
     async def test_reconcile_positions_empty(self, client):
-        """AC11.4.2: POST /assets/reconcile with no snapshots returns 0 counts."""
+        """AC-portfolio.router.8: AC11.4.2: POST /assets/reconcile with no snapshots returns 0 counts."""
         response = await client.post("/assets/reconcile")
         assert response.status_code == 200
         data = response.json()
@@ -213,22 +213,22 @@ class TestAssetsRouter:
         assert data["skipped_assets"] == []
 
     async def test_list_positions_requires_auth(self, public_client):
-        """AC11.5.1: GET /assets/positions requires authentication."""
+        """AC-portfolio.router.9: AC11.5.1: GET /assets/positions requires authentication."""
         response = await public_client.get("/assets/positions")
         assert response.status_code == 401
 
     async def test_get_position_requires_auth(self, public_client):
-        """AC11.5.2: GET /assets/positions/{id} requires authentication."""
+        """AC-portfolio.router.10: AC11.5.2: GET /assets/positions/{id} requires authentication."""
         response = await public_client.get(f"/assets/positions/{uuid4()}")
         assert response.status_code == 401
 
     async def test_reconcile_requires_auth(self, public_client):
-        """AC11.5.3: POST /assets/reconcile requires authentication."""
+        """AC-portfolio.router.11: AC11.5.3: POST /assets/reconcile requires authentication."""
         response = await public_client.post("/assets/reconcile")
         assert response.status_code == 401
 
     async def test_get_position_depreciation_success(self, client, db, test_user):
-        """AC11.6.1: GET /assets/positions/{id}/depreciation returns depreciation schedule."""
+        """AC-portfolio.depreciation.1: AC11.6.1: GET /assets/positions/{id}/depreciation returns depreciation schedule."""
         account = Account(
             user_id=test_user.id,
             name="Test Broker",
@@ -268,7 +268,7 @@ class TestAssetsRouter:
         assert data["useful_life_years"] == 5
 
     async def test_get_position_depreciation_not_found(self, client):
-        """AC11.6.2: GET /assets/positions/{id}/depreciation returns 400 for non-existent position."""
+        """AC-portfolio.depreciation.2: AC11.6.2: GET /assets/positions/{id}/depreciation returns 400 for non-existent position."""
         fake_id = uuid4()
         response = await client.get(
             f"/assets/positions/{fake_id}/depreciation",
@@ -278,7 +278,7 @@ class TestAssetsRouter:
         assert "not found" in response.json()["detail"].lower()
 
     async def test_get_position_depreciation_disposed_position(self, client, db, test_user):
-        """AC11.6.3: GET /assets/positions/{id}/depreciation returns 400 for disposed position."""
+        """AC-portfolio.depreciation.3: AC11.6.3: GET /assets/positions/{id}/depreciation returns 400 for disposed position."""
         account = Account(
             user_id=test_user.id,
             name="Test Broker",
@@ -311,7 +311,7 @@ class TestAssetsRouter:
         assert "disposed" in response.json()["detail"].lower()
 
     async def test_get_position_depreciation_invalid_params(self, client, db, test_user):
-        """AC11.6.4: GET /assets/positions/{id}/depreciation returns 422 for invalid params."""
+        """AC-portfolio.depreciation.4: AC11.6.4: GET /assets/positions/{id}/depreciation returns 422 for invalid params."""
         account = Account(
             user_id=test_user.id,
             name="Test Broker",
@@ -345,7 +345,7 @@ class TestAssetsRouter:
         assert response.status_code == 422
 
     async def test_get_position_user_isolation(self, client, db, test_user):
-        """AC11.7.1: Verify position queries are isolated by user_id (security boundary test).
+        """AC-portfolio.router.12: AC11.7.1: Verify position queries are isolated by user_id (security boundary test).
 
         This test documents that the service layer correctly filters positions by user_id.
         A position belonging to another user will not be found even if the ID is known.

--- a/apps/backend/tests/e2e/test_core_journeys.py
+++ b/apps/backend/tests/e2e/test_core_journeys.py
@@ -525,7 +525,7 @@ async def test_reconciliation_stats(client, db, test_user):
 
 @pytest.mark.e2e
 async def test_balance_sheet_report(client, test_user):
-    """AC-testing.journeys.4:
+    """AC-reporting.journeys.1 AC-testing.journeys.4:
     EPIC-005 / AC8.6.1: View Balance Sheet
     AC8.8.4: Core journey — reports API
     GIVEN a user posts a known balanced entry (Bank 1000 ← Opening Equity 1000)
@@ -557,7 +557,7 @@ async def test_balance_sheet_report(client, test_user):
 
 @pytest.mark.e2e
 async def test_income_statement_report(client, test_user):
-    """
+    """AC-reporting.journeys.2:
     EPIC-005 / AC8.6.2: View Income Statement
     GIVEN a user posts a known salary entry (Bank 3000 ← Salary 3000) inside the period
     WHEN requesting the income statement for that range
@@ -592,7 +592,7 @@ async def test_income_statement_report(client, test_user):
 
 @pytest.mark.e2e
 async def test_cash_flow_report(client, test_user):
-    """
+    """AC-reporting.journeys.3:
     EPIC-005 / AC8.6.3: View Cash Flow Report
     GIVEN a user posts a known cash inflow (Bank 1000 ← Opening Equity 1000) inside the period
     WHEN requesting the cash flow report for that range
@@ -925,7 +925,7 @@ async def test_reconciliation_match_acceptance(client, db, test_user):
 
 @pytest.mark.e2e
 async def test_report_navigation_all_endpoints(client, test_user):
-    """
+    """AC-reporting.journeys.4:
     EPIC-005 / AC8.6.4: All 4 report endpoints accessible in sequence
     GIVEN a user is authenticated
     WHEN requesting balance sheet, income statement, cash flow, and currencies

--- a/apps/backend/tests/integration/test_augmentation_seam_e2e.py
+++ b/apps/backend/tests/integration/test_augmentation_seam_e2e.py
@@ -74,7 +74,7 @@ async def _posted(
 
 @ac_proof(
     "report-input-selection-excludes-superseded-pr",
-    ac_ids=["AC8.16.1"],
+    ac_ids=["AC-reporting.augmentation.1"],
     scope="behavioral",
     ci_tier="pr_ci",
     trust_mode="deterministic_pr",
@@ -84,7 +84,7 @@ async def _posted(
 async def test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confidence(
     db: AsyncSession, test_user: User, ac_evidence
 ) -> None:
-    """AC8.16.1: low-confidence extracted inputs and a corrected valuation reach the
+    """AC-reporting.augmentation.1: AC8.16.1: low-confidence extracted inputs and a corrected valuation reach the
     report without leaking a superseded row or laundering a low-confidence input."""
     user_id = test_user.id
     as_of = date(2026, 5, 31)
@@ -156,7 +156,7 @@ async def test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confi
     # Behavioral evidence: the corrected-only net-worth total (1.1M, not 2.1M) is the
     # deterministic proof that the seam excludes the superseded row.
     ac_evidence(
-        ac_id="AC8.16.1",
+        ac_id="AC-reporting.augmentation.1",
         score=1.0,
         metric="superseded_excluded_corrected_total_match",
         comment="net-worth components == 1,100,000 (corrected only); a superseded leak would be 2,100,000",

--- a/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
+++ b/apps/backend/tests/integration/test_bank_statement_auto_account_post.py
@@ -48,6 +48,7 @@ def _balanced_bank_payload() -> dict:
 
 
 async def test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping(db, test_user):
+    """AC-reporting.full-year.2: was AC8.15.2."""
     service = ExtractionService()
     service.extract_financial_data = AsyncMock(return_value=_balanced_bank_payload())
 

--- a/apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py
+++ b/apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py
@@ -52,7 +52,7 @@ async def _post(db: AsyncSession, user_id: UUID, *, debit: Account, credit: Acco
 
 
 async def test_AC8_16_2_reports_exclude_other_users_entries(db: AsyncSession, test_user: User, ac_evidence) -> None:
-    """AC8.16.2: user A's report totals reflect only A's facts; B's data never leaks in."""
+    """AC-reporting.augmentation.2: AC8.16.2: user A's report totals reflect only A's facts; B's data never leaks in."""
     user_a = test_user.id
     user_b = (await UserFactory.create_async(db)).id
 
@@ -122,7 +122,7 @@ async def test_AC8_16_2_reports_exclude_other_users_entries(db: AsyncSession, te
     # own 1500.00, never 1500 + B's 17776; A's net-worth valuation is 200000.00, never
     # 200000 + B's 800000. A cross-user leak would move both off these golden numbers.
     ac_evidence(
-        ac_id="AC8.16.2",
+        ac_id="AC-reporting.augmentation.2",
         score=1.0,
         metric="cross_user_excluded_own_totals_match",
         comment="A assets 1500.00 (not 1500+17776) and A net-worth 200000.00 (not +800000); B never leaks in",

--- a/apps/backend/tests/integration/test_full_year_statement_to_report_e2e.py
+++ b/apps/backend/tests/integration/test_full_year_statement_to_report_e2e.py
@@ -94,7 +94,7 @@ async def test_AC8_15_1_full_year_statement_to_report_ties_out(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """EPIC-003 EPIC-008 EPIC-019 / AC8.15.1: A multi-month run of real CSV
+    """AC-reporting.full-year.1: EPIC-003 EPIC-008 EPIC-019 / AC8.15.1: A multi-month run of real CSV
     statements parses, approves under the balance-chain guard, auto-posts to the
     ledger, and the assembled period reports tie out end-to-end (income,
     expenses, net income, ending cash, total assets, and the accounting

--- a/apps/backend/tests/integration/test_reporting_e2e.py
+++ b/apps/backend/tests/integration/test_reporting_e2e.py
@@ -55,7 +55,7 @@ async def _posted_entry(
 
 @ac_proof(
     "structured-source-reporting-pr",
-    ac_ids=["AC5.15.1", "AC-testing.trust-mirrors.4"],
+    ac_ids=["AC-reporting.integration.1", "AC-testing.trust-mirrors.4"],
     scope="behavioral",
     ci_tier="pr_ci",
     trust_mode="deterministic_pr",
@@ -66,7 +66,7 @@ async def test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf(
     db: AsyncSession,
     test_user,
 ) -> None:
-    """AC-testing.trust-mirrors.4: AC5.15.1 AC8.14.4: Structured/manual facts deterministically generate BS, IS, and CF reports."""
+    """AC-reporting.integration.1 AC-testing.trust-mirrors.4: AC5.15.1 AC8.14.4: Structured/manual facts deterministically generate BS, IS, and CF reports."""
     user_id = test_user.id
     period_start = date(2026, 1, 1)
     period_end = date(2026, 1, 31)

--- a/apps/backend/tests/metrics/test_confidence_north_star_metric.py
+++ b/apps/backend/tests/metrics/test_confidence_north_star_metric.py
@@ -18,7 +18,7 @@ from tests.ledger._ledger_helpers import create_valid_posted_entry
 
 @pytest.mark.asyncio
 async def test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic(db, test_user):
-    """AC18.12.1: The metric is the LOW-tier share of posted ledger facts, with a full tier breakdown."""
+    """AC-reporting.north-star.1: AC18.12.1: The metric is the LOW-tier share of posted ledger facts, with a full tier breakdown."""
     service = ConfidenceMetricService()
     # source_type -> confidence tier: manual=TRUSTED, user_confirmed=HIGH,
     # auto_matched=MEDIUM, auto_parsed/system=LOW.
@@ -51,7 +51,7 @@ async def test_AC18_12_1_empty_ledger_reports_zero_not_undefined(db, test_user):
 
 @pytest.mark.asyncio
 async def test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend(db, test_user):
-    """AC18.12.2: Snapshots accumulate (never overwrite) and read newest-first, so the trend is observable."""
+    """AC-reporting.north-star.2: AC18.12.2: Snapshots accumulate (never overwrite) and read newest-first, so the trend is observable."""
     service = ConfidenceMetricService()
 
     await create_valid_posted_entry(db, test_user.id, source_type=JournalEntrySourceType.MANUAL)
@@ -76,7 +76,7 @@ async def test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_tr
 
 @pytest.mark.asyncio
 async def test_AC18_12_3_north_star_endpoint_returns_current_and_series(client):
-    """AC18.12.3: The metric and its series are exposed read-only via the API."""
+    """AC-reporting.north-star.3: AC18.12.3: The metric and its series are exposed read-only via the API."""
     response = await client.get("/metrics/confidence-north-star")
     assert response.status_code == 200
     body = response.json()
@@ -88,7 +88,7 @@ async def test_AC18_12_3_north_star_endpoint_returns_current_and_series(client):
 
 @pytest.mark.asyncio
 async def test_AC18_12_4_post_records_a_snapshot_into_the_series(client):
-    """AC18.12.4: POST records a North-Star point on demand, so the trend accumulates."""
+    """AC-reporting.north-star.4: AC18.12.4: POST records a North-Star point on demand, so the trend accumulates."""
     assert (await client.get("/metrics/confidence-north-star")).json()["series"] == []
 
     created = await client.post("/metrics/confidence-north-star/snapshots")

--- a/apps/backend/tests/portfolio/test_allocation_service.py
+++ b/apps/backend/tests/portfolio/test_allocation_service.py
@@ -130,7 +130,7 @@ async def test_asset_class_allocation_empty_portfolio(db: AsyncSession, test_use
 async def test_sector_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC17.4.4: Sector allocation with positions returns category/value/percentage/count.
+    """AC-portfolio.allocation.1: AC17.4.4: Sector allocation with positions returns category/value/percentage/count.
 
     Verify that sector allocation correctly groups positions by sector with market values.
     """
@@ -146,7 +146,7 @@ async def test_sector_allocation_with_positions(
 async def test_geography_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC17.4.5: Geography allocation with positions returns grouped results.
+    """AC-portfolio.allocation.2: AC17.4.5: Geography allocation with positions returns grouped results.
 
     Verify that geography allocation correctly groups positions by geography.
     """
@@ -159,7 +159,7 @@ async def test_geography_allocation_with_positions(
 async def test_asset_class_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC17.4.6: Asset class allocation with positions returns grouped results.
+    """AC-portfolio.allocation.3: AC17.4.6: Asset class allocation with positions returns grouped results.
 
     Verify that asset class allocation correctly groups positions by asset type.
     """

--- a/apps/backend/tests/portfolio/test_allocation_service.py
+++ b/apps/backend/tests/portfolio/test_allocation_service.py
@@ -130,7 +130,7 @@ async def test_asset_class_allocation_empty_portfolio(db: AsyncSession, test_use
 async def test_sector_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC-portfolio.allocation.1: AC17.4.4: Sector allocation with positions returns category/value/percentage/count.
+    """AC-portfolio.allocation.1: AC17.3.1: Sector allocation with positions returns category/value/percentage/count.
 
     Verify that sector allocation correctly groups positions by sector with market values.
     """
@@ -146,7 +146,7 @@ async def test_sector_allocation_with_positions(
 async def test_geography_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC-portfolio.allocation.2: AC17.4.5: Geography allocation with positions returns grouped results.
+    """AC-portfolio.allocation.2: AC17.3.2: Geography allocation with positions returns grouped results.
 
     Verify that geography allocation correctly groups positions by geography.
     """
@@ -159,7 +159,7 @@ async def test_geography_allocation_with_positions(
 async def test_asset_class_allocation_with_positions(
     db: AsyncSession, test_user, tech_stock_position, finance_stock_position
 ):
-    """AC-portfolio.allocation.3: AC17.4.6: Asset class allocation with positions returns grouped results.
+    """AC-portfolio.allocation.3: AC17.3.3: Asset class allocation with positions returns grouped results.
 
     Verify that asset class allocation correctly groups positions by asset type.
     """

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -717,7 +717,7 @@ async def test_statement_scoped_brokerage_import_uses_persisted_extraction_posit
 
 
 async def test_statement_import_flows_to_holdings_and_balance_sheet(client, db, test_user):
-    """AC-extraction.813.10/AC17.4.6/AC17.5.4: Parsed brokerage import reaches holdings and balance sheet."""
+    """AC-portfolio.valuation.1: AC-extraction.813.10/AC17.4.6/AC17.5.4: Parsed brokerage import reaches holdings and balance sheet."""
     statement = await _seed_statement(
         db,
         test_user.id,

--- a/apps/backend/tests/portfolio/test_financial_logic_audit.py
+++ b/apps/backend/tests/portfolio/test_financial_logic_audit.py
@@ -36,12 +36,12 @@ async def _investment_position(db: AsyncSession, test_user, *, asset_identifier:
 
 
 def test_AC17_11_4_source_document_links_ignore_non_structured_payloads():
-    """AC17.11.4: Non-structured source document payloads produce no audit links."""
+    """AC-portfolio.logic-audit.4: AC17.11.4: Non-structured source document payloads produce no audit links."""
     assert _source_document_links("legacy-import") == []
 
 
 async def test_AC17_11_1_xirr_excludes_unrelated_bank_transactions(db: AsyncSession, test_user):
-    """AC17.11.1: XIRR/MWR use investment transactions, not unrelated bank atomic transactions."""
+    """AC-portfolio.logic-audit.1: AC17.11.1: XIRR/MWR use investment transactions, not unrelated bank atomic transactions."""
     position = await _investment_position(db, test_user, asset_identifier="XIRRAUDIT")
     start = date.today() - timedelta(days=365)
     db.add_all(
@@ -94,7 +94,7 @@ async def test_AC17_11_1_xirr_excludes_unrelated_bank_transactions(db: AsyncSess
 
 
 async def test_AC17_11_3_twr_excludes_unrelated_bank_transactions(db: AsyncSession, test_user):
-    """AC17.11.3: TWR excludes unrelated bank transactions from cash-flow adjustment."""
+    """AC-portfolio.logic-audit.3: AC17.11.3: TWR excludes unrelated bank transactions from cash-flow adjustment."""
     position = await _investment_position(db, test_user, asset_identifier="TWRAUDIT")
     start = date.today() - timedelta(days=30)
     end = date.today()
@@ -146,7 +146,7 @@ async def test_AC17_11_2_summary_ytd_amounts_convert_to_presentation_currency(
     db: AsyncSession,
     test_user,
 ):
-    """AC17.11.2: Summary YTD realized/dividend amounts are converted before aggregation."""
+    """AC-portfolio.logic-audit.2: AC17.11.2: Summary YTD realized/dividend amounts are converted before aggregation."""
     position = await _investment_position(db, test_user, asset_identifier="USDAUDIT")
     today = date.today()
     sell_date = date(today.year, 3, 1)

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -157,7 +157,7 @@ async def test_xirr_insufficient_data(db: AsyncSession, test_user):
 
 
 async def test_xirr_with_realistic_data(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC-portfolio.performance.1: AC17.3.2: XIRR calculates annualized return for realistic portfolio.
+    """AC-portfolio.performance.1: AC17.2.1: XIRR calculates annualized return for realistic portfolio.
 
     Verify that XIRR returns a negative Decimal for a loss scenario (deposits > current value).
     """
@@ -229,7 +229,7 @@ async def test_time_weighted_return_empty_portfolio(db: AsyncSession, test_user)
 
 
 async def test_time_weighted_return_with_period(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC-portfolio.performance.2: AC17.3.4: TWR calculates period return within reasonable bounds.
+    """AC-portfolio.performance.2: AC17.2.2 (canonical; AC17.3.4 was a duplicate restatement): TWR calculates period return within reasonable bounds.
 
     Verify that TWR returns a valid percentage for a period with transactions.
     """
@@ -311,7 +311,7 @@ async def test_money_weighted_return_insufficient_data(db: AsyncSession, test_us
 
 
 async def test_money_weighted_return_with_data(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC-portfolio.performance.3: AC17.3.6: MWR calculates money-weighted return for loss scenario.
+    """AC-portfolio.performance.3: AC17.2.3 (canonical; AC17.3.6 was a duplicate restatement): MWR calculates money-weighted return for loss scenario.
 
     Verify that MWR returns a negative Decimal when total deposits exceed current value.
     """

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -157,7 +157,7 @@ async def test_xirr_insufficient_data(db: AsyncSession, test_user):
 
 
 async def test_xirr_with_realistic_data(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC17.3.2: XIRR calculates annualized return for realistic portfolio.
+    """AC-portfolio.performance.1: AC17.3.2: XIRR calculates annualized return for realistic portfolio.
 
     Verify that XIRR returns a negative Decimal for a loss scenario (deposits > current value).
     """
@@ -170,7 +170,7 @@ async def test_xirr_with_realistic_data(db: AsyncSession, test_user, portfolio_w
 
 
 async def test_AC5_6_1_xirr_matches_single_year_excel_case(db: AsyncSession, test_user, investment_account):
-    """AC5.6.1: XIRR is within 0.01 percentage points of a one-year Excel case."""
+    """AC-portfolio.metrics.1: AC5.6.1: XIRR is within 0.01 percentage points of a one-year Excel case."""
     from src.models.layer2 import AtomicPosition
 
     start = date.today() - timedelta(days=365)
@@ -229,7 +229,7 @@ async def test_time_weighted_return_empty_portfolio(db: AsyncSession, test_user)
 
 
 async def test_time_weighted_return_with_period(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC17.3.4: TWR calculates period return within reasonable bounds.
+    """AC-portfolio.performance.2: AC17.3.4: TWR calculates period return within reasonable bounds.
 
     Verify that TWR returns a valid percentage for a period with transactions.
     """
@@ -250,7 +250,7 @@ async def test_AC5_6_2_time_weighted_return_matches_snapshot_period(
     test_user,
     investment_account,
 ):
-    """AC5.6.2: TWR computes the exact period return from start/end snapshots."""
+    """AC-portfolio.metrics.2: AC5.6.2: TWR computes the exact period return from start/end snapshots."""
     from src.models.layer2 import AtomicPosition
 
     start = date.today() - timedelta(days=30)
@@ -302,7 +302,7 @@ async def test_AC5_6_2_time_weighted_return_matches_snapshot_period(
 
 
 async def test_money_weighted_return_insufficient_data(db: AsyncSession, test_user):
-    """AC17.3.5: MWR raises InsufficientDataError on empty portfolio.
+    """AC-portfolio.allocation.4: AC17.3.5: MWR raises InsufficientDataError on empty portfolio.
 
     Verify that MWR calculation fails gracefully when no data exists.
     """
@@ -311,7 +311,7 @@ async def test_money_weighted_return_insufficient_data(db: AsyncSession, test_us
 
 
 async def test_money_weighted_return_with_data(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC17.3.6: MWR calculates money-weighted return for loss scenario.
+    """AC-portfolio.performance.3: AC17.3.6: MWR calculates money-weighted return for loss scenario.
 
     Verify that MWR returns a negative Decimal when total deposits exceed current value.
     """
@@ -328,7 +328,7 @@ async def test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value
     test_user,
     investment_account,
 ):
-    """AC5.6.3: Dividend yield equals annual dividends divided by current value."""
+    """AC-portfolio.metrics.3: AC5.6.3: Dividend yield equals annual dividends divided by current value."""
     from src.models.layer2 import AtomicPosition
 
     today = date.today()
@@ -421,7 +421,7 @@ async def test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow(
     test_user,
     investment_account,
 ):
-    """AC5.6.6: MWR matches XIRR for a single cash-flow portfolio."""
+    """AC-portfolio.metrics.4: AC5.6.6: MWR matches XIRR for a single cash-flow portfolio."""
     from src.models.layer2 import AtomicPosition
 
     start = date.today() - timedelta(days=365)
@@ -469,7 +469,7 @@ async def test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow(
 
 
 async def test_xirr_with_as_of_date(db: AsyncSession, test_user, portfolio_with_transactions):
-    """AC17.3.7: XIRR respects as_of_date parameter.
+    """AC-portfolio.allocation.5: AC17.3.7: XIRR respects as_of_date parameter.
 
     Verify that XIRR calculates return as of a historical date.
     """
@@ -482,7 +482,7 @@ async def test_xirr_with_as_of_date(db: AsyncSession, test_user, portfolio_with_
 
 
 async def test_time_weighted_return_same_day(db: AsyncSession, test_user):
-    """AC17.3.8: TWR returns zero for same-day period.
+    """AC-portfolio.allocation.6: AC17.3.8: TWR returns zero for same-day period.
 
     Verify that TWR returns 0 when period_start == period_end.
     """
@@ -495,7 +495,7 @@ async def test_time_weighted_return_same_day(db: AsyncSession, test_user):
 
 
 async def test_performance_metrics_with_zero_positions(db: AsyncSession, test_user):
-    """AC17.3.9: Performance metrics handle cash-only portfolios.
+    """AC-portfolio.allocation.7: AC17.3.9: Performance metrics handle cash-only portfolios.
 
     Verify that XIRR raises InsufficientDataError when portfolio has deposits but no positions.
     """
@@ -521,7 +521,7 @@ async def test_performance_metrics_with_zero_positions(db: AsyncSession, test_us
 
 
 async def test_xirr_convergence_edge_case(db: AsyncSession, test_user, investment_account):
-    """AC17.3.10: XIRR handles extreme convergence edge cases.
+    """AC-portfolio.allocation.8: AC17.3.10: XIRR handles extreme convergence edge cases.
 
     Verify that extreme gain scenarios either produce a very high XIRR or raise InsufficientDataError.
     """
@@ -580,7 +580,7 @@ async def test_xirr_convergence_edge_case(db: AsyncSession, test_user, investmen
 
 
 def test_xirr_bisection_no_root_raises():
-    """AC17.3.11: _xirr_bisection raises ValueError when no root exists.
+    """AC-portfolio.allocation.9: AC17.3.11: _xirr_bisection raises ValueError when no root exists.
 
     Verify that all-positive cash flows cause a ValueError (no sign change in search range).
     """
@@ -594,7 +594,7 @@ def test_xirr_bisection_no_root_raises():
 
 
 def test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows():
-    """AC17.10.5: XIRR internals do not convert monetary Decimal cash flows to float."""
+    """AC-portfolio.report-schedule.5: AC17.10.5: XIRR internals do not convert monetary Decimal cash flows to float."""
     import src.services.performance as performance_module
 
     solver_source = inspect.getsource(performance_module._xirr_newton) + inspect.getsource(
@@ -606,7 +606,7 @@ def test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows():
 
 
 def test_xirr_bisection_max_iter_returns():
-    """AC17.3.12: _xirr_bisection returns Decimal estimate after max_iter exhaustion.
+    """AC-portfolio.allocation.10: AC17.3.12: _xirr_bisection returns Decimal estimate after max_iter exhaustion.
 
     Verify that bisection returns a Decimal midpoint when max_iter is too small to converge.
     """
@@ -621,7 +621,7 @@ def test_xirr_bisection_max_iter_returns():
 
 
 def test_xirr_newton_fallthrough_to_bisection():
-    """AC17.3.13: _xirr_newton falls back to bisection on non-convergence.
+    """AC-portfolio.allocation.11: AC17.3.13: _xirr_newton falls back to bisection on non-convergence.
 
     Verify that Newton's method with insufficient iterations falls back to bisection and returns Decimal.
     """
@@ -635,7 +635,7 @@ def test_xirr_newton_fallthrough_to_bisection():
 
 
 async def test_xirr_calculation_error_raised(db: AsyncSession, test_user, investment_account, monkeypatch):
-    """AC17.3.14: XIRRCalculationError raised when Newton and bisection both fail.
+    """AC-portfolio.allocation.12: AC17.3.14: XIRRCalculationError raised when Newton and bisection both fail.
 
     Verify that monkeypatching _xirr_newton to always raise causes XIRRCalculationError.
     """

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -243,7 +243,7 @@ async def test_update_holding_cost_basis_method_returns_404_for_missing_holding(
 
 
 async def test_get_holdings_with_date_filter(client: AsyncClient, portfolio_with_data):
-    """AC17.6.3: GET /portfolio/holdings with as_of_date filter returns 200.
+    """AC-portfolio.api.1: AC17.6.3: GET /portfolio/holdings with as_of_date filter returns 200.
 
     Verify that the holdings endpoint accepts and processes date filter.
     """
@@ -339,7 +339,7 @@ async def test_get_holdings_explicit_date_uses_historical_snapshot_quantity(
     test_user,
     investment_account,
 ):
-    """AC17.9.2: GET /portfolio/holdings with as_of_date returns historical snapshot quantity/value."""
+    """AC-portfolio.as-of.2: AC17.9.2: GET /portfolio/holdings with as_of_date returns historical snapshot quantity/value."""
     historical_date = date(2025, 1, 31)
     current_date = date(2025, 2, 28)
     position = ManagedPosition(
@@ -389,7 +389,7 @@ async def test_get_holdings_explicit_date_uses_historical_snapshot_quantity(
 
 
 async def test_get_holdings_include_disposed(client: AsyncClient, portfolio_with_data):
-    """AC17.6.4: GET /portfolio/holdings with include_disposed=true returns 200.
+    """AC-portfolio.api.2: AC17.6.4: GET /portfolio/holdings with include_disposed=true returns 200.
 
     Verify that the holdings endpoint accepts the include_disposed parameter.
     """
@@ -398,7 +398,7 @@ async def test_get_holdings_include_disposed(client: AsyncClient, portfolio_with
 
 
 async def test_get_performance_without_period(client: AsyncClient, portfolio_with_data):
-    """AC17.6.5: GET /portfolio/performance without period returns metrics.
+    """AC-portfolio.api.3: AC17.6.5: GET /portfolio/performance without period returns metrics.
 
     Verify that the performance endpoint returns xirr, twr, and mwr.
     """
@@ -411,7 +411,7 @@ async def test_get_performance_without_period(client: AsyncClient, portfolio_wit
 
 
 async def test_get_performance_with_period(client: AsyncClient, portfolio_with_data):
-    """AC17.6.6: GET /portfolio/performance with period params returns metrics.
+    """AC-portfolio.api.4: AC17.6.6: GET /portfolio/performance with period params returns metrics.
 
     Verify that the performance endpoint accepts period_start and period_end.
     """
@@ -430,7 +430,7 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
     test_user,
     portfolio_with_data,
 ):
-    """AC17.10.1 AC17.10.2 AC17.10.3: schedule exposes metrics, rows, freshness, sources, and notes."""
+    """AC-portfolio.report-schedule.1 · AC-portfolio.report-schedule.3: AC17.10.1 AC17.10.2 AC17.10.3: schedule exposes metrics, rows, freshness, sources, and notes."""
     position = portfolio_with_data["position"]
     source_id = uuid4()
     journal_entry = await create_valid_posted_entry(
@@ -509,7 +509,7 @@ async def test_AC17_10_6_investment_performance_schedule_converts_mixed_currency
     test_user,
     investment_account,
 ):
-    """AC17.10.6: Report schedule amounts are converted into presentation currency."""
+    """AC-portfolio.report-schedule.6: AC17.10.6: Report schedule amounts are converted into presentation currency."""
     period_start = date(2026, 1, 1)
     sell_date = date(2026, 3, 1)
     dividend_date = date(2026, 4, 1)
@@ -612,7 +612,7 @@ async def test_AC19_8_8_investment_schedule_fallback_holding_cost_basis_converts
     investment_account,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC19.8.8: Fallback holdings without ManagedPosition still convert cost basis to presentation currency."""
+    """AC-portfolio.schedule-fallback.1: AC19.8.8: Fallback holdings without ManagedPosition still convert cost basis to presentation currency."""
     period_start = date(2026, 1, 1)
     as_of_date = date(2026, 5, 20)
     db.add(
@@ -667,7 +667,7 @@ async def test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_s
     investment_account,
     portfolio_with_data,
 ):
-    """AC17.10.4: freshness is stale when any holding lacks current as-of-date price evidence."""
+    """AC-portfolio.report-schedule.4: AC17.10.4: freshness is stale when any holding lacks current as-of-date price evidence."""
     stale_date = date.today() - timedelta(days=7)
     position = ManagedPosition(
         user_id=test_user.id,
@@ -782,7 +782,7 @@ async def test_AC17_10_1_report_schedule_uses_manual_override_after_period_end(
 
 
 async def test_get_sector_allocation_empty(client: AsyncClient):
-    """AC17.6.7: GET /portfolio/allocation/sector on empty portfolio returns [].
+    """AC-portfolio.api.5: AC17.6.7: GET /portfolio/allocation/sector on empty portfolio returns [].
 
     Verify that the sector allocation endpoint returns empty list for no positions.
     """
@@ -792,7 +792,7 @@ async def test_get_sector_allocation_empty(client: AsyncClient):
 
 
 async def test_get_sector_allocation_with_data(client: AsyncClient, portfolio_with_data):
-    """AC17.6.8: GET /portfolio/allocation/sector with data returns breakdown.
+    """AC-portfolio.api.6: AC17.6.8: GET /portfolio/allocation/sector with data returns breakdown.
 
     Verify that the sector allocation endpoint returns category/value/percentage/count.
     """
@@ -808,7 +808,7 @@ async def test_get_sector_allocation_with_data(client: AsyncClient, portfolio_wi
 
 
 async def test_get_geography_allocation_empty(client: AsyncClient):
-    """AC17.6.9: GET /portfolio/allocation/geography on empty portfolio returns [].
+    """AC-portfolio.api.7: AC17.6.9: GET /portfolio/allocation/geography on empty portfolio returns [].
 
     Verify that the geography allocation endpoint returns empty list for no positions.
     """
@@ -818,7 +818,7 @@ async def test_get_geography_allocation_empty(client: AsyncClient):
 
 
 async def test_get_geography_allocation_with_data(client: AsyncClient, portfolio_with_data):
-    """AC17.6.10: GET /portfolio/allocation/geography with data returns breakdown.
+    """AC-portfolio.api.8: AC17.6.10: GET /portfolio/allocation/geography with data returns breakdown.
 
     Verify that the geography allocation endpoint returns grouped results.
     """
@@ -829,7 +829,7 @@ async def test_get_geography_allocation_with_data(client: AsyncClient, portfolio
 
 
 async def test_get_asset_class_allocation_empty(client: AsyncClient):
-    """AC17.6.11: GET /portfolio/allocation/asset-class on empty portfolio returns [].
+    """AC-portfolio.api.9: AC17.6.11: GET /portfolio/allocation/asset-class on empty portfolio returns [].
 
     Verify that the asset class allocation endpoint returns empty list for no positions.
     """
@@ -839,7 +839,7 @@ async def test_get_asset_class_allocation_empty(client: AsyncClient):
 
 
 async def test_get_asset_class_allocation_with_data(client: AsyncClient, portfolio_with_data):
-    """AC17.6.12: GET /portfolio/allocation/asset-class with data returns breakdown.
+    """AC-portfolio.api.10: AC17.6.12: GET /portfolio/allocation/asset-class with data returns breakdown.
 
     Verify that the asset class allocation endpoint returns grouped results.
     """
@@ -850,7 +850,7 @@ async def test_get_asset_class_allocation_with_data(client: AsyncClient, portfol
 
 
 async def test_update_prices_single(client: AsyncClient, portfolio_with_data):
-    """AC17.6.13: POST /portfolio/prices/update with single asset returns success.
+    """AC-portfolio.api.11: AC17.6.13: POST /portfolio/prices/update with single asset returns success.
 
     Verify that a single price update creates a MarketDataOverride.
     """
@@ -872,7 +872,7 @@ async def test_update_prices_single(client: AsyncClient, portfolio_with_data):
 
 
 async def test_update_prices_batch(client: AsyncClient, portfolio_with_data):
-    """AC17.6.14: POST /portfolio/prices/update with batch returns success.
+    """AC-portfolio.api.12: AC17.6.14: POST /portfolio/prices/update with batch returns success.
 
     Verify that batch price updates are processed.
     """
@@ -897,7 +897,7 @@ async def test_update_prices_batch(client: AsyncClient, portfolio_with_data):
 
 
 async def test_update_prices_invalid_payload(client: AsyncClient):
-    """AC17.6.15: POST /portfolio/prices/update with invalid payload returns 422.
+    """AC-portfolio.api.13: AC17.6.15: POST /portfolio/prices/update with invalid payload returns 422.
 
     Verify that missing required fields trigger validation error.
     """
@@ -907,7 +907,7 @@ async def test_update_prices_invalid_payload(client: AsyncClient):
 
 
 async def test_portfolio_endpoints_require_auth(public_client: AsyncClient):
-    """AC17.6.16: All portfolio endpoints require authentication.
+    """AC-portfolio.api.14: AC17.6.16: All portfolio endpoints require authentication.
 
     Verify that unauthenticated requests return 401.
     """
@@ -924,7 +924,7 @@ async def test_portfolio_endpoints_require_auth(public_client: AsyncClient):
 
 
 async def test_allocation_with_as_of_date(client: AsyncClient, portfolio_with_data):
-    """AC17.6.17: GET /portfolio/allocation/sector with as_of_date returns 200.
+    """AC-portfolio.api.15: AC17.6.17: GET /portfolio/allocation/sector with as_of_date returns 200.
 
     Verify that allocation endpoints accept as_of_date filter.
     """
@@ -934,7 +934,7 @@ async def test_allocation_with_as_of_date(client: AsyncClient, portfolio_with_da
 
 
 async def test_performance_metrics_response_format(client: AsyncClient, portfolio_with_data):
-    """AC17.6.18: GET /portfolio/performance returns string-formatted metrics.
+    """AC-portfolio.api.16: AC17.6.18: GET /portfolio/performance returns string-formatted metrics.
 
     Verify that xirr, twr, mwr are returned as strings.
     """
@@ -948,7 +948,7 @@ async def test_performance_metrics_response_format(client: AsyncClient, portfoli
 
 
 async def test_get_performance_insufficient_data(client: AsyncClient):
-    """AC17.6.19: InsufficientDataError on empty portfolio -> xirr/mwr default to 0."""
+    """AC-portfolio.api.17: AC17.6.19: InsufficientDataError on empty portfolio -> xirr/mwr default to 0."""
     response = await client.get("/portfolio/performance")
     assert response.status_code == 200
     data = response.json()
@@ -958,7 +958,7 @@ async def test_get_performance_insufficient_data(client: AsyncClient):
 
 
 async def test_get_performance_xirr_calculation_error(client: AsyncClient, portfolio_with_data, monkeypatch):
-    """AC17.6.20: PerformanceError (non-InsufficientData) on XIRR -> 422."""
+    """AC-portfolio.api.18: AC17.6.20: PerformanceError (non-InsufficientData) on XIRR -> 422."""
     from src.services.performance import XIRRCalculationError
 
     async def _raise_xirr(*args, **kwargs):
@@ -972,7 +972,7 @@ async def test_get_performance_xirr_calculation_error(client: AsyncClient, portf
 
 
 async def test_get_performance_mwr_calculation_error(client: AsyncClient, portfolio_with_data, monkeypatch):
-    """AC17.6.21: PerformanceError (non-InsufficientData) on MWR -> 422."""
+    """AC-portfolio.api.19: AC17.6.21: PerformanceError (non-InsufficientData) on MWR -> 422."""
     from src.services.performance import XIRRCalculationError
 
     async def _ok_xirr(*args, **kwargs):
@@ -1062,7 +1062,7 @@ async def test_AC17_30_1_holdings_default_cap_applied(
     investment_account,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC17.30.1: GET /portfolio/holdings caps results at the *default* limit when
+    """AC-portfolio.pagination.1: AC17.30.1: GET /portfolio/holdings caps results at the *default* limit when
     no `limit` param is passed.
 
     The default cap is monkeypatched to 2 and 3 holdings are seeded, so omitting
@@ -1112,7 +1112,7 @@ async def test_AC17_30_2_holdings_limit_offset_honored(
     test_user,
     investment_account,
 ):
-    """AC17.30.2: GET /portfolio/holdings honors limit and offset to page through holdings."""
+    """AC-portfolio.pagination.2: AC17.30.2: GET /portfolio/holdings honors limit and offset to page through holdings."""
     for index in range(3):
         ticker = f"PAGE{index}"
         db.add_all(
@@ -1155,7 +1155,7 @@ async def test_AC17_30_2_holdings_limit_offset_honored(
 
 
 async def test_AC17_30_3_holdings_rejects_out_of_range_pagination(client: AsyncClient):
-    """AC17.30.3: GET /portfolio/holdings rejects out-of-range limit/offset with 422."""
+    """AC-portfolio.pagination.3: AC17.30.3: GET /portfolio/holdings rejects out-of-range limit/offset with 422."""
     too_large = await client.get("/portfolio/holdings?limit=10000")
     assert too_large.status_code == 422
 
@@ -1170,7 +1170,7 @@ async def test_AC17_30_4_dividends_limit_offset_honored(
     client: AsyncClient,
     portfolio_with_many_dividends,
 ):
-    """AC17.30.4: GET /portfolio/{ticker}/dividends honors limit/offset and rejects out-of-range."""
+    """AC-portfolio.pagination.4: AC17.30.4: GET /portfolio/{ticker}/dividends honors limit/offset and rejects out-of-range."""
     ticker = portfolio_with_many_dividends["ticker"]
     total = portfolio_with_many_dividends["count"]
 
@@ -1193,7 +1193,7 @@ async def test_AC17_30_5_realized_limit_offset_honored(
     client: AsyncClient,
     portfolio_with_many_realized,
 ):
-    """AC17.30.5: GET /portfolio/{ticker}/realized honors limit/offset and rejects out-of-range."""
+    """AC-portfolio.pagination.5: AC17.30.5: GET /portfolio/{ticker}/realized honors limit/offset and rejects out-of-range."""
     ticker = portfolio_with_many_realized["ticker"]
     total = portfolio_with_many_realized["count"]
 
@@ -1216,7 +1216,7 @@ async def test_AC17_30_6_allocation_limit_offset_honored(
     client: AsyncClient,
     portfolio_with_data,
 ):
-    """AC17.30.6: GET /portfolio/allocation/* honors limit/offset and rejects out-of-range."""
+    """AC-portfolio.pagination.6: AC17.30.6: GET /portfolio/allocation/* honors limit/offset and rejects out-of-range."""
     full = await client.get("/portfolio/allocation/sector")
     assert full.status_code == 200
     full_rows = full.json()

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -770,7 +770,7 @@ async def test_realized_pnl_fx_conversion(db, test_user, svc, account):
 
 
 async def test_unrealized_pnl_happy_path(db, test_user, svc, active_position, atomic_snapshot):
-    """AC-portfolio.holdings.2: AC17.2.6: Unrealized PnL happy path returns correct totals.
+    """AC-portfolio.holdings.2: AC17.1.5 (canonical; AC17.2.6 was a duplicate restatement): Unrealized PnL happy path returns correct totals.
 
     Verify that calculate_unrealized_pnl returns correct market value, cost basis, and PnL.
     """

--- a/apps/backend/tests/portfolio/test_portfolio_service.py
+++ b/apps/backend/tests/portfolio/test_portfolio_service.py
@@ -84,7 +84,7 @@ async def atomic_snapshot(db: AsyncSession, test_user):
 
 
 async def test_get_holdings_happy_path(db, test_user, svc, active_position, atomic_snapshot):
-    """AC17.1.1: Holdings happy path returns correct market value, cost basis, and classification.
+    """AC-portfolio.holdings.1: AC17.1.1: Holdings happy path returns correct market value, cost basis, and classification.
 
     Verify that get_holdings returns enriched HoldingResponse with PnL and sector data.
     """
@@ -105,7 +105,7 @@ async def test_get_holdings_happy_path(db, test_user, svc, active_position, atom
 
 
 async def test_get_holdings_provenance_imported_with_source_document(db, test_user, svc, active_position):
-    """AC22.10.1: a holding backed by a source document is labelled imported."""
+    """AC-portfolio.provenance.1: AC22.10.1: a holding backed by a source document is labelled imported."""
     atom = AtomicPosition(
         user_id=test_user.id,
         snapshot_date=date.today(),
@@ -129,7 +129,7 @@ async def test_get_holdings_provenance_imported_with_source_document(db, test_us
 
 
 async def test_AC22_13_1_explicit_as_of_holdings_preserve_snapshot_provenance(db, test_user, svc, account):
-    """AC22.13.1: explicit as-of holdings carry normalized provenance from the selected snapshot."""
+    """AC-portfolio.provenance.2: AC22.13.1: explicit as-of holdings carry normalized provenance from the selected snapshot."""
     as_of_date = date(2025, 1, 31)
     position = ManagedPosition(
         user_id=test_user.id,
@@ -232,7 +232,7 @@ async def test_get_holdings_explicit_as_of_date_does_not_use_future_snapshot(db,
 
 
 async def test_get_holdings_explicit_as_of_uses_historical_atomic_snapshot(db, test_user, svc, account):
-    """AC17.9.1: Explicit as-of holdings derive quantity and value from the selected snapshot."""
+    """AC-portfolio.as-of.1: AC17.9.1: Explicit as-of holdings derive quantity and value from the selected snapshot."""
     historical_date = date(2025, 1, 31)
     current_date = date(2025, 2, 28)
     position = ManagedPosition(
@@ -676,7 +676,7 @@ async def test_realized_pnl_no_disposed(db, test_user, svc):
 
 
 async def test_realized_pnl_zero_cost(db, test_user, svc, account):
-    """AC17.2.4: Zero cost -> realized_pnl_percent = 0."""
+    """AC-portfolio.performance.4: AC17.2.4: Zero cost -> realized_pnl_percent = 0."""
     pos = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -711,7 +711,7 @@ async def test_realized_pnl_zero_cost(db, test_user, svc, account):
 
 
 async def test_realized_pnl_fx_conversion(db, test_user, svc, account):
-    """AC17.2.5: Disposed position in non-base currency triggers FX conversion."""
+    """AC-portfolio.performance.5: AC17.2.5: Disposed position in non-base currency triggers FX conversion."""
     pos = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -770,7 +770,7 @@ async def test_realized_pnl_fx_conversion(db, test_user, svc, account):
 
 
 async def test_unrealized_pnl_happy_path(db, test_user, svc, active_position, atomic_snapshot):
-    """AC17.2.6: Unrealized PnL happy path returns correct totals.
+    """AC-portfolio.holdings.2: AC17.2.6: Unrealized PnL happy path returns correct totals.
 
     Verify that calculate_unrealized_pnl returns correct market value, cost basis, and PnL.
     """
@@ -783,7 +783,7 @@ async def test_unrealized_pnl_happy_path(db, test_user, svc, active_position, at
 
 
 async def test_unrealized_pnl_no_positions(db, test_user, svc):
-    """AC17.2.7: Unrealized PnL on empty portfolio raises PortfolioNotFoundError.
+    """AC-portfolio.performance.6: AC17.2.7: Unrealized PnL on empty portfolio raises PortfolioNotFoundError.
 
     Verify that calculate_unrealized_pnl raises when user has no active positions.
     """
@@ -792,7 +792,7 @@ async def test_unrealized_pnl_no_positions(db, test_user, svc):
 
 
 async def test_unrealized_pnl_zero_cost(db, test_user, svc, account):
-    """AC17.2.8: Zero cost -> unrealized_pnl_percent in details = 0."""
+    """AC-portfolio.performance.7: AC17.2.8: Zero cost -> unrealized_pnl_percent in details = 0."""
     pos = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -826,7 +826,7 @@ async def test_unrealized_pnl_zero_cost(db, test_user, svc, account):
 
 
 async def test_unrealized_pnl_fx_conversion(db, test_user, svc, account):
-    """AC17.2.9: FX conversion for unrealized PnL."""
+    """AC-portfolio.performance.8: AC17.2.9: FX conversion for unrealized PnL."""
     pos = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -885,7 +885,7 @@ async def test_unrealized_pnl_fx_conversion(db, test_user, svc, account):
 
 
 async def test_portfolio_summary_happy(db, test_user, svc, active_position, atomic_snapshot):
-    """AC17.1.7: Portfolio summary happy path returns correct counts and totals.
+    """AC-portfolio.holdings.3: AC17.1.7: Portfolio summary happy path returns correct counts and totals.
 
     Verify that get_portfolio_summary returns accurate summary with PnL.
     """
@@ -900,7 +900,7 @@ async def test_portfolio_summary_happy(db, test_user, svc, active_position, atom
 
 
 async def test_portfolio_summary_with_disposed(db, test_user, svc, account, atomic_snapshot):
-    """AC17.1.8: Summary includes both active and disposed positions."""
+    """AC-portfolio.holdings.4: AC17.1.8: Summary includes both active and disposed positions."""
     active = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -948,7 +948,7 @@ async def test_portfolio_summary_with_disposed(db, test_user, svc, account, atom
 
 
 async def test_portfolio_summary_zero_cost(db, test_user, svc, account):
-    """AC17.1.9: Zero total cost -> net_pnl_percent = 0."""
+    """AC-portfolio.holdings.5: AC17.1.9: Zero total cost -> net_pnl_percent = 0."""
     pos = ManagedPosition(
         user_id=test_user.id,
         account_id=account.id,
@@ -1053,7 +1053,7 @@ async def test_get_latest_price_from_atomic(db, test_user, svc, active_position,
 
 
 async def test_get_latest_price_zero_quantity(db, test_user, svc, active_position):
-    """AC17.5.5: Quantity == 0 -> return market_value directly."""
+    """AC-portfolio.valuation.2: AC17.5.5: Quantity == 0 -> return market_value directly."""
     atom = AtomicPosition(
         user_id=test_user.id,
         snapshot_date=date.today(),
@@ -1073,7 +1073,7 @@ async def test_get_latest_price_zero_quantity(db, test_user, svc, active_positio
 
 
 async def test_get_latest_price_no_data(db, test_user, svc, active_position):
-    """AC17.5.6: No price data -> AssetNotFoundError."""
+    """AC-portfolio.valuation.3: AC17.5.6: No price data -> AssetNotFoundError."""
     with pytest.raises(AssetNotFoundError):
         await svc._get_latest_price(db, active_position, date.today(), test_user.id)
 
@@ -1084,7 +1084,7 @@ async def test_get_latest_price_no_data(db, test_user, svc, active_position):
 
 
 async def test_get_latest_atomic_returns_latest(db, test_user, svc):
-    """AC17.5.7: _get_latest_atomic returns the most recent snapshot.
+    """AC-portfolio.valuation.4: AC17.5.7: _get_latest_atomic returns the most recent snapshot.
 
     Verify that when multiple snapshots exist, the latest by date is returned.
     """
@@ -1121,7 +1121,7 @@ async def test_get_latest_atomic_returns_latest(db, test_user, svc):
 
 
 async def test_get_latest_atomic_none(db, test_user, svc):
-    """AC17.5.8: _get_latest_atomic returns None when no snapshots exist.
+    """AC-portfolio.valuation.5: AC17.5.8: _get_latest_atomic returns None when no snapshots exist.
 
     Verify that _get_latest_atomic returns None for unknown asset.
     """

--- a/apps/backend/tests/reporting/test_account_lineage.py
+++ b/apps/backend/tests/reporting/test_account_lineage.py
@@ -26,7 +26,7 @@ async def cash_account(db: AsyncSession, user_id):
 
 
 async def test_AC22_3_3_account_lineage_returns_posted_contributing_lines(db: AsyncSession, user_id, cash_account):
-    """AC22.3.3: account-lineage returns posted journal lines with journal_line anchors and signed totals."""
+    """AC-reporting.lineage.1: AC22.3.3: account-lineage returns posted journal lines with journal_line anchors and signed totals."""
     posted = JournalEntry(
         user_id=user_id, entry_date=date(2025, 1, 10), memo="Salary", status=JournalEntryStatus.POSTED
     )

--- a/apps/backend/tests/reporting/test_annualized_income_schedule.py
+++ b/apps/backend/tests/reporting/test_annualized_income_schedule.py
@@ -201,7 +201,7 @@ async def test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_to
     db: AsyncSession,
     test_user,
 ):
-    """AC5.11.3/AC11.11.3: Annualized package totals use one reporting currency."""
+    """AC-reporting.package-annualized.2: AC5.11.3/AC11.11.3: Annualized package totals use one reporting currency."""
     salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="USD")
     sgd_cash = Account(user_id=test_user.id, name="SGD Cash", type=AccountType.ASSET, currency="SGD")

--- a/apps/backend/tests/reporting/test_balance_sheet_confidence.py
+++ b/apps/backend/tests/reporting/test_balance_sheet_confidence.py
@@ -45,7 +45,7 @@ async def _post(db, user_id, *, debit: Account, credit: Account, amount: Decimal
 
 @pytest.mark.asyncio
 async def test_AC5_18_1_lines_carry_worst_input_confidence_tier(db, test_user):
-    """AC5.18.1: A line's tier is the worst confidence tier among its contributing entries."""
+    """AC-reporting.confidence.1: AC5.18.1: A line's tier is the worst confidence tier among its contributing entries."""
     cash = Account(user_id=test_user.id, name="Cash A", type=AccountType.ASSET, currency="SGD")
     savings = Account(user_id=test_user.id, name="Savings B", type=AccountType.ASSET, currency="SGD")
     salary = Account(user_id=test_user.id, name="Salary", type=AccountType.INCOME, currency="SGD")
@@ -83,7 +83,7 @@ async def test_AC5_18_1_lines_carry_worst_input_confidence_tier(db, test_user):
 
 @pytest.mark.asyncio
 async def test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier(db, test_user):
-    """AC5.18.2: The balance-sheet aggregate tier is the worst tier across its lines; None when there is nothing to rate."""
+    """AC-reporting.confidence.2: AC5.18.2: The balance-sheet aggregate tier is the worst tier across its lines; None when there is nothing to rate."""
     empty = await generate_balance_sheet(db, test_user.id, as_of_date=date(2026, 12, 31))
     assert empty["confidence_tier"] is None
     assert empty["assets"] == []

--- a/apps/backend/tests/reporting/test_financial_logic_audit.py
+++ b/apps/backend/tests/reporting/test_financial_logic_audit.py
@@ -49,7 +49,7 @@ async def cash_flow_accounts(db: AsyncSession, test_user):
 
 
 async def test_AC5_10_1_cash_flow_uses_cumulative_cash_balances(db: AsyncSession, cash_flow_accounts):
-    """AC5.10.1: Cash-flow beginning/ending cash are cumulative balances."""
+    """AC-reporting.logic-audit.1: AC5.10.1: Cash-flow beginning/ending cash are cumulative balances."""
     user_id, cash, equity, rent = cash_flow_accounts
     await _add_entry(
         db,
@@ -74,7 +74,7 @@ async def test_AC5_10_1_cash_flow_uses_cumulative_cash_balances(db: AsyncSession
 
 
 async def test_AC5_10_2_cash_flow_activity_totals_preserve_signs(db: AsyncSession, cash_flow_accounts):
-    """AC5.10.2: Cash-flow activities preserve outflow signs."""
+    """AC-reporting.logic-audit.2: AC5.10.2: Cash-flow activities preserve outflow signs."""
     user_id, cash, equity, rent = cash_flow_accounts
     await _add_entry(
         db,

--- a/apps/backend/tests/reporting/test_framework_package_integration.py
+++ b/apps/backend/tests/reporting/test_framework_package_integration.py
@@ -163,7 +163,7 @@ async def test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers(
     db: AsyncSession,
     test_user: User,
 ) -> None:
-    """AC19.7.1: Framework-selected readiness blocks policy gaps and evidence deficiencies."""
+    """AC-reporting.readiness.6: AC19.7.1: Framework-selected readiness blocks policy gaps and evidence deficiencies."""
     report_date = date(2026, 5, 31)
     stale_position = AtomicPosition(
         user_id=test_user.id,

--- a/apps/backend/tests/reporting/test_income_annualized_router.py
+++ b/apps/backend/tests/reporting/test_income_annualized_router.py
@@ -17,7 +17,7 @@ async def test_annualized_income_endpoint_groups_last_12_month_income(
     db: AsyncSession,
     test_user,
 ):
-    """AC11.8.1/AC5.6.4: GET /income/annualized returns salary, bonus, dividend, total, currency, and as_of."""
+    """AC-reporting.kpis.1: AC11.8.1/AC5.6.4: GET /income/annualized returns salary, bonus, dividend, total, currency, and as_of."""
     salary = Account(user_id=test_user.id, name="Salary Income", type=AccountType.INCOME, currency="SGD")
     bonus = Account(user_id=test_user.id, name="Annual Bonus", type=AccountType.INCOME, currency="SGD")
     dividend = Account(user_id=test_user.id, name="Dividend Income", type=AccountType.INCOME, currency="SGD")

--- a/apps/backend/tests/reporting/test_income_typed_currency.py
+++ b/apps/backend/tests/reporting/test_income_typed_currency.py
@@ -22,7 +22,7 @@ from src.services.reporting_calc import AnnualizedIncomeTotals, resolve_line_cur
 
 
 def test_AC5_32_1_currency_code_type_validates_and_normalizes():
-    """AC5.32.1: AnnualizedIncomeResponse.currency is a typed, normalized currency code."""
+    """AC-reporting.income-typed.1: AC5.32.1: AnnualizedIncomeResponse.currency is a typed, normalized currency code."""
     # The schema field reuses the shared CurrencyCode type: Pydantic flattens the
     # Annotated alias, so assert on the carried metadata (length bounds + the
     # shared normalizer) rather than identity of the alias object.
@@ -56,7 +56,7 @@ def test_AC5_32_1_currency_code_type_validates_and_normalizes():
 
 
 def test_AC5_32_2_annualized_income_totals_is_typed_intermediate():
-    """AC5.32.2: AnnualizedIncomeTotals is a typed Decimal accumulator, not a str-keyed dict."""
+    """AC-reporting.income-typed.2: AC5.32.2: AnnualizedIncomeTotals is a typed Decimal accumulator, not a str-keyed dict."""
     totals = AnnualizedIncomeTotals()
     assert (totals.salary, totals.bonus, totals.dividend, totals.total) == (
         Decimal("0.00"),
@@ -87,7 +87,7 @@ def test_AC5_32_2_annualized_income_totals_is_typed_intermediate():
 
 
 def test_AC5_32_3_resolve_line_currency_uses_canonical_fallback_chain():
-    """AC5.32.3: resolve_line_currency centralizes line||account||base resolution + normalization."""
+    """AC-reporting.income-typed.3: AC5.32.3: resolve_line_currency centralizes line||account||base resolution + normalization."""
     account = Account(name="Salary", type=AccountType.INCOME, currency="usd")
     line_with_currency = JournalLine(direction=Direction.CREDIT, amount=Decimal("1.00"), currency="eur")
     line_no_currency = JournalLine(direction=Direction.CREDIT, amount=Decimal("1.00"), currency=None)
@@ -100,13 +100,13 @@ def test_AC5_32_3_resolve_line_currency_uses_canonical_fallback_chain():
 
 
 def test_AC5_32_4_fx_conversion_error_response_model_declared():
-    """AC5.32.4: an explicit FX-error response model exists for the income endpoint."""
+    """AC-reporting.income-typed.4: AC5.32.4: an explicit FX-error response model exists for the income endpoint."""
     err = FxConversionErrorResponse(detail="no FX rate for USD/SGD")
     assert err.detail == "no FX rate for USD/SGD"
 
 
 def test_AC5_32_5_normalize_currency_code_is_shared_helper():
-    """AC5.32.5: the currency normalizer is a single shared helper (no duplicated .strip().upper())."""
+    """AC-reporting.income-typed.5: AC5.32.5: the currency normalizer is a single shared helper (no duplicated .strip().upper())."""
     assert normalize_currency_code("  sgd ") == "SGD"
     assert normalize_currency_code("usd") == "USD"
 
@@ -117,7 +117,7 @@ async def test_AC5_32_6_endpoint_returns_normalized_currency_for_soft_base_confi
     test_user,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """AC5.32.6: endpoint normalizes a soft (lower-case) base currency setting in its response."""
+    """AC-reporting.income-typed.6: AC5.32.6: endpoint normalizes a soft (lower-case) base currency setting in its response."""
     from src import config
 
     monkeypatch.setattr(config.settings, "base_currency", "sgd")

--- a/apps/backend/tests/reporting/test_reporting.py
+++ b/apps/backend/tests/reporting/test_reporting.py
@@ -33,7 +33,7 @@ async def chart_of_accounts(db: AsyncSession, test_user_id):
 
 
 async def test_balance_sheet_equation(db: AsyncSession, chart_of_accounts, test_user_id):
-    """[AC5.1.1] Balance sheet should satisfy Assets = Liabilities + Equity."""
+    """AC-reporting.balance-sheet.1: [AC5.1.1] Balance sheet should satisfy Assets = Liabilities + Equity."""
     cash, _liability, equity, *_rest = chart_of_accounts
 
     entry = JournalEntry(
@@ -83,7 +83,7 @@ async def test_balance_sheet_equation(db: AsyncSession, chart_of_accounts, test_
 async def test_AC22_13_1_report_amount_lines_expose_normalized_provenance(
     db: AsyncSession, chart_of_accounts, test_user_id
 ):
-    """AC22.13.1: report amount lines expose Imported/Manual/Derived provenance when known."""
+    """AC-reporting.provenance.1: AC22.13.1: report amount lines expose Imported/Manual/Derived provenance when known."""
     cash, _liability, equity, income, expense = chart_of_accounts
 
     manual_entry = JournalEntry(
@@ -192,7 +192,7 @@ async def test_AC22_13_1_report_amount_lines_expose_normalized_provenance(
 
 
 async def test_income_statement_calculation(db: AsyncSession, chart_of_accounts, test_user_id):
-    """[AC5.2.1] Income statement should satisfy Net Income = Income - Expenses."""
+    """AC-reporting.income-statement.1: [AC5.2.1] Income statement should satisfy Net Income = Income - Expenses."""
     cash, _liability, _equity, income, expense = chart_of_accounts
 
     salary_entry = JournalEntry(
@@ -268,7 +268,7 @@ async def test_income_statement_calculation(db: AsyncSession, chart_of_accounts,
 
 
 async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_of_accounts, test_user_id, ac_evidence):
-    """[AC5.1.1][AC5.2.1][AC5.3.1][AC5.6.5] Deterministic fixture yields exact report totals."""
+    """AC-reporting.kpis.2 · AC-reporting.lineage.2: [AC5.1.1][AC5.2.1][AC5.3.1][AC5.6.5] Deterministic fixture yields exact report totals."""
     cash, liability, equity, income, expense = chart_of_accounts
 
     owner_contribution = JournalEntry(
@@ -488,21 +488,21 @@ async def test_reporting_dashboard_fixture_exact_totals(db: AsyncSession, chart_
     # computed from the deterministic fixture above; any drift in the report math
     # (sign rules, status/date filtering, FX) would move these numbers off the golden.
     ac_evidence(
-        ac_id="AC5.1.1",
+        ac_id="AC-reporting.balance-sheet.1",
         score=1.0,
         metric="balance_sheet_totals_match_golden",
         comment="assets 1600.00, liabilities 300.00, equity 1000.00; equation balanced (delta 0.00)",
         provenance="deterministic",
     )
     ac_evidence(
-        ac_id="AC5.2.1",
+        ac_id="AC-reporting.income-statement.1",
         score=1.0,
         metric="income_statement_net_income_match_golden",
         comment="income 500.00 - expenses 200.00 == net_income 300.00",
         provenance="deterministic",
     )
     ac_evidence(
-        ac_id="AC5.3.1",
+        ac_id="AC-reporting.cash-flow.1",
         score=1.0,
         metric="cash_flow_net_match_golden",
         comment="operating 300.00 + financing 1300.00 == net_cash_flow 1600.00; ending_cash 1600.00",
@@ -551,7 +551,7 @@ async def test_balance_sheet_fx_error(db: AsyncSession, chart_of_accounts, test_
 
 
 async def test_income_statement_invalid_range(db: AsyncSession, test_user_id):
-    """[AC5.2.3] Test income statement invalid date range validation."""
+    """AC-reporting.income-statement.3: [AC5.2.3] Test income statement invalid date range validation."""
     with pytest.raises(ReportError, match="start_date must be before end_date"):
         await generate_income_statement(
             db,
@@ -1056,7 +1056,7 @@ async def test_category_breakdown_quarterly(db: AsyncSession, chart_of_accounts,
 
 
 async def test_cash_flow_statement(db: AsyncSession, chart_of_accounts, test_user_id):
-    """[AC5.3.1] Cash flow statement should track movements across periods."""
+    """AC-reporting.cash-flow.1: [AC5.3.1] Cash flow statement should track movements across periods."""
     cash, _liability, equity, income, expense = chart_of_accounts
 
     entry = JournalEntry(
@@ -1199,7 +1199,7 @@ async def test_cash_flow_statement(db: AsyncSession, chart_of_accounts, test_use
 
 
 async def test_cash_flow_empty_period(db: AsyncSession, chart_of_accounts, test_user_id):
-    """[AC5.3.2] Cash flow statement with no transactions should return empty lists."""
+    """AC-reporting.cash-flow.2: [AC5.3.2] Cash flow statement with no transactions should return empty lists."""
     report = cast(
         dict[str, Any],
         await generate_cash_flow(

--- a/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py
@@ -334,7 +334,7 @@ async def test_net_income_sql_detects_missing_fx_map_row() -> None:
 
 
 async def test_account_trend_raises_when_prefetched_rate_missing(db: AsyncSession, test_user_id):
-    """AC5.6.8: Account trend raises when prefetched non-base FX rate is missing."""
+    """AC-reporting.kpis.4: AC5.6.8: Account trend raises when prefetched non-base FX rate is missing."""
     account = Account(user_id=test_user_id, name="USD Trend", type=AccountType.ASSET, currency="USD")
     offset = Account(user_id=test_user_id, name="USD Equity", type=AccountType.EQUITY, currency="USD")
     db.add_all([account, offset])
@@ -373,7 +373,7 @@ async def test_account_trend_raises_when_prefetched_rate_missing(db: AsyncSessio
 
 
 async def test_category_breakdown_raises_when_prefetched_rate_missing(db: AsyncSession, test_user_id):
-    """AC5.6.9: Category breakdown raises when prefetched non-base FX rate is missing."""
+    """AC-reporting.kpis.5: AC5.6.9: Category breakdown raises when prefetched non-base FX rate is missing."""
     expense = Account(user_id=test_user_id, name="USD Expense", type=AccountType.EXPENSE, currency="USD")
     bank = Account(user_id=test_user_id, name="USD Bank", type=AccountType.ASSET, currency="USD")
     db.add_all([expense, bank])
@@ -420,7 +420,7 @@ async def test_category_breakdown_raises_when_prefetched_rate_missing(db: AsyncS
 
 
 async def test_cash_flow_raises_when_start_date_rate_missing(db: AsyncSession, test_user_id):
-    """AC5.6.10: Cash flow raises when start-date non-base FX rate is missing."""
+    """AC-reporting.kpis.6: AC5.6.10: Cash flow raises when start-date non-base FX rate is missing."""
     bank = Account(user_id=test_user_id, name="USD Cash Before", type=AccountType.ASSET, currency="USD")
     offset = Account(user_id=test_user_id, name="USD Equity Before", type=AccountType.EQUITY, currency="USD")
     db.add_all([bank, offset])
@@ -463,7 +463,7 @@ async def test_cash_flow_raises_when_start_date_rate_missing(db: AsyncSession, t
 
 
 async def test_cash_flow_raises_when_end_date_rate_missing(db: AsyncSession, test_user_id):
-    """AC5.6.10 AC5.6.11: Cash flow raises when end-date rate missing; FxRateError propagated."""
+    """AC-reporting.kpis.7: AC5.6.10 AC5.6.11: Cash flow raises when end-date rate missing; FxRateError propagated."""
     bank = Account(user_id=test_user_id, name="USD Cash During", type=AccountType.ASSET, currency="USD")
     offset = Account(user_id=test_user_id, name="USD Equity During", type=AccountType.EQUITY, currency="USD")
     db.add_all([bank, offset])

--- a/apps/backend/tests/reporting/test_reporting_fx.py
+++ b/apps/backend/tests/reporting/test_reporting_fx.py
@@ -65,7 +65,7 @@ async def fx_rates(db: AsyncSession):
 
 
 async def test_fx_unrealized_gain_calculation(db: AsyncSession, multi_currency_accounts, fx_rates, test_user_id):
-    """[AC5.1.2] Test that unrealized FX gain is correctly calculated in the balance sheet."""
+    """AC-reporting.balance-sheet.2: [AC5.1.2] Test that unrealized FX gain is correctly calculated in the balance sheet."""
     sgd_cash, usd_savings, capital, *_ = multi_currency_accounts
 
     # 1. Opening Entry: Invest 100 USD when rate is 1.30 (Historical Cost = 130 SGD)
@@ -111,7 +111,7 @@ async def test_fx_unrealized_gain_calculation(db: AsyncSession, multi_currency_a
 
 
 async def test_income_statement_comprehensive_income(db: AsyncSession, multi_currency_accounts, fx_rates, test_user_id):
-    """[AC5.2.2] Test that income statement includes both net income and unrealized FX change."""
+    """AC-reporting.income-statement.2: [AC5.2.2] Test that income statement includes both net income and unrealized FX change."""
     sgd_cash, usd_savings, capital, salary, _ = multi_currency_accounts
 
     # 1. Opening (already in USD)
@@ -240,7 +240,7 @@ async def test_fx_liability_inversion(db: AsyncSession, multi_currency_accounts,
 
 
 async def test_multi_currency_aggregation(db: AsyncSession, multi_currency_accounts, test_user_id):
-    """[AC5.1.3] Test aggregation of multiple foreign currencies (USD and EUR)."""
+    """AC-reporting.balance-sheet.3: [AC5.1.3] Test aggregation of multiple foreign currencies (USD and EUR)."""
     sgd_cash, usd_savings, capital, *_ = multi_currency_accounts
     eur_savings = Account(user_id=test_user_id, name="EUR Savings", type=AccountType.ASSET, currency="EUR")
     db.add(eur_savings)
@@ -410,7 +410,7 @@ async def test_historical_vs_average_discrepancy_bridge(db: AsyncSession, multi_
 
 
 async def test_reporting_fx_fallbacks(db: AsyncSession, multi_currency_accounts, test_user_id):
-    """[AC5.4.1] Test FX fallbacks when rates are missing for BS and IS."""
+    """AC-reporting.fx.1: [AC5.4.1] Test FX fallbacks when rates are missing for BS and IS."""
     sgd_cash, usd_savings, capital, salary, dining = multi_currency_accounts
 
     # Rate only on Jan 31
@@ -1034,7 +1034,7 @@ async def test_reporting_income_statement_period_fx_fallback_to_spot(
 
 
 async def test_balance_sheet_net_income_fx_fallback(db: AsyncSession, multi_currency_accounts, test_user_id):
-    """[AC5.4.2] Test balance sheet uses FX fallback (Rate Caching logic).
+    """AC-reporting.fx.2: [AC5.4.2] Test balance sheet uses FX fallback (Rate Caching logic).
 
     This covers the fallback path in _aggregate_net_income_sql (lines 312-333).
     """
@@ -1092,7 +1092,7 @@ async def test_balance_sheet_net_income_fx_fallback(db: AsyncSession, multi_curr
 
 
 async def test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates(db: AsyncSession, test_user_id):
-    """[AC5.4.3] Reports derive and persist a missing HKD/SGD rate from bridge rates."""
+    """AC-reporting.fx.3: [AC5.4.3] Reports derive and persist a missing HKD/SGD rate from bridge rates."""
     hkd_cash = Account(user_id=test_user_id, name="HKD Cash", type=AccountType.ASSET, currency="HKD")
     hkd_salary = Account(user_id=test_user_id, name="HKD Salary", type=AccountType.INCOME, currency="HKD")
     db.add_all([hkd_cash, hkd_salary])

--- a/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
+++ b/apps/backend/tests/reporting/test_reporting_fx_fallbacks.py
@@ -120,7 +120,7 @@ async def test_aggregate_balances_with_start_date(db: AsyncSession, accounts, us
 async def test_aggregate_balances_missing_fx_skips_unconvertible_currency_with_warning(
     db: AsyncSession, accounts, user_id
 ):
-    """
+    """AC-reporting.fx.4:
     AC5.4.4: Missing FX during balance aggregation returns an explicit partial warning
     instead of aborting the whole report.
     """

--- a/apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py
+++ b/apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py
@@ -82,7 +82,7 @@ async def test_balance_sheet_fx_revaluation_is_calculated_not_plugged(db: AsyncS
 
 
 async def test_income_statement_includes_average_rate_fallback_warning(db: AsyncSession, test_user):
-    """AC5.6.7: Report output lists currencies that used average-rate spot fallback."""
+    """AC-reporting.kpis.3: AC5.6.7: Report output lists currencies that used average-rate spot fallback."""
     start_date = date(2025, 1, 1)
     end_date = date(2025, 1, 31)
     cash = await _account(db, test_user.id, "USD Cash", AccountType.ASSET, "USD")

--- a/apps/backend/tests/reporting/test_reporting_net_worth_components.py
+++ b/apps/backend/tests/reporting/test_reporting_net_worth_components.py
@@ -538,7 +538,7 @@ async def test_AC11_20_1_retirement_and_benefit_assets_are_restricted_assets_in_
     db: AsyncSession,
     test_user,
 ):
-    """AC11.20.1: Retirement and benefit account values are restricted assets in full net worth."""
+    """AC-reporting.net-worth-components.1: AC11.20.1: Retirement and benefit account values are restricted assets in full net worth."""
     report_date = date(2026, 6, 18)
     service = ValuationService()
     fixtures = [
@@ -593,7 +593,7 @@ async def test_AC11_20_2_net_worth_allocation_groups_retirement_and_benefit_asse
     db: AsyncSession,
     test_user,
 ):
-    """AC11.20.2: Retirement and benefit values have a dedicated allocation asset class."""
+    """AC-reporting.net-worth-components.2: AC11.20.2: Retirement and benefit values have a dedicated allocation asset class."""
     report_date = date(2026, 6, 18)
     fixtures = [
         (ManualValuationComponentType.RETIREMENT_ACCOUNT, "401k statement", Decimal("100000.00")),
@@ -786,7 +786,7 @@ async def test_AC17_14_2_net_worth_allocation_groups_balance_sheet_sources(
 
 
 async def test_income_statement_includes_applied_classification_breakdown(db: AsyncSession, test_user):
-    """AC18.4.4: Income statements include applied Layer 3 classification coverage."""
+    """AC-reporting.layer3.1 · AC-reporting.layer3.3: AC18.4.4: Income statements include applied Layer 3 classification coverage."""
     report_date = date(2025, 3, 31)
     income = await _create_account(db, test_user.id, name="Salary", account_type=AccountType.INCOME)
     atomic = AtomicTransaction(

--- a/apps/backend/tests/reporting/test_reports_errors.py
+++ b/apps/backend/tests/reporting/test_reports_errors.py
@@ -13,7 +13,7 @@ from tests.ledger._ledger_helpers import create_valid_posted_entry
 
 
 async def test_reports_router_errors_extended(client: AsyncClient, monkeypatch):
-    """[AC5.5.2] Test ReportError in all report endpoints using patch on the router's imports."""
+    """AC-reporting.errors.1: [AC5.5.2] Test ReportError in all report endpoints using patch on the router's imports."""
 
     test_cases = [
         ("/reports/balance-sheet", {"currency": "SGD"}, "generate_balance_sheet"),

--- a/apps/backend/tests/reporting/test_reports_router.py
+++ b/apps/backend/tests/reporting/test_reports_router.py
@@ -68,7 +68,7 @@ def test_data_setup_reports(db: AsyncSession, test_user):
 
 
 async def test_balance_sheet_endpoint(client, test_data_setup_reports):
-    """[AC5.1.4] Test balance sheet endpoint."""
+    """AC-reporting.balance-sheet.4: [AC5.1.4] Test balance sheet endpoint."""
     await test_data_setup_reports()
 
     response = await client.get("/reports/balance-sheet", params={"currency": "SGD"})
@@ -82,7 +82,7 @@ async def test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings(
     client,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC5.16.1: Balance sheet endpoint defaults restricted holdings to excluded."""
+    """AC-reporting.trust-signals.1: AC5.16.1: Balance sheet endpoint defaults restricted holdings to excluded."""
 
     async def fake_generate_balance_sheet(*_args, **kwargs):
         assert kwargs["include_restricted"] is False
@@ -111,7 +111,7 @@ async def test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings(
 
 
 async def test_income_statement_endpoint(client, test_data_setup_reports):
-    """Test income statement endpoint."""
+    """AC-reporting.errors.4: Test income statement endpoint."""
     await test_data_setup_reports()
 
     today = date.today()
@@ -141,7 +141,7 @@ async def test_AC5_16_2_cash_flow_response_preserves_fx_warnings(
     client,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC5.16.2: Cash flow response model exposes partial FX warnings."""
+    """AC-reporting.trust-signals.2: AC5.16.2: Cash flow response model exposes partial FX warnings."""
 
     async def fake_generate_cash_flow(*_args, **_kwargs):
         return {
@@ -400,7 +400,7 @@ async def test_AC5_17_1_cash_flow_export_returns_csv(
     client,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC5.17.1: Cash-flow report export is a first-class CSV export type."""
+    """AC-reporting.csv-export.1: AC5.17.1: Cash-flow report export is a first-class CSV export type."""
 
     async def fake_generate_cash_flow(*_args, **kwargs):
         assert kwargs["start_date"] == date(2026, 1, 1)

--- a/apps/backend/tests/reporting/test_reports_router_errors.py
+++ b/apps/backend/tests/reporting/test_reports_router_errors.py
@@ -11,7 +11,7 @@ class TestReportsRouterErrors:
     """Test error handling in reports router endpoints."""
 
     async def test_balance_sheet_report_error(self, client, db, test_user):
-        """
+        """AC-reporting.errors.2:
         [AC5.5.1] GIVEN a report generation that fails
         WHEN requesting balance sheet
         THEN it should return 400 with error message

--- a/apps/backend/tests/reporting/test_year_scale_reporting.py
+++ b/apps/backend/tests/reporting/test_year_scale_reporting.py
@@ -23,7 +23,7 @@ LATENCY_BUDGET_SECONDS = 30.0  # generous regression backstop, not a benchmark
 
 
 async def test_AC5_20_year_scale_reporting_ties_out_within_budget(db: AsyncSession, test_user) -> None:
-    """AC5.20.1: at a full year's transaction volume the three core statements
+    """AC-reporting.year-scale.1: AC5.20.1: at a full year's transaction volume the three core statements
     tie out and generate within a generous wall-clock budget."""
     user_id = test_user.id
     bank = Account(user_id=user_id, name="Bank", code="1001", type=AccountType.ASSET, currency="SGD")

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -289,5 +289,1237 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group reconcile: AtomicPosition -> ManagedPosition reconciliation
+        # (migrated from EPIC-011 AC11.1.1-12, migration closeout continuation, #1663) ──
+        ACRecord(
+            id="AC-portfolio.reconcile.1",
+            statement="Reconcile creates a new ManagedPosition from an AtomicPosition snapshot.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_creates_position",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.2",
+            statement="Reconcile updates an existing position's quantity from the latest snapshot.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_updates_position",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.3",
+            statement="Reconcile disposes a position when the latest snapshot quantity is 0.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_disposes_position",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.4",
+            statement="Reconcile sets cost basis from the snapshot's market_value.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_cost_basis_uses_market_value",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.5",
+            statement="Reconcile handles multiple different assets in one run.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_multiple_assets",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.6",
+            statement="The same asset at different brokers reconciles into separate positions.",
+            test=(
+                "apps/backend/tests/assets/test_asset_service.py"
+                "::test_reconcile_multiple_brokers_same_asset"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.7",
+            statement="A null/missing broker name falls back to 'Unknown Broker' instead of failing.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_with_null_broker",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.8",
+            statement="A disposed position reactivates to ACTIVE when it reappears in a later snapshot.",
+            test=(
+                "apps/backend/tests/assets/test_asset_service.py"
+                "::test_reconcile_reactivates_disposed_position"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.9",
+            statement="Listing positions returns an empty list when none exist, not an error.",
+            test="apps/backend/tests/assets/test_asset_service.py::test_get_positions_empty",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.10",
+            statement="Reconcile with no atomic snapshots is a no-op (no positions created/changed).",
+            test="apps/backend/tests/assets/test_asset_service.py::test_reconcile_no_snapshots",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.11",
+            statement="Negative quantities (short positions) reconcile correctly, not as an error.",
+            test=(
+                "apps/backend/tests/assets/test_asset_service.py"
+                "::test_reconcile_negative_quantity_short_position"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.reconcile.12",
+            statement="A single reconcile run's updated and disposed position counts are mutually exclusive.",
+            test=(
+                "apps/backend/tests/assets/test_asset_service.py"
+                "::test_reconcile_result_counts_are_mutually_exclusive"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group router: positions/reconcile/depreciation HTTP surface
+        # (migrated from EPIC-011 AC11.2/.3/.4/.5/.7, migration closeout continuation, #1663) ──
+        ACRecord(
+            id="AC-portfolio.router.1",
+            statement="GET /assets/positions returns an empty list when the user has no positions.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_list_positions_empty",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.2",
+            statement="GET /assets/positions returns the user's positions with data.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_list_positions_with_data",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.3",
+            statement="GET /assets/positions filters correctly by status.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_list_positions_filter_by_status",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.4",
+            statement="GET /assets/positions/{id} returns the position's details.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_get_position_success",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.5",
+            statement="GET /assets/positions/{id} returns 404 for a non-existent position.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_get_position_not_found",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.6",
+            statement="GET /assets/positions/{id} returns 404 for another user's position.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_get_position_wrong_user",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.7",
+            statement="POST /assets/reconcile creates positions from the latest atomic snapshots.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_reconcile_positions_success",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.8",
+            statement="POST /assets/reconcile with no snapshots returns zero created/updated/disposed counts.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_reconcile_positions_empty",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.9",
+            statement="GET /assets/positions requires authentication.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_list_positions_requires_auth",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.10",
+            statement="GET /assets/positions/{id} requires authentication.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_get_position_requires_auth",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.11",
+            statement="POST /assets/reconcile requires authentication.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_reconcile_requires_auth",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.router.12",
+            statement="Position queries are isolated by user_id — one user never sees another's positions.",
+            test="apps/backend/tests/assets/test_assets_router.py::test_get_position_user_isolation",
+            priority="P0",
+            status="done",
+        ),
+        # ── group depreciation: depreciation-schedule HTTP surface
+        # (migrated from EPIC-011 AC11.6, migration closeout continuation, #1663) ──
+        ACRecord(
+            id="AC-portfolio.depreciation.1",
+            statement="GET /assets/positions/{id}/depreciation returns the depreciation schedule.",
+            test=(
+                "apps/backend/tests/assets/test_assets_router.py"
+                "::test_get_position_depreciation_success"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.depreciation.2",
+            statement="GET /assets/positions/{id}/depreciation returns 400 for a non-existent position.",
+            test=(
+                "apps/backend/tests/assets/test_assets_router.py"
+                "::test_get_position_depreciation_not_found"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.depreciation.3",
+            statement="GET /assets/positions/{id}/depreciation returns 400 for a disposed position.",
+            test=(
+                "apps/backend/tests/assets/test_assets_router.py"
+                "::test_get_position_depreciation_disposed_position"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.depreciation.4",
+            statement="GET /assets/positions/{id}/depreciation returns 422 for invalid method/parameters.",
+            test=(
+                "apps/backend/tests/assets/test_assets_router.py"
+                "::test_get_position_depreciation_invalid_params"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group holdings: holdings summary + portfolio summary reads (was
+        # EPIC-017 AC17.1.1, AC17.1.5 and AC17.1.7-9, migration closeout
+        # continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.holdings.1",
+            statement=(
+                "get_holdings returns the holdings summary (ticker, quantity, cost basis, "
+                "market value) for active positions."
+            ),
+            # was AC17.1.1
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_holdings_happy_path"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.holdings.2",
+            statement="Unrealized P&L is calculated from cost basis and current market value.",
+            # was AC17.1.5
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_unrealized_pnl_happy_path"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.holdings.3",
+            statement="The portfolio summary happy path returns correct counts and totals.",
+            # was AC17.1.7
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_portfolio_summary_happy"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.holdings.4",
+            statement="The portfolio summary includes both active and disposed positions.",
+            # was AC17.1.8
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_portfolio_summary_with_disposed"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.holdings.5",
+            statement="A zero total cost yields net_pnl_percent = 0 instead of a division error.",
+            # was AC17.1.9
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_portfolio_summary_zero_cost"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group performance: XIRR/TWR/MWR + realized/unrealized P&L math
+        # (was EPIC-017 AC17.2.1-5 and AC17.2.7-9; AC17.2.6 deduped into
+        # AC-portfolio.holdings.2 — same test, same fact; migration closeout
+        # continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.performance.1",
+            statement=(
+                "XIRR over realistic data is accurate (within 0.01% of the Excel XIRR "
+                "reference)."
+            ),
+            # was AC17.2.1
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_with_realistic_data"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.2",
+            statement="Time-weighted return is computed correctly for a period.",
+            # was AC17.2.2
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_time_weighted_return_with_period"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.3",
+            statement="Money-weighted return is computed from dated cash flows.",
+            # was AC17.2.3
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_money_weighted_return_with_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.4",
+            statement=(
+                "A zero cost basis yields realized_pnl_percent = 0 instead of a division error."
+            ),
+            # was AC17.2.4
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_realized_pnl_zero_cost"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.5",
+            statement=(
+                "A disposed position in a non-base currency triggers FX conversion for realized "
+                "P&L."
+            ),
+            # was AC17.2.5
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_realized_pnl_fx_conversion"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.6",
+            statement="Unrealized P&L on an empty portfolio raises PortfolioNotFoundError.",
+            # was AC17.2.7
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_unrealized_pnl_no_positions"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.7",
+            statement=(
+                "A zero cost basis yields unrealized_pnl_percent = 0 in per-position details."
+            ),
+            # was AC17.2.8
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_unrealized_pnl_zero_cost"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.performance.8",
+            statement="Unrealized P&L converts non-base-currency positions via FX.",
+            # was AC17.2.9
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_unrealized_pnl_fx_conversion"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group allocation: allocation breakdowns + performance edge cases
+        # (was EPIC-017 AC17.3.1-3, AC17.3.5 and AC17.3.7-14; AC17.3.4/.6
+        # deduped into AC-portfolio.performance.2/.3 — same tests, same facts;
+        # migration closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.allocation.1",
+            statement="Sector allocation breaks holdings down by sector.",
+            # was AC17.3.1
+            test=(
+                "apps/backend/tests/portfolio/test_allocation_service.py"
+                "::test_sector_allocation_with_positions"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.2",
+            statement="Geography allocation breaks holdings down by geography.",
+            # was AC17.3.2
+            test=(
+                "apps/backend/tests/portfolio/test_allocation_service.py"
+                "::test_geography_allocation_with_positions"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.3",
+            statement="Asset-class allocation breaks holdings down by asset class.",
+            # was AC17.3.3
+            test=(
+                "apps/backend/tests/portfolio/test_allocation_service.py"
+                "::test_asset_class_allocation_with_positions"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.4",
+            statement="MWR raises InsufficientDataError on an empty portfolio.",
+            # was AC17.3.5
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_money_weighted_return_insufficient_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.5",
+            statement="XIRR respects the as_of_date parameter.",
+            # was AC17.3.7
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_with_as_of_date"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.6",
+            statement="TWR returns zero for a same-day period.",
+            # was AC17.3.8
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_time_weighted_return_same_day"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.7",
+            statement="Performance metrics handle cash-only portfolios without positions.",
+            # was AC17.3.9
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_performance_metrics_with_zero_positions"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.8",
+            statement="XIRR handles extreme convergence edge cases.",
+            # was AC17.3.10
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_convergence_edge_case"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.9",
+            statement="_xirr_bisection raises ValueError when no root exists.",
+            # was AC17.3.11
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_bisection_no_root_raises"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.10",
+            statement="_xirr_bisection returns a Decimal estimate after max_iter exhaustion.",
+            # was AC17.3.12
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_bisection_max_iter_returns"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.11",
+            statement="_xirr_newton falls back to bisection on non-convergence.",
+            # was AC17.3.13
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_newton_fallthrough_to_bisection"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.allocation.12",
+            statement="XIRRCalculationError is raised when Newton and bisection both fail.",
+            # was AC17.3.14
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_xirr_calculation_error_raised"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group valuation: position valuation reads + balance-sheet flow
+        # (was EPIC-017 AC17.5.4-8, migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.valuation.1",
+            statement=(
+                "Unrealized P&L flows into the balance sheet: an imported statement's holdings "
+                "change balance-sheet value."
+            ),
+            # was AC17.5.4
+            test=(
+                "apps/backend/tests/portfolio/test_brokerage_position_parsing.py"
+                "::test_statement_import_flows_to_holdings_and_balance_sheet"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.valuation.2",
+            statement=(
+                "A zero-quantity position returns its market_value directly instead of deriving "
+                "a unit price."
+            ),
+            # was AC17.5.5
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_latest_price_zero_quantity"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.valuation.3",
+            statement="Missing price data raises AssetNotFoundError.",
+            # was AC17.5.6
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_latest_price_no_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.valuation.4",
+            statement="_get_latest_atomic returns the most recent snapshot.",
+            # was AC17.5.7
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_latest_atomic_returns_latest"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.valuation.5",
+            statement="_get_latest_atomic returns None when no snapshots exist.",
+            # was AC17.5.8
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_latest_atomic_none"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group api: portfolio HTTP surface (was EPIC-017 AC17.6.3-21,
+        # migration closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.api.1",
+            statement="GET /portfolio/holdings with an as_of_date filter returns 200.",
+            # was AC17.6.3
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_holdings_with_date_filter"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.2",
+            statement="GET /portfolio/holdings with include_disposed=true returns 200.",
+            # was AC17.6.4
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_holdings_include_disposed"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.3",
+            statement="GET /portfolio/performance without a period returns metrics.",
+            # was AC17.6.5
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_performance_without_period"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.4",
+            statement="GET /portfolio/performance with period params returns metrics.",
+            # was AC17.6.6
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_performance_with_period"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.5",
+            statement="GET /portfolio/allocation/sector on an empty portfolio returns [].",
+            # was AC17.6.7
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_sector_allocation_empty"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.6",
+            statement="GET /portfolio/allocation/sector with data returns the breakdown.",
+            # was AC17.6.8
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_sector_allocation_with_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.7",
+            statement="GET /portfolio/allocation/geography on an empty portfolio returns [].",
+            # was AC17.6.9
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_geography_allocation_empty"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.8",
+            statement="GET /portfolio/allocation/geography with data returns the breakdown.",
+            # was AC17.6.10
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_geography_allocation_with_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.9",
+            statement="GET /portfolio/allocation/asset-class on an empty portfolio returns [].",
+            # was AC17.6.11
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_asset_class_allocation_empty"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.10",
+            statement="GET /portfolio/allocation/asset-class with data returns the breakdown.",
+            # was AC17.6.12
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_asset_class_allocation_with_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.11",
+            statement="POST /portfolio/prices/update with a single asset returns success.",
+            # was AC17.6.13
+            test="apps/backend/tests/portfolio/test_portfolio_router.py::test_update_prices_single",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.12",
+            statement="POST /portfolio/prices/update with a batch returns success.",
+            # was AC17.6.14
+            test="apps/backend/tests/portfolio/test_portfolio_router.py::test_update_prices_batch",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.13",
+            statement="POST /portfolio/prices/update with an invalid payload returns 422.",
+            # was AC17.6.15
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_update_prices_invalid_payload"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.14",
+            statement="All portfolio endpoints require authentication.",
+            # was AC17.6.16
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_portfolio_endpoints_require_auth"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.15",
+            statement="GET /portfolio/allocation/sector with as_of_date returns 200.",
+            # was AC17.6.17
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_allocation_with_as_of_date"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.16",
+            statement="GET /portfolio/performance returns string-formatted metrics.",
+            # was AC17.6.18
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_performance_metrics_response_format"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.17",
+            statement="InsufficientDataError on an empty portfolio defaults xirr/mwr to 0.",
+            # was AC17.6.19
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_performance_insufficient_data"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.18",
+            statement="A non-InsufficientData PerformanceError on XIRR returns 422.",
+            # was AC17.6.20
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_performance_xirr_calculation_error"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.api.19",
+            statement="A non-InsufficientData PerformanceError on MWR returns 422.",
+            # was AC17.6.21
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_performance_mwr_calculation_error"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group as-of: point-in-time holdings snapshots (was EPIC-017
+        # AC17.9.1-2 — the frontend selector row AC17.9.3 stays in EPIC-017;
+        # migration closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.as-of.1",
+            statement=(
+                "Historical holdings quantity and market value come from the latest "
+                "AtomicPosition snapshot at or before as_of_date."
+            ),
+            # was AC17.9.1
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_holdings_explicit_as_of_uses_historical_atomic_snapshot"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.as-of.2",
+            statement=(
+                "The holdings API returns date-bounded snapshot quantities for explicit "
+                "as_of_date requests."
+            ),
+            # was AC17.9.2
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_get_holdings_explicit_date_uses_historical_snapshot_quantity"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group report-schedule: investment performance report schedule API
+        # (was EPIC-017 AC17.10.1-6, migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.report-schedule.1",
+            statement=(
+                "The investment performance schedule API exposes report-ready metrics and "
+                "per-holding/allocation rows."
+            ),
+            # was AC17.10.1
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.report-schedule.2",
+            statement=(
+                "The schedule API exposes data freshness, source links, and notes for report "
+                "traceability."
+            ),
+            # was AC17.10.2
+            test=(
+                "tests/tooling/test_investment_performance_report_contract.py"
+                "::test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.report-schedule.3",
+            statement=(
+                "Schedule source links preserve brokerage statement, price source, ledger, "
+                "transaction source, and report-section anchors."
+            ),
+            # was AC17.10.3
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.report-schedule.4",
+            statement=(
+                "Schedule data freshness marks the schedule stale when any holding lacks "
+                "current as-of-date price evidence."
+            ),
+            # was AC17.10.4
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.report-schedule.5",
+            statement="The XIRR solver never converts monetary Decimal cash flows to float.",
+            # was AC17.10.5
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.report-schedule.6",
+            statement=(
+                "The schedule converts mixed-currency cost basis, market value, realized P&L, "
+                "and dividend income into the presentation currency before aggregation."
+            ),
+            # was AC17.10.6
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_10_6_investment_performance_schedule_converts_mixed_currency_amounts"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group logic-audit: portfolio financial logic audit fixes (was
+        # EPIC-017 AC17.11.1-4, migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.logic-audit.1",
+            statement=(
+                "XIRR and MWR use investment transactions only, excluding unrelated bank atomic "
+                "transactions."
+            ),
+            # was AC17.11.1
+            test=(
+                "apps/backend/tests/portfolio/test_financial_logic_audit.py"
+                "::test_AC17_11_1_xirr_excludes_unrelated_bank_transactions"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.logic-audit.2",
+            statement=(
+                "Summary YTD realized P&L and dividend income convert to the presentation "
+                "currency before aggregation."
+            ),
+            # was AC17.11.2
+            test=(
+                "apps/backend/tests/portfolio/test_financial_logic_audit.py"
+                "::test_AC17_11_2_summary_ytd_amounts_convert_to_presentation_currency"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.logic-audit.3",
+            statement=(
+                "TWR excludes unrelated bank atomic transactions from the period cash-flow "
+                "adjustment."
+            ),
+            # was AC17.11.3
+            test=(
+                "apps/backend/tests/portfolio/test_financial_logic_audit.py"
+                "::test_AC17_11_3_twr_excludes_unrelated_bank_transactions"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.logic-audit.4",
+            statement="Non-structured source document payloads produce no audit links.",
+            # was AC17.11.4
+            test=(
+                "apps/backend/tests/portfolio/test_financial_logic_audit.py"
+                "::test_AC17_11_4_source_document_links_ignore_non_structured_payloads"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group fixtures: portfolio audit fixture contract (was EPIC-017
+        # AC17.12.1-3, migration closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.fixtures.1",
+            statement=(
+                "The portfolio audit fixture contract covers multi-broker, multi-currency "
+                "expected positions and a report period containing every activity row."
+            ),
+            # was AC17.12.1
+            test=(
+                "tests/tooling/test_portfolio_audit_fixture_contract.py"
+                "::test_AC17_12_1_portfolio_fixture_contract_covers_multi_broker_multi_currency_inputs"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fixtures.2",
+            statement=(
+                "The fixture contract pins sanitized trade, dividend, fee, and valuation "
+                "activity rows and derives expected totals from fixture rows and positions."
+            ),
+            # was AC17.12.2
+            test=(
+                "tests/tooling/test_portfolio_audit_fixture_contract.py"
+                "::test_AC17_12_2_portfolio_fixture_pins_activity_rows_without_raw_documents"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fixtures.3",
+            statement=(
+                "The personal report package fixture consumes the expanded portfolio expected "
+                "outputs instead of inline one-position constants."
+            ),
+            # was AC17.12.3
+            test=(
+                "tests/tooling/test_portfolio_audit_fixture_contract.py"
+                "::test_AC17_12_3_personal_package_references_expanded_portfolio_fixture_contract"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group fact-boundary: portfolio facts vs framework conclusions
+        # (was EPIC-017 AC17.13.1, migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.fact-boundary.1",
+            statement=(
+                "Portfolio owns holdings, lots, dividends, fees, and source links and relays "
+                "pricing facts as framework policy inputs; it does not own final US/HK report "
+                "presentation decisions."
+            ),
+            # was AC17.13.1
+            test=(
+                "tests/tooling/test_framework_reporting_epic_contract.py"
+                "::test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group pagination: list endpoint pagination bounds (was EPIC-017
+        # AC17.30.1-6, migration closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.pagination.1",
+            statement="GET /portfolio/holdings caps results at the default limit when paginating.",
+            # was AC17.30.1
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_1_holdings_default_cap_applied"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.pagination.2",
+            statement="GET /portfolio/holdings honors limit and offset to page through holdings.",
+            # was AC17.30.2
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_2_holdings_limit_offset_honored"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.pagination.3",
+            statement="GET /portfolio/holdings rejects out-of-range limit/offset with 422.",
+            # was AC17.30.3
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_3_holdings_rejects_out_of_range_pagination"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.pagination.4",
+            statement=(
+                "GET /portfolio/{ticker}/dividends honors limit/offset and rejects out-of-range "
+                "values."
+            ),
+            # was AC17.30.4
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_4_dividends_limit_offset_honored"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.pagination.5",
+            statement=(
+                "GET /portfolio/{ticker}/realized honors limit/offset and rejects out-of-range "
+                "values."
+            ),
+            # was AC17.30.5
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_5_realized_limit_offset_honored"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.pagination.6",
+            statement=(
+                "GET /portfolio/allocation/* honors limit/offset and rejects out-of-range "
+                "values."
+            ),
+            # was AC17.30.6
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC17_30_6_allocation_limit_offset_honored"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group typed-responses: typed Pydantic router responses (was
+        # EPIC-017 AC17.31.1-2, migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.typed-responses.1",
+            statement=(
+                "POST /portfolio/prices/update returns the typed {updated_count, results} "
+                "shape."
+            ),
+            # was AC17.31.1
+            test=(
+                "apps/backend/tests/api/test_typed_contract_sweep.py"
+                "::test_AC17_31_1_prices_update_returns_typed_batch_response"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.typed-responses.2",
+            statement="PATCH /portfolio/{ticker} for an unknown holding returns a structured 404.",
+            # was AC17.31.2
+            test=(
+                "apps/backend/tests/api/test_typed_contract_sweep.py"
+                "::test_AC17_31_2_patch_unknown_holding_returns_404"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        # ── group metrics: portfolio-owned performance math that lived in the
+        # reporting EPIC (was EPIC-005 AC5.6.1-3 and AC5.6.6, migration
+        # closeout continuation, #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.metrics.1",
+            statement="XIRR matches the single-year Excel XIRR reference case within 0.01%.",
+            # was AC5.6.1
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC5_6_1_xirr_matches_single_year_excel_case"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.metrics.2",
+            statement="Annualized time-weighted return matches the snapshot period reference.",
+            # was AC5.6.2
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC5_6_2_time_weighted_return_matches_snapshot_period"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.metrics.3",
+            statement="Dividend yield is trailing annual dividends over current value.",
+            # was AC5.6.3
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.metrics.4",
+            statement="Money-weighted return matches XIRR for a single cash flow.",
+            # was AC5.6.6
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group schedule-fallback: mixed-currency schedule fallback (was
+        # EPIC-019 AC19.8.8's portfolio share — the readiness-FX and Playwright
+        # shares stay in EPIC-019; migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.schedule-fallback.1",
+            statement=(
+                "The mixed-currency investment schedule fallback converts holding cost basis "
+                "into the schedule currency."
+            ),
+            # was AC19.8.8 (portfolio share)
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC19_8_8_investment_schedule_fallback_holding_cost_basis_converts_currency"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group provenance: conservative provenance labeling (was EPIC-022
+        # AC22.10.1's backend half and AC22.13.1's portfolio share — the
+        # frontend badge halves stay in EPIC-022; the pricing share is
+        # AC-pricing.provenance.1 and the reporting share is
+        # AC-reporting.provenance.1; migration closeout continuation,
+        # #1663 / #1717) ──
+        ACRecord(
+            id="AC-portfolio.provenance.1",
+            statement=(
+                "A holding whose latest snapshot is backed by a source document is labeled "
+                "imported; holdings without document evidence carry no provenance label."
+            ),
+            # was AC22.10.1 (backend half)
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_get_holdings_provenance_imported_with_source_document"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.provenance.2",
+            statement=(
+                "Portfolio holdings and explicit as-of holdings expose the normalized "
+                "provenance enum when the source basis is known, and stay unlabeled instead of "
+                "guessing."
+            ),
+            # was AC22.13.1 (portfolio share)
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_service.py"
+                "::test_AC22_13_1_explicit_as_of_holdings_preserve_snapshot_provenance"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -527,5 +527,1269 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── group balance-sheet: balance-sheet generation (was EPIC-005
+        # AC5.1.1-4, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.balance-sheet.1",
+            statement=(
+                "The generated balance sheet satisfies the accounting equation: assets = "
+                "liabilities + equity (net income included)."
+            ),
+            # was AC5.1.1
+            test="apps/backend/tests/reporting/test_reporting.py::test_balance_sheet_equation",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.balance-sheet.2",
+            statement=(
+                "FX unrealized gain is calculated for foreign-currency balances on the balance "
+                "sheet."
+            ),
+            # was AC5.1.2
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx.py"
+                "::test_fx_unrealized_gain_calculation"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.balance-sheet.3",
+            statement=(
+                "Multi-currency account balances aggregate into the base reporting currency on "
+                "the balance sheet."
+            ),
+            # was AC5.1.3
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx.py"
+                "::test_multi_currency_aggregation"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.balance-sheet.4",
+            statement="GET /reports/balance-sheet returns the generated balance sheet payload.",
+            # was AC5.1.4
+            test="apps/backend/tests/reporting/test_reports_router.py::test_balance_sheet_endpoint",
+            priority="P0",
+            status="done",
+        ),
+        # ── group income-statement (was EPIC-005 AC5.2.1-3, migration
+        # closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.income-statement.1",
+            statement="The income statement computes net income as income minus expenses.",
+            # was AC5.2.1
+            test=(
+                "apps/backend/tests/reporting/test_reporting.py"
+                "::test_income_statement_calculation"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-statement.2",
+            statement="The income statement includes comprehensive income from FX effects.",
+            # was AC5.2.2
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx.py"
+                "::test_income_statement_comprehensive_income"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-statement.3",
+            statement=(
+                "The income statement rejects an invalid date range (start after end) with a "
+                "domain error."
+            ),
+            # was AC5.2.3
+            test=(
+                "apps/backend/tests/reporting/test_reporting.py"
+                "::test_income_statement_invalid_range"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group cash-flow: cash-flow statement + trend/breakdown endpoints
+        # (was EPIC-005 AC5.3.1-5, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.cash-flow.1",
+            statement=(
+                "The cash-flow statement is generated with operating, investing, and financing "
+                "sections."
+            ),
+            # was AC5.3.1
+            test="apps/backend/tests/reporting/test_reporting.py::test_cash_flow_statement",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.cash-flow.2",
+            statement=(
+                "A period with no cash movement generates an empty (zeroed) cash-flow "
+                "statement, not an error."
+            ),
+            # was AC5.3.2
+            test="apps/backend/tests/reporting/test_reporting.py::test_cash_flow_empty_period",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.cash-flow.3",
+            statement=(
+                "GET /reports/trend returns account trend data across different period "
+                "granularities."
+            ),
+            # was AC5.3.3
+            test="apps/backend/tests/api/test_reports_router.py::test_account_trend_with_period",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.cash-flow.4",
+            statement="GET /reports/breakdown returns the category breakdown.",
+            # was AC5.3.4
+            test="apps/backend/tests/api/test_reports_router.py::test_category_breakdown_success",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.cash-flow.5",
+            statement="GET /reports/breakdown honors the requested period parameter.",
+            # was AC5.3.5
+            test=(
+                "apps/backend/tests/api/test_reports_router.py"
+                "::test_category_breakdown_with_period"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group fx: multi-currency conversion fallbacks (was EPIC-005
+        # AC5.4.1-4, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.fx.1",
+            statement=(
+                "Report FX conversion falls back through the documented rate-resolution chain."
+            ),
+            # was AC5.4.1
+            test="apps/backend/tests/reporting/test_reporting_fx.py::test_reporting_fx_fallbacks",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fx.2",
+            statement=(
+                "Balance-sheet net income uses the FX fallback path when a direct rate is "
+                "missing."
+            ),
+            # was AC5.4.2
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx.py"
+                "::test_balance_sheet_net_income_fx_fallback"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fx.3",
+            statement=(
+                "Reports lazily resolve a missing cross rate (e.g. HKD/SGD) from stored bridge "
+                "rates."
+            ),
+            # was AC5.4.3
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx.py"
+                "::test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fx.4",
+            statement=(
+                "Missing report FX rates produce explicit partial warnings for the "
+                "unconvertible currency instead of aborting the whole aggregation."
+            ),
+            # was AC5.4.4
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx_fallbacks.py"
+                "::test_aggregate_balances_missing_fx_skips_unconvertible_currency_with_warning"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group errors: report error handling + auth boundary (was EPIC-005
+        # AC5.5.1-5, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.errors.1",
+            statement="Report-generation failures surface as structured router errors.",
+            # was AC5.5.1
+            test=(
+                "apps/backend/tests/reporting/test_reports_errors.py"
+                "::test_reports_router_errors_extended"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.errors.2",
+            statement=(
+                "Each reports endpoint maps a ReportError to a structured HTTP error response "
+                "(TestReportsRouterErrors suite; representative test cited)."
+            ),
+            # was AC5.5.2
+            test=(
+                "apps/backend/tests/reporting/test_reports_router_errors.py"
+                "::test_balance_sheet_report_error"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.errors.3",
+            statement="Unauthenticated clients cannot access the reports endpoints.",
+            # was AC5.5.3
+            test="apps/backend/tests/api/test_reports_router.py::test_unauthenticated_access",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.errors.4",
+            statement=(
+                "The reports router endpoints respond successfully for an authenticated user "
+                "(representative endpoint test cited)."
+            ),
+            # was AC5.5.4
+            test=(
+                "apps/backend/tests/reporting/test_reports_router.py"
+                "::test_income_statement_endpoint"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.errors.5",
+            statement=(
+                "GET /reports/{report_type}/snapshots returns the user's persisted report "
+                "snapshots."
+            ),
+            # was AC5.5.5
+            test=(
+                "apps/backend/tests/api/test_reports_router.py"
+                "::test_list_report_snapshots_returns_created_snapshots"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group kpis: dashboard/report KPI surfaces + FX guardrails (was
+        # EPIC-005 AC5.6.4-5 and AC5.6.7-11 — AC5.6.4's frontend dashboard-card
+        # half stays in EPIC-005; migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.kpis.1",
+            statement=(
+                "The annualized income KPI endpoint groups the last 12 months of income; "
+                "calculation ownership stays with AC11.8.1."
+            ),
+            # was AC5.6.4 (backend half)
+            test=(
+                "apps/backend/tests/reporting/test_income_annualized_router.py"
+                "::test_annualized_income_endpoint_groups_last_12_month_income"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.2",
+            statement=(
+                "Unrealized P&L is reflected in balance-sheet equity (golden dashboard fixture "
+                "asserts exact totals)."
+            ),
+            # was AC5.6.5
+            test=(
+                "apps/backend/tests/reporting/test_reporting.py"
+                "::test_reporting_dashboard_fixture_exact_totals"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.3",
+            statement=(
+                "Report output lists the currencies that used the average-rate spot fallback."
+            ),
+            # was AC5.6.7
+            test=(
+                "apps/backend/tests/reporting/test_reporting_fx_revaluation_integration.py"
+                "::test_income_statement_includes_average_rate_fallback_warning"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.4",
+            statement="Account trend raises when a prefetched non-base FX rate is missing.",
+            # was AC5.6.8
+            test=(
+                "apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py"
+                "::test_account_trend_raises_when_prefetched_rate_missing"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.5",
+            statement="Category breakdown raises when a prefetched non-base FX rate is missing.",
+            # was AC5.6.9
+            test=(
+                "apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py"
+                "::test_category_breakdown_raises_when_prefetched_rate_missing"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.6",
+            statement="Cash flow raises when the start-date non-base FX rate is missing.",
+            # was AC5.6.10
+            test=(
+                "apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py"
+                "::test_cash_flow_raises_when_start_date_rate_missing"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.kpis.7",
+            statement=(
+                "Cash flow raises when the end-date FX rate is missing, propagating "
+                "FxRateError."
+            ),
+            # was AC5.6.11
+            test=(
+                "apps/backend/tests/reporting/test_reporting_extreme_fallbacks.py"
+                "::test_cash_flow_raises_when_end_date_rate_missing"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group package-investment: investment-performance section consumption
+        # (was EPIC-005 AC5.8.1's backend contract half — the frontend render
+        # and post-merge journey proofs stay in EPIC-005; migration closeout
+        # continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-investment.1",
+            statement=(
+                "The personal report package defines the investment_performance section as a "
+                "consumer of the EPIC-017 schedule API, preserving source_links and notes."
+            ),
+            # was AC5.8.1 (backend half)
+            test=(
+                "tests/tooling/test_investment_performance_report_contract.py"
+                "::test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group package-contract: personal report package API contract (was
+        # EPIC-005 AC5.9.1-2 — the frontend rows AC5.9.3-4 stay in EPIC-005;
+        # migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-contract.1",
+            statement=(
+                "The package contract endpoint defines the required section IDs, labels, "
+                "owners, and source endpoints."
+            ),
+            # was AC5.9.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_9_1_package_contract_endpoint_defines_required_sections"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-contract.2",
+            statement=(
+                "The package contract exposes Decimal-safe total fields and explicit "
+                "period/as-of semantics."
+            ),
+            # was AC5.9.2
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group logic-audit: financial statement logic audit fixes (was
+        # EPIC-005 AC5.10.1-2, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.logic-audit.1",
+            statement=(
+                "Cash-flow beginning cash, ending cash, and net cash flow use cumulative cash "
+                "balances."
+            ),
+            # was AC5.10.1
+            test=(
+                "apps/backend/tests/reporting/test_financial_logic_audit.py"
+                "::test_AC5_10_1_cash_flow_uses_cumulative_cash_balances"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.logic-audit.2",
+            statement=(
+                "Cash-flow operating, investing, and financing totals preserve inflow/outflow "
+                "signs."
+            ),
+            # was AC5.10.2
+            test=(
+                "apps/backend/tests/reporting/test_financial_logic_audit.py"
+                "::test_AC5_10_2_cash_flow_activity_totals_preserve_signs"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group package-annualized: annualized income schedule consumption
+        # (was EPIC-005 AC5.11.1 and AC5.11.3 — the frontend row AC5.11.2 stays
+        # in EPIC-005; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-annualized.1",
+            statement=(
+                "The package contract marks annualized_income_long_term ready and points at the "
+                "schedule endpoint."
+            ),
+            # was AC5.11.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_11_1_package_contract_marks_annualized_schedule_ready"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-annualized.2",
+            statement=(
+                "The annualized income package schedule converts mixed-currency income and "
+                "restricted totals into one reporting currency."
+            ),
+            # was AC5.11.3
+            test=(
+                "apps/backend/tests/reporting/test_annualized_income_schedule.py"
+                "::test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_totals"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group package-notes: notes and disclosure basis (was EPIC-005
+        # AC5.12.1-2 and AC5.12.4 — the frontend row AC5.12.3 stays in
+        # EPIC-005; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-notes.1",
+            statement=(
+                "The package notes endpoint returns the required note IDs, owner EPICs, source "
+                "states, and non-compliance wording."
+            ),
+            # was AC5.12.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_12_1_package_notes_endpoint_returns_required_note_taxonomy"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-notes.2",
+            statement="The package contract marks notes ready and points at the notes endpoint.",
+            # was AC5.12.2
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_12_2_package_contract_marks_notes_ready"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-notes.3",
+            statement=(
+                "The post-merge package proof asserts the notes endpoint, required note IDs, "
+                "and non-compliance wording."
+            ),
+            # was AC5.12.4
+            test=(
+                "tests/e2e/test_personal_financial_report_package.py"
+                "::test_personal_financial_report_package_post_merge_journey"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group package-traceability: source-ledger-report appendix (was
+        # EPIC-005 AC5.13.1-2 and AC5.13.4-5 — the frontend row AC5.13.3 stays
+        # in EPIC-005; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-traceability.1",
+            statement=(
+                "The package traceability endpoint returns source-to-ledger anchors per report "
+                "line."
+            ),
+            # was AC5.13.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-traceability.2",
+            statement=(
+                "The traceability appendix exposes explicit completeness states where anchors "
+                "are unavailable."
+            ),
+            # was AC5.13.2
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_13_2_package_traceability_declares_completeness_warnings"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-traceability.3",
+            statement=(
+                "The post-merge package proof fails trusted totals without source/ledger "
+                "anchors or explicit manual inputs."
+            ),
+            # was AC5.13.4
+            test=(
+                "tests/e2e/test_personal_financial_report_package.py"
+                "::test_personal_financial_report_package_post_merge_journey"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-traceability.4",
+            statement=(
+                "The package traceability endpoint returns current-user dynamic source "
+                "identifiers and excludes unrelated-user anchors."
+            ),
+            # was AC5.13.5
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_13_5_package_traceability_returns_dynamic_current_user_identifiers"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group integration: backend reporting integration journey (was
+        # EPIC-005 AC5.15.1, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.integration.1",
+            statement=(
+                "Multi-currency posted entries generate balanced balance-sheet, "
+                "income-statement, and cash-flow reports in the base currency."
+            ),
+            # was AC5.15.1
+            test=(
+                "apps/backend/tests/integration/test_reporting_e2e.py"
+                "::test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group trust-signals: report trust signals + restricted-asset
+        # defaults (was EPIC-005 AC5.16.1-2 backend halves and AC5.16.4 — the
+        # frontend halves and AC5.16.3 stay in EPIC-005; migration closeout
+        # continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.trust-signals.1",
+            statement=(
+                "The balance sheet defaults restricted holdings to excluded and exposes an "
+                "include toggle."
+            ),
+            # was AC5.16.1 (backend half)
+            test=(
+                "apps/backend/tests/reporting/test_reports_router.py"
+                "::test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.trust-signals.2",
+            statement=(
+                "Report responses preserve backend fx_warnings so pages never silently render "
+                "partial totals."
+            ),
+            # was AC5.16.2 (backend half)
+            test=(
+                "apps/backend/tests/reporting/test_reports_router.py"
+                "::test_AC5_16_2_cash_flow_response_preserves_fx_warnings"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.trust-signals.3",
+            statement=(
+                "Package traceability lines expose source classes, proof level, anchor count, "
+                "and blocker codes for report-line confidence review."
+            ),
+            # was AC5.16.4
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group csv-export: authenticated report CSV exports (was EPIC-005
+        # AC5.17.1's backend half — the frontend apiDownload half and AC5.17.2
+        # stay in EPIC-005; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.csv-export.1",
+            statement=(
+                "The backend CSV export supports cash-flow reports with date-range and currency "
+                "filters."
+            ),
+            # was AC5.17.1 (backend half)
+            test=(
+                "apps/backend/tests/reporting/test_reports_router.py"
+                "::test_AC5_17_1_cash_flow_export_returns_csv"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group confidence: per-node confidence tier on balance-sheet
+        # payloads (was EPIC-005 AC5.18.1-2, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.confidence.1",
+            statement=(
+                "Each balance-sheet line carries the worst-input confidence tier of its "
+                "contributing journal entries."
+            ),
+            # was AC5.18.1
+            test=(
+                "apps/backend/tests/reporting/test_balance_sheet_confidence.py"
+                "::test_AC5_18_1_lines_carry_worst_input_confidence_tier"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.confidence.2",
+            statement=(
+                "The Net Worth aggregate rolls up to the worst-input tier across rated lines, "
+                "and is null when nothing is rated."
+            ),
+            # was AC5.18.2
+            test=(
+                "apps/backend/tests/reporting/test_balance_sheet_confidence.py"
+                "::test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group package-snapshot: durable package snapshot artifact (was
+        # EPIC-005 AC5.19.1-3 — the frontend row AC5.19.4 stays in EPIC-005;
+        # migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.package-snapshot.1",
+            statement=(
+                "POST /api/reports/package/generate creates an immutable package snapshot; "
+                "blocked readiness may generate only a draft while ready readiness generates "
+                "trusted output."
+            ),
+            # was AC5.19.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_19_1_package_generate_creates_draft_or_trusted_snapshot"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-snapshot.2",
+            statement=(
+                "Package snapshot list/reopen endpoints are user-scoped and reopening returns "
+                "the original payload after live inputs change."
+            ),
+            # was AC5.19.2
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_19_2_package_snapshot_get_is_user_scoped_and_immutable"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.package-snapshot.3",
+            statement=(
+                "Package JSON and CSV downloads are derived from a saved snapshot rather than "
+                "recalculating live data."
+            ),
+            # was AC5.19.3
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC5_19_3_package_snapshot_exports_are_snapshot_derived"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group year-scale: year-scale reporting validation (was EPIC-005
+        # AC5.20.1, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.year-scale.1",
+            statement=(
+                "At a full year's transaction volume the three statements tie out and generate "
+                "within a wall-clock backstop, guarding against a silent O(n^2) regression."
+            ),
+            # was AC5.20.1
+            test=(
+                "apps/backend/tests/reporting/test_year_scale_reporting.py"
+                "::test_AC5_20_year_scale_reporting_ties_out_within_budget"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group income-typed: income module typed currency + typed
+        # intermediates (was EPIC-005 AC5.32.1-6, migration closeout
+        # continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.income-typed.1",
+            statement=(
+                "AnnualizedIncomeResponse.currency is the shared typed CurrencyCode (validated "
+                "length + normalized), not a soft str."
+            ),
+            # was AC5.32.1
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_1_currency_code_type_validates_and_normalizes"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-typed.2",
+            statement=(
+                "Income totals accumulate in a typed AnnualizedIncomeTotals Decimal "
+                "intermediate, not a string-keyed dict."
+            ),
+            # was AC5.32.2
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_2_annualized_income_totals_is_typed_intermediate"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-typed.3",
+            statement=(
+                "resolve_line_currency centralizes the line/account/base currency fallback + "
+                "normalization."
+            ),
+            # was AC5.32.3
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_3_resolve_line_currency_uses_canonical_fallback_chain"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-typed.4",
+            statement=(
+                "An explicit FX-failure response model (FxConversionErrorResponse) is declared "
+                "for the income endpoint."
+            ),
+            # was AC5.32.4
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_4_fx_conversion_error_response_model_declared"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-typed.5",
+            statement=(
+                "Currency normalization is a single shared helper (normalize_currency_code), "
+                "not duplicated strip/upper."
+            ),
+            # was AC5.32.5
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_5_normalize_currency_code_is_shared_helper"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.income-typed.6",
+            statement=(
+                "The income endpoint normalizes a soft (lower-case) base-currency setting in "
+                "its response."
+            ),
+            # was AC5.32.6
+            test=(
+                "apps/backend/tests/reporting/test_income_typed_currency.py"
+                "::test_AC5_32_6_endpoint_returns_normalized_currency_for_soft_base_config"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        # ── group snapshots-typed: report snapshots typed contract (was
+        # EPIC-005 AC5.36.1-2, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.snapshots-typed.1",
+            statement=(
+                "GET /reports/{report_type}/snapshots rejects an unknown report_type with 422."
+            ),
+            # was AC5.36.1
+            test=(
+                "apps/backend/tests/api/test_typed_contract_sweep.py"
+                "::test_AC5_36_1_report_snapshots_unknown_type_returns_422"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.snapshots-typed.2",
+            statement="A valid report_type returns a typed list[ReportSnapshotSummary] response.",
+            # was AC5.36.2
+            test=(
+                "apps/backend/tests/api/test_typed_contract_sweep.py"
+                "::test_AC5_36_2_report_snapshots_valid_type_returns_typed_list"
+            ),
+            priority="P2",
+            status="done",
+        ),
+        # ── group journeys: reporting core-journey E2E (was EPIC-008
+        # AC8.6.1-4, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.journeys.1",
+            statement="The core-journey E2E views the balance sheet end to end.",
+            # was AC8.6.1
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_balance_sheet_report",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.journeys.2",
+            statement="The core-journey E2E views the income statement end to end.",
+            # was AC8.6.2
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_income_statement_report",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.journeys.3",
+            statement="The core-journey E2E views the cash-flow report end to end.",
+            # was AC8.6.3
+            test="apps/backend/tests/e2e/test_core_journeys.py::test_cash_flow_report",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.journeys.4",
+            statement="The core-journey E2E navigates every reports endpoint.",
+            # was AC8.6.4
+            test=(
+                "apps/backend/tests/e2e/test_core_journeys.py"
+                "::test_report_navigation_all_endpoints"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group full-year: full-year statement-to-report acceptance (was
+        # EPIC-008 AC8.15.1-2, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.full-year.1",
+            statement=(
+                "Multi-month CSV statements parse, approve under the balance-chain guard, "
+                "auto-post, and the assembled period reports tie out end to end."
+            ),
+            # was AC8.15.1
+            test=(
+                "apps/backend/tests/integration/test_full_year_statement_to_report_e2e.py"
+                "::test_AC8_15_1_full_year_statement_to_report_ties_out"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.full-year.2",
+            statement=(
+                "A high-confidence balance-validated bank statement with no pre-selected "
+                "account auto-creates+links its asset account, reaches APPROVED, and auto-posts "
+                "to the ledger."
+            ),
+            # was AC8.15.2
+            test=(
+                "apps/backend/tests/integration/test_bank_statement_auto_account_post.py"
+                "::test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group augmentation: augmentation-layer report integrity (was
+        # EPIC-008 AC8.16.1-2, migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.augmentation.1",
+            statement=(
+                "A low-confidence ledger input and a superseded manual valuation both reach the "
+                "report correctly: the equation holds, the low-confidence line carries the "
+                "worst-input tier, and the superseded valuation is excluded."
+            ),
+            # was AC8.16.1
+            test=(
+                "apps/backend/tests/integration/test_augmentation_seam_e2e.py"
+                "::test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confidence"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.augmentation.2",
+            statement=(
+                "A report aggregates only the requesting user's facts: another user's accounts "
+                "never appear and never inflate a total."
+            ),
+            # was AC8.16.2
+            test=(
+                "apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py"
+                "::test_AC8_16_2_reports_exclude_other_users_entries"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group net-worth-components: retirement/benefit assets in reports
+        # (was EPIC-011 AC11.20.1-2 — the frontend row AC11.20.3 stays in
+        # EPIC-011; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.net-worth-components.1",
+            statement=(
+                "Retirement accounts, social-security personal balances, legacy CPF, and "
+                "insurance cash value default to restricted assets and contribute to full "
+                "balance-sheet assets."
+            ),
+            # was AC11.20.1
+            test=(
+                "apps/backend/tests/reporting/test_reporting_net_worth_components.py"
+                "::test_AC11_20_1_retirement_and_benefit_assets_are_restricted_assets_in_balance_sheet"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.net-worth-components.2",
+            statement=(
+                "Net-worth allocation groups retirement and benefit balances under the "
+                "retirement-and-benefit asset class."
+            ),
+            # was AC11.20.2
+            test=(
+                "apps/backend/tests/reporting/test_reporting_net_worth_components.py"
+                "::test_AC11_20_2_net_worth_allocation_groups_retirement_and_benefit_assets"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group layer3: Layer 3/4 read integration (was EPIC-018 AC18.4.1-2
+        # and AC18.4.4 — AC18.4.3 is extraction-owned and stays; migration
+        # closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.layer3.1",
+            statement=(
+                "The income statement's classification coverage reads Layer 3 APPLIED "
+                "TransactionClassification rows joined to their category accounts — the "
+                "report-side read of Layer 3 classifications."
+            ),
+            # was AC18.4.1
+            test=(
+                "apps/backend/tests/reporting/test_reporting_net_worth_components.py"
+                "::test_income_statement_includes_applied_classification_breakdown"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.layer3.2",
+            statement=(
+                "ReportSnapshot (Layer 4) rows are generated and queryable via the reports "
+                "snapshots API."
+            ),
+            # was AC18.4.2
+            test=(
+                "apps/backend/tests/api/test_reports_router.py"
+                "::test_list_report_snapshots_returns_created_snapshots"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.layer3.3",
+            statement=(
+                "Income statement payloads include the applied Layer 3 classification coverage "
+                "breakdown."
+            ),
+            # was AC18.4.4
+            test=(
+                "apps/backend/tests/reporting/test_reporting_net_worth_components.py"
+                "::test_income_statement_includes_applied_classification_breakdown"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group north-star: North-Star confidence metric (was EPIC-018
+        # AC18.12.1-4, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.north-star.1",
+            statement=(
+                "The low-confidence proportion is the deterministic LOW-tier share of "
+                "posted/reconciled journal entries, with a full tier breakdown and a defined "
+                "zero on an empty ledger."
+            ),
+            # was AC18.12.1
+            test=(
+                "apps/backend/tests/metrics/test_confidence_north_star_metric.py"
+                "::test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.north-star.2",
+            statement=(
+                "The metric is recorded as an append-only series — snapshots accumulate "
+                "newest-first and are never overwritten — so the trend is observable."
+            ),
+            # was AC18.12.2
+            test=(
+                "apps/backend/tests/metrics/test_confidence_north_star_metric.py"
+                "::test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.north-star.3",
+            statement=(
+                "The current metric and its recorded series are exposed read-only via the API."
+            ),
+            # was AC18.12.3
+            test=(
+                "apps/backend/tests/metrics/test_confidence_north_star_metric.py"
+                "::test_AC18_12_3_north_star_endpoint_returns_current_and_series"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.north-star.4",
+            statement=(
+                "A North-Star snapshot is recorded when a report package is generated, and on "
+                "demand via a POST endpoint, so the trend accumulates in production."
+            ),
+            # was AC18.12.4
+            test=(
+                "apps/backend/tests/metrics/test_confidence_north_star_metric.py"
+                "::test_AC18_12_4_post_records_a_snapshot_into_the_series"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group readiness: report readiness + blocker state (was EPIC-019
+        # AC19.5.1-3, AC19.5.6-7 and AC19.7.1 — the frontend rows AC19.5.4-5
+        # stay in EPIC-019; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.readiness.1",
+            statement=(
+                "The personal report package exposes a user-scoped readiness endpoint returning "
+                "deterministic state, action link, blocker count, and source summary."
+            ),
+            # was AC19.5.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_5_1_package_readiness_returns_draft_for_empty_user"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.readiness.2",
+            statement=(
+                "Blocked package readiness lists exact blocker categories across parsing, "
+                "review, balance, reconciliation, consistency, Processing balance, and source "
+                "coverage."
+            ),
+            # was AC19.5.2
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_5_2_package_readiness_lists_actionable_blockers"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.readiness.3",
+            statement=(
+                "Package readiness deterministically promotes through draft, processing, "
+                "blocked, ready, generated, and stale based on source state and snapshot "
+                "freshness."
+            ),
+            # was AC19.5.3
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.readiness.4",
+            statement=(
+                "Package readiness fails deterministically when duplicate Processing system "
+                "accounts would make blockers non-deterministic."
+            ),
+            # was AC19.5.6
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_5_6_package_readiness_rejects_duplicate_processing_accounts"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.readiness.5",
+            statement=(
+                "Package readiness converts Processing Account journal lines into the base "
+                "reporting currency before deciding whether the in-transit balance nets to "
+                "zero."
+            ),
+            # was AC19.5.7
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_5_7_package_readiness_converts_processing_balance_before_zero_check"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.readiness.6",
+            statement=(
+                "Report readiness evaluates framework-specific evidence blockers from the "
+                "framework policy layer before marking US/HK personal reports trusted."
+            ),
+            # was AC19.7.1
+            test=(
+                "apps/backend/tests/reporting/test_framework_package_integration.py"
+                "::test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group source-trust: source trust readiness summary (was EPIC-019
+        # AC19.9.1 — the frontend row AC19.9.2 stays in EPIC-019; migration
+        # closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.source-trust.1",
+            statement=(
+                "Package readiness returns a source-trust summary by source class: "
+                "deterministic PR proof availability, post-merge LLM/OCR coverage, "
+                "manual-trusted classes, gaps, and blocker codes."
+            ),
+            # was AC19.9.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_9_1_package_readiness_reports_source_trust_summary"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group source-anchors: typed package source anchors (was EPIC-019
+        # AC19.10.1, migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.source-anchors.1",
+            statement=(
+                "Package traceability resolves journal source IDs to typed source anchors and "
+                "blocks unknown source IDs instead of presenting them as statement "
+                "transactions."
+            ),
+            # was AC19.10.1
+            test=(
+                "apps/backend/tests/api/test_personal_report_package_contract.py"
+                "::test_AC19_10_1_unknown_journal_source_ids_are_not_reported_as_statement_transactions"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        # ── group lineage: account lineage drill-down (was EPIC-022 AC22.3.3
+        # and AC22.7.1's backend half — AC22.7.1's frontend drawer half stays
+        # in EPIC-022; migration closeout continuation, #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.lineage.1",
+            statement=(
+                "GET /api/reports/account-lineage returns the user-scoped posted/reconciled "
+                "journal lines contributing to an account's balance, each with a journal_line "
+                "evidence anchor and Decimal-safe signed amounts."
+            ),
+            # was AC22.3.3
+            test=(
+                "apps/backend/tests/reporting/test_account_lineage.py"
+                "::test_AC22_3_3_account_lineage_returns_posted_contributing_lines"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.lineage.2",
+            statement=(
+                "Each cash-flow line carries its account anchor (account_id) so a cash-flow "
+                "amount can drill down to the account's contributing journal lines."
+            ),
+            # was AC22.7.1 (backend half)
+            test=(
+                "apps/backend/tests/reporting/test_reporting.py"
+                "::test_reporting_dashboard_fixture_exact_totals"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        # ── group provenance: normalized report-line provenance (was EPIC-022
+        # AC22.13.1's reporting share — the pricing share is
+        # AC-pricing.provenance.1 and the portfolio share is
+        # AC-portfolio.provenance.2; migration closeout continuation,
+        # #1663 / #1716) ──
+        ACRecord(
+            id="AC-reporting.provenance.1",
+            statement=(
+                "Report amount lines expose the normalized provenance enum "
+                "(imported/manual/derived) when the source basis is known, and stay unlabeled "
+                "instead of guessing."
+            ),
+            # was AC22.13.1 (reporting share)
+            test=(
+                "apps/backend/tests/reporting/test_reporting.py"
+                "::test_AC22_13_1_report_amount_lines_expose_normalized_provenance"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -110,65 +110,47 @@ Accounting Equation Verification: Reports must comply with accounting equation
 
 ### AC5.1: Balance Sheet
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.1.1 | Accounting Equation | `test_balance_sheet_equation` | `reporting/test_reporting.py` | P0 |
-| AC5.1.2 | FX Unrealized Gain | `test_fx_unrealized_gain_calculation` | `reporting/test_reporting_fx.py` | P0 |
-| AC5.1.3 | Multi-Currency Aggregation | `test_multi_currency_aggregation` | `reporting/test_reporting_fx.py` | P0 |
-| AC5.1.4 | Endpoint Response | `test_balance_sheet_endpoint` | `reporting/test_reports_router.py` | P0 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.balance-sheet.1-4` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.2: Income Statement
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.2.1 | Net Income Calculation | `test_income_statement_calculation` | `reporting/test_reporting.py` | P0 |
-| AC5.2.2 | Comprehensive Income | `test_income_statement_comprehensive_income` | `reporting/test_reporting_fx.py` | P1 |
-| AC5.2.3 | Date Range Filtering | `test_income_statement_invalid_range` | `reporting/test_reporting.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.income-statement.1-3` (migration closeout continuation,
+> #1663 / #1716).
 
 ### AC5.3: Cash Flow Statement
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.3.1 | Statement Generation | `test_cash_flow_statement` | `reporting/test_reporting.py` | P0 |
-| AC5.3.2 | Empty Period Handling | `test_cash_flow_empty_period` | `reporting/test_reporting.py` | P1 |
-| AC5.3.3 | Test getting account trend with different period. | `test_account_trend_with_period` | `api/test_reports_router.py` | P1 |
-| AC5.3.4 | Test getting category breakdown. | `test_category_breakdown_success` | `api/test_reports_router.py` | P1 |
-| AC5.3.5 | Test getting category breakdown with different period. | `test_category_breakdown_with_period` | `api/test_reports_router.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.cash-flow.1-5` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.4: FX & Multi-Currency
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.4.1 | FX Fallbacks | `test_reporting_fx_fallbacks` | `reporting/test_reporting_fx.py` | P1 |
-| AC5.4.2 | Balance Sheet Net Income FX Fallback | `test_balance_sheet_net_income_fx_fallback` | `reporting/test_reporting_fx.py` | P1 |
-| AC5.4.3 | Report FX Lazy Resolution | `test_reports_lazy_resolve_missing_hkd_sgd_from_bridge_rates` | `reporting/test_reporting_fx.py` | P0 |
-| AC5.4.4 | Missing report FX rates produce explicit partial warnings instead of aborting the whole aggregation | `test_aggregate_balances_missing_fx_skips_unconvertible_currency_with_warning` | `reporting/test_reporting_fx_fallbacks.py` | P0 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.fx.1-4` (migration closeout continuation, #1663 / #1716).
 
 ### AC5.5: Error Handling
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.5.1 | Report Generation Error | `test_reports_router_errors_extended` | `reporting/test_reports_errors.py` | P1 |
-| AC5.5.2 | Router Error Handling | `TestReportsRouterErrors` | `reporting/test_reports_router_errors.py` | P1 |
-| AC5.5.3 | Test that unauthenticated clients cannot access reports endpoints. | `test_unauthenticated_access` | `api/test_reports_router.py` | P1 |
-| AC5.5.4 | Reports Router Tests | `test_reports_router` | `reporting/test_reports_router.py` | P1 |
-| AC5.5.5 | GET /reports/{type}/snapshots returns persisted snapshots. | `test_list_report_snapshots_returns_created_snapshots` | `api/test_reports_router.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.errors.1-5` (migration closeout continuation, #1663 / #1716).
+>
+> *(AC5.5.2 removed and AC5.5.4 removed with the group — their class/file-level citations are now representative function-level citations in the package roadmap)*
 
 ### AC5.6: Investment & Portfolio KPIs
 
+> *(AC5.6.5 removed and AC5.6.7 removed and AC5.6.8 removed and AC5.6.9 removed and AC5.6.10 removed and AC5.6.11 removed — migrated to the `reporting` package roadmap as `AC-reporting.kpis.2-7`; AC5.6.4's backend endpoint half migrated as `AC-reporting.kpis.1` while its frontend dashboard-card proof stays in the row below. Migration closeout continuation, #1663 / #1716)*
+>
+> *(AC5.6.1 removed and AC5.6.2 removed and AC5.6.3 removed and AC5.6.6
+> removed — portfolio-owned performance math that lived in this reporting
+> EPIC; migrated to the `portfolio` package roadmap as
+> `AC-portfolio.metrics.1-4`, migration closeout continuation, #1663 /
+> #1717.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.6.1 | XIRR calculation accuracy ≤ 0.01% error vs Excel XIRR | `test_AC5_6_1_xirr_matches_single_year_excel_case` | `portfolio/test_performance_service.py` | P0 |
-| AC5.6.2 | Annualized return (TWR) computed correctly | `test_AC5_6_2_time_weighted_return_matches_snapshot_period` | `portfolio/test_performance_service.py` | P0 |
-| AC5.6.3 | Dividend yield = annual dividends / current value | `test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value` | `portfolio/test_performance_service.py` | P0 |
-| AC5.6.4 | Annualized income KPI is surfaced through the dashboard/reporting path and delegates calculation ownership to AC11.8.1 | `test_annualized_income_endpoint_groups_last_12_month_income`, `AC11.8.2/AC11.8.6 renders Annualized Income card with the four metric labels` | `reporting/test_income_annualized_router.py`, `frontend/src/__tests__/dashboardPage.test.tsx` | P0 |
-| AC5.6.5 | Unrealized P&L reflected in balance sheet equity | `test_reporting_dashboard_fixture_exact_totals` | `reporting/test_reporting.py` | P0 |
-| AC5.6.6 | MWR (money-weighted return) matches XIRR for single cashflow | `test_AC5_6_6_money_weighted_return_matches_xirr_for_single_cashflow` | `portfolio/test_performance_service.py` | P1 |
-| AC5.6.7 | Report output lists currencies that used average-rate spot fallback. | `test_income_statement_includes_average_rate_fallback_warning` | `reporting/test_reporting_fx_revaluation_integration.py` | P1 |
-| AC5.6.8 | Account trend raises when prefetched non-base FX rate is missing. | `test_account_trend_raises_when_prefetched_rate_missing` | `reporting/test_reporting_extreme_fallbacks.py` | P1 |
-| AC5.6.9 | Category breakdown raises when prefetched non-base FX rate is missing. | `test_category_breakdown_raises_when_prefetched_rate_missing` | `reporting/test_reporting_extreme_fallbacks.py` | P1 |
-| AC5.6.10 | Cash flow raises when start-date non-base FX rate is missing. | `test_cash_flow_raises_when_start_date_rate_missing` | `reporting/test_reporting_extreme_fallbacks.py` | P1 |
-| AC5.6.11 | Cash flow raises when end-date rate missing; FxRateError propagated. | `test_cash_flow_raises_when_end_date_rate_missing` | `reporting/test_reporting_extreme_fallbacks.py` | P1 |
+| AC5.6.4 | Annualized income KPI dashboard card renders the endpoint's figures (backend endpoint half migrated as `AC-reporting.kpis.1`; calculation ownership stays with AC11.8.1) | `AC11.8.2/AC11.8.6 renders Annualized Income card with the four metric labels` | `frontend/src/__tests__/dashboardPage.test.tsx` | P0 |
 
 ### AC5.8: Personal Report Package Investment Performance Consumption
 
@@ -179,9 +161,13 @@ package. The report section must preserve `source_links` and `notes` from the
 schedule payload so the package can explain market-data freshness, cost-basis
 method, dividends, realized/unrealized P&L, and return metric limitations.
 
+> *(AC5.8.1's backend contract half migrated to the `reporting` package
+> roadmap as `AC-reporting.package-investment.1`; the frontend render proof
+> stays in the row below. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.8.1 | Personal report package defines the `investment_performance` report section as a consumer of the EPIC-017 schedule API | `AC5.8.1 renders investment performance report schedule from the schedule API`; `test_personal_financial_report_package_post_merge_journey`; `test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract` | `apps/frontend/src/__tests__/portfolioPage.test.tsx`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
+| AC5.8.1 | Personal report package renders the `investment_performance` report section from the EPIC-017 schedule API (backend contract half migrated as `AC-reporting.package-investment.1`) | `AC5.8.1 renders investment performance report schedule from the schedule API` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P0 |
 
 ### AC5.9: Personal Report Package Contract
 
@@ -193,19 +179,20 @@ Decimal-safe total field names. Supporting EPICs keep ownership of their
 calculations; this contract only describes how their outputs plug into one
 personal financial-report package.
 
+> *(AC5.9.1 removed and AC5.9.2 removed — migrated to the `reporting`
+> package roadmap as `AC-reporting.package-contract.1-2`; the frontend rows
+> below stay here. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.9.1 | Package contract endpoint defines required section IDs, labels, owners, and source endpoints | `test_AC5_9_1_package_contract_endpoint_defines_required_sections` | `api/test_personal_report_package_contract.py` | P0 |
-| AC5.9.2 | Package contract exposes Decimal-safe total fields and explicit period/as-of semantics | `test_AC5_9_2_package_contract_marks_decimal_totals_and_period_semantics` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.9.3 | Frontend personal package page renders the contract section IDs and labels from the API contract | `AC5.9.3 renders personal package contract sections from API` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 | AC5.9.4 | Frontend/export contract surfaces stable export format and CSV columns for package consumers | `AC5.9.4 renders export contract metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P1 |
 
 ### AC5.10: Financial Statement Logic Audit Fixes
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.10.1 | Cash-flow statement beginning cash, ending cash, and net cash flow use cumulative cash balances | `test_AC5_10_1_cash_flow_uses_cumulative_cash_balances()` | `reporting/test_financial_logic_audit.py` | P0 |
-| AC5.10.2 | Cash-flow operating, investing, and financing totals preserve inflow/outflow signs | `test_AC5_10_2_cash_flow_activity_totals_preserve_signs()` | `reporting/test_financial_logic_audit.py` | P0 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.logic-audit.1-2` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.11: Personal Report Package Annualized Income Schedule Consumption
 
@@ -214,11 +201,13 @@ supplies the report-ready annualized income and long-term compensation schedule
 that plugs into the `annualized_income_long_term` package section defined by
 AC5.9. Supporting calculations remain owned by EPIC-011.
 
+> *(AC5.11.1 removed and AC5.11.3 removed — migrated to the `reporting`
+> package roadmap as `AC-reporting.package-annualized.1-2`; the frontend row
+> below stays here. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.11.1 | Package contract marks `annualized_income_long_term` as ready and points to the schedule endpoint | `test_AC5_11_1_package_contract_marks_annualized_schedule_ready` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.11.2 | Frontend personal package page renders annualized income totals and restricted treatment from the schedule endpoint | `AC5.11.2 renders annualized income schedule values and restricted treatment` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
-| AC5.11.3 | Annualized income package schedule converts mixed-currency income and restricted totals into one reporting currency | `test_AC5_11_3_AC11_11_3_annualized_schedule_converts_mixed_currency_totals` | `reporting/test_annualized_income_schedule.py` | P0 |
 
 ### AC5.12: Personal Report Package Notes and Disclosure Basis
 
@@ -229,12 +218,14 @@ basis, data freshness, restricted-asset treatment, and explicit non-compliance
 wording. The notes use standards-inspired disclosure discipline but do not
 claim statutory filing compliance.
 
+> *(AC5.12.1 removed and AC5.12.2 removed and AC5.12.4 removed — migrated to
+> the `reporting` package roadmap as `AC-reporting.package-notes.1-3`; the
+> frontend row below stays here. Migration closeout continuation, #1663 /
+> #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.12.1 | Package notes endpoint returns required note IDs, owner EPICs, source states, and non-compliance wording | `test_AC5_12_1_package_notes_endpoint_returns_required_note_taxonomy` | `api/test_personal_report_package_contract.py` | P0 |
-| AC5.12.2 | Package contract marks `notes` as ready and points to the notes endpoint | `test_AC5_12_2_package_contract_marks_notes_ready` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.12.3 | Frontend personal package page renders notes and disclosure basis from the notes endpoint | `AC5.12.3 renders package notes and disclosure basis` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
-| AC5.12.4 | Post-merge package proof asserts notes endpoint, required note IDs, and non-compliance wording | `test_personal_financial_report_package_post_merge_journey` | `tests/e2e/test_personal_financial_report_package.py` | P0 |
 
 ### AC5.13: Personal Report Package Traceability Appendix
 
@@ -245,13 +236,14 @@ traceability anchors, explicit unavailable/not-applicable states, review state,
 confidence tier, and completeness warning taxonomy that package consumers need
 to audit each report line.
 
+> *(AC5.13.1 removed and AC5.13.2 removed and AC5.13.4 removed and AC5.13.5
+> removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.package-traceability.1-4`; the frontend row below stays
+> here. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.13.1 | Package traceability endpoint returns source-to-ledger anchors per report line | `test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors` | `api/test_personal_report_package_contract.py` | P0 |
-| AC5.13.2 | Traceability appendix exposes explicit completeness states where anchors are unavailable | `test_AC5_13_2_package_traceability_declares_completeness_warnings` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.13.3 | Frontend personal package page renders source, ledger, review, and confidence metadata from the appendix | `AC5.13.3 renders traceability appendix source, ledger, review, and confidence metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
-| AC5.13.4 | Post-merge package proof fails trusted totals without source/ledger anchors or explicit manual inputs | `test_personal_financial_report_package_post_merge_journey` | `tests/e2e/test_personal_financial_report_package.py` | P0 |
-| AC5.13.5 | Package traceability endpoint returns current-user dynamic source identifiers and excludes unrelated-user anchors | `test_AC5_13_5_package_traceability_returns_dynamic_current_user_identifiers` | `api/test_personal_report_package_contract.py` | P0 |
 
 ### AC5.14: Framework Policy Result Consumption
 
@@ -273,9 +265,9 @@ backend Tier-1 integration proof for the multi-currency reporting cycle without
 changing the later PDF export scope tracked by
 [#205](https://github.com/wangzitian0/finance_report/issues/205).
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.15.1 | Multi-currency posted entries generate balanced balance sheet, income statement, and cash-flow reports in base currency | `test_AC5_15_1_multicurrency_reporting_cycle_reconciles_bs_is_cf` | `integration/test_reporting_e2e.py` | P0 |
+> This group's row removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.integration.1` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.16: Report Trust Signals and Restricted-Asset Defaults
 
@@ -284,12 +276,16 @@ covered but did not render important trust signals already present in backend
 payloads. This group makes report default semantics and partial-data warnings
 visible to users.
 
+> *(AC5.16.4 removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.trust-signals.3`; AC5.16.1-2's backend halves migrated as
+> `AC-reporting.trust-signals.1-2` while their frontend proofs stay in the
+> rows below. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.16.1 | Balance sheet defaults restricted holdings to excluded, exposes an include toggle, and renders equation component detail | `test_AC5_16_1_balance_sheet_defaults_to_excluding_restricted_holdings` / `AC16.14.2 / test_AC8_13_48 renders string totals and refetches by date` | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx` | P0 |
-| AC5.16.2 | Balance sheet, income statement, and cash-flow report pages surface backend `fx_warnings` instead of silently rendering partial totals | `test_AC5_16_2_cash_flow_response_preserves_fx_warnings` / page warning assertions | `reporting/test_reports_router.py`, `frontend/src/__tests__/balanceSheetPage.test.tsx`, `frontend/src/__tests__/incomeStatementPage.test.tsx`, `frontend/src/__tests__/cashFlowPage.test.tsx` | P0 |
+| AC5.16.1 | Balance sheet page exposes the restricted-holdings include toggle and renders equation component detail (backend default-exclusion half migrated as `AC-reporting.trust-signals.1`) | `AC16.14.2 / test_AC8_13_48 renders string totals and refetches by date` | `frontend/src/__tests__/balanceSheetPage.test.tsx` | P0 |
+| AC5.16.2 | Balance sheet, income statement, and cash-flow report pages surface backend `fx_warnings` instead of silently rendering partial totals (backend fx_warnings-preservation half migrated as `AC-reporting.trust-signals.2`) | page warning assertions | `frontend/src/__tests__/balanceSheetPage.test.tsx`, `frontend/src/__tests__/incomeStatementPage.test.tsx`, `frontend/src/__tests__/cashFlowPage.test.tsx` | P0 |
 | AC5.16.3 | Personal report package traceability renders concrete source and ledger identifiers when the appendix provides them | `AC5.13.3 renders traceability appendix source, ledger, review, and confidence metadata` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
-| AC5.16.4 | Personal report package traceability lines expose source classes, proof level, anchor count, and blocker codes for report-line confidence review | `test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors`, `test_AC5_13_2_package_traceability_declares_completeness_warnings` | `api/test_personal_report_package_contract.py` | P0 |
 
 ### AC5.17: Authenticated Report CSV Exports
 
@@ -297,9 +293,13 @@ The report export workflow must preserve the authenticated API boundary and
 support every first-class financial statement page that exposes an export
 action.
 
+> *(AC5.17.1's backend export half migrated to the `reporting` package
+> roadmap as `AC-reporting.csv-export.1`; its frontend apiDownload proof
+> stays in the row below. Migration closeout continuation, #1663 / #1716.)*
+
 | AC | Acceptance Criteria | Test(s) | File(s) | Priority |
 |----|--------------------|---------|---------|----------|
-| AC5.17.1 | Balance sheet, income statement, and cash-flow pages download CSV through the authenticated API wrapper, and the backend CSV export supports cash-flow reports with date range and currency filters | `AC5.17.1 downloads cash-flow CSV through authenticated apiDownload`, `test_AC5_17_1_cash_flow_export_returns_csv` | `frontend/src/__tests__/cashFlowPage.test.tsx`, `reporting/test_reports_router.py` | P0 |
+| AC5.17.1 | Balance sheet, income statement, and cash-flow pages download CSV through the authenticated API wrapper (backend cash-flow CSV export half migrated as `AC-reporting.csv-export.1`) | `AC5.17.1 downloads cash-flow CSV through authenticated apiDownload` | `frontend/src/__tests__/cashFlowPage.test.tsx` | P0 |
 | AC5.17.2 | Personal report package page exposes an authenticated CSV export action after framework selection, using the package export contract and selected framework ID | `AC5.17.2 downloads package CSV through authenticated apiDownload` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 
 ### AC5.18: Per-Node Confidence Tier on Balance-Sheet Payloads
@@ -311,10 +311,9 @@ Worth aggregate rolls up to the worst-input tier (see
 Rollup) — a defined rollup, not an invented number. Income statement, cash flow,
 and the monthly cards are a follow-up; provenance (#888) is the co-equal sibling axis.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.18.1 | Each balance-sheet line carries the worst-input confidence tier of its contributing journal entries | `test_AC5_18_1_lines_carry_worst_input_confidence_tier()` | `reporting/test_balance_sheet_confidence.py` | P1 |
-| AC5.18.2 | The Net Worth aggregate rolls up to the worst-input tier across rated lines, and is null when nothing is rated | `test_AC5_18_2_net_worth_rolls_up_to_worst_input_tier()` | `reporting/test_balance_sheet_confidence.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.confidence.1-2` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.19: Report Package Snapshot Artifact
 
@@ -324,18 +323,20 @@ period, currency, selected framework, readiness state, source anchors,
 traceability lines, and section payloads so the user can reopen and export the
 same package after later ledger or market-data changes.
 
+> *(AC5.19.1 removed and AC5.19.2 removed and AC5.19.3 removed — migrated to
+> the `reporting` package roadmap as `AC-reporting.package-snapshot.1-3`;
+> the frontend row below stays here. Migration closeout continuation,
+> #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC5.19.1 | `POST /api/reports/package/generate` creates an immutable package snapshot that records period, currency, framework, readiness, source trust, traceability, and section payloads; blocked readiness may generate only a draft, while ready readiness generates trusted output | `test_AC5_19_1_package_generate_creates_draft_or_trusted_snapshot` | `api/test_personal_report_package_contract.py` | P0 |
-| AC5.19.2 | `GET /api/reports/package/snapshots` and `GET /api/reports/package/snapshots/{snapshot_id}` list and reopen only the current user's saved package snapshots, and reopening returns the original payload after live report inputs change | `test_AC5_19_2_package_snapshot_get_is_user_scoped_and_immutable` | `api/test_personal_report_package_contract.py` | P0 |
-| AC5.19.3 | Package JSON and CSV downloads are derived from a saved snapshot rather than recalculating live data | `test_AC5_19_3_package_snapshot_exports_are_snapshot_derived` | `api/test_personal_report_package_contract.py` | P0 |
 | AC5.19.4 | The package page shows recent snapshots, can generate a new snapshot, and downloads JSON/CSV from the saved snapshot artifact | `AC5.19.4 generates and downloads package snapshots` | `frontend/src/__tests__/personalReportPackagePage.test.tsx` | P0 |
 
 ### AC5.20: Year-Scale Reporting Validation ([#951](https://github.com/wangzitian0/finance_report/issues/951))
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.20.1 | At a full year's transaction volume (~1000 entries) the balance sheet, income statement, and cash flow tie out and generate within a generous wall-clock backstop — guarding the income-statement aggregation against a silent O(n^2) regression | `test_AC5_20_year_scale_reporting_ties_out_within_budget` | `reporting/test_year_scale_reporting.py` | P1 |
+> This group's row removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.year-scale.1` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.32: Income Module Typed Currency + Typed-Intermediate Response ([#1009](https://github.com/wangzitian0/finance_report/issues/1009))
 
@@ -345,14 +346,9 @@ replace soft `str` currency handling with a shared validated/normalized
 (`AnnualizedIncomeTotals`) instead of a string-keyed dict, and declare an
 explicit FX-failure response model. Monetary values stay `Decimal`.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.32.1 | `AnnualizedIncomeResponse.currency` is the shared typed `CurrencyCode` (validated length + normalized), not a soft `str` | `test_AC5_32_1_currency_code_type_validates_and_normalizes` | `reporting/test_income_typed_currency.py` | P2 |
-| AC5.32.2 | Income totals accumulate in a typed `AnnualizedIncomeTotals` Decimal intermediate, not a string-keyed dict | `test_AC5_32_2_annualized_income_totals_is_typed_intermediate` | `reporting/test_income_typed_currency.py` | P2 |
-| AC5.32.3 | `resolve_line_currency` centralizes the `line\|\|account\|\|base` currency fallback + normalization | `test_AC5_32_3_resolve_line_currency_uses_canonical_fallback_chain` | `reporting/test_income_typed_currency.py` | P2 |
-| AC5.32.4 | An explicit FX-failure response model (`FxConversionErrorResponse`) is declared for the income endpoint | `test_AC5_32_4_fx_conversion_error_response_model_declared` | `reporting/test_income_typed_currency.py` | P2 |
-| AC5.32.5 | Currency normalization is a single shared helper (`normalize_currency_code`), not duplicated `.strip().upper()` | `test_AC5_32_5_normalize_currency_code_is_shared_helper` | `reporting/test_income_typed_currency.py` | P2 |
-| AC5.32.6 | The endpoint normalizes a soft (lower-case) base-currency setting in its response | `test_AC5_32_6_endpoint_returns_normalized_currency_for_soft_base_config` | `reporting/test_income_typed_currency.py` | P2 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.income-typed.1-6` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC5.33: Report Page Shell + Toolbar Primitives ([#751](https://github.com/wangzitian0/finance_report/issues/751))
 
@@ -593,10 +589,9 @@ Tier 2 of #1000. `GET /reports/{report_type}/snapshots` declares a typed
 instead of a hand-rolled dict), and `report_type` is typed as the snapshot enum so
 an unknown value is rejected with 422 instead of silently returning an empty list.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC5.36.1 | An unknown `report_type` returns 422 | `test_AC5_36_1_report_snapshots_unknown_type_returns_422` | `api/test_typed_contract_sweep.py` | P2 |
-| AC5.36.2 | A valid `report_type` returns a typed list | `test_AC5_36_2_report_snapshots_valid_type_returns_typed_list` | `api/test_typed_contract_sweep.py` | P2 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.snapshots-typed.1-2` (migration closeout continuation,
+> #1663 / #1716).
 
 ### AC5.37: Trust-First Reports Cockpit ([#1209](https://github.com/wangzitian0/finance_report/issues/1209))
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -200,12 +200,9 @@ job inventories or scenario counts into this EPIC.
 
 ### AC8.6: Phase 5 - Reporting & Visualization
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.6.1 | View Balance Sheet | `test_balance_sheet_report()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.6.2 | View Income Statement | `test_income_statement_report()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.6.3 | View Cash Flow Report | `test_cash_flow_report()` | `e2e/test_core_journeys.py` | P0 |
-| AC8.6.4 | Report navigation (all endpoints) | `test_report_navigation_all_endpoints()` | `e2e/test_core_journeys.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.journeys.1-4` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC8.7: API Authentication & Authorization
 
@@ -455,10 +452,9 @@ job inventories or scenario counts into this EPIC.
 
 Closing gate for the **Usable** milestone (G2∩G3, [#950](https://github.com/wangzitian0/finance_report/issues/950)): AC-testing.trust-mirrors.4 mirrors the ledger→report leg from *manual* entries in a *single* period; this group proves the **assembled** pipeline — statement parse → Stage-1 approval (balance-chain validated) → auto-posted ledger entries → period reports — ties out across **multiple months**. Deterministic by construction (rule-based CSV parse, no LLM; no AI classification, so counter-accounts fall back to `Income - Uncategorized` / `Expense - Uncategorized`).
 
-| AC ID | Test Case | Test Function | File | Priority |
-|---|---|---|---|---|
-| AC8.15.1 | Multi-month CSV statements parse, approve under the balance-chain guard, auto-post to the ledger, and the assembled period reports tie out end-to-end (income, expenses, net income, ending cash, total assets, and the accounting equation) | `test_AC8_15_1_full_year_statement_to_report_ties_out` | `apps/backend/tests/integration/test_full_year_statement_to_report_e2e.py` | P0 |
-| AC8.15.2 | A high-confidence, balance-validated bank statement with no pre-selected account auto-creates+links its physical asset account (by institution + account_last4 + currency), reaches APPROVED, and auto-posts to the ledger — the everyday-user upload→report path no longer dead-ends in review (#1444) {tier:CODE-ONLY} | `test_AC8_15_2_bank_statement_auto_creates_account_and_posts_without_manual_mapping` | `apps/backend/tests/integration/test_bank_statement_auto_account_post.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.full-year.1-2` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC8.16: Augmentation-Layer Report Integrity
 
@@ -471,10 +467,10 @@ It stands up the *combined* state production actually has (a low-confidence ledg
 input AND a corrected/superseded valuation present at once) and asserts the report
 is right on every axis simultaneously. Part of [#990](https://github.com/wangzitian0/finance_report/issues/990) (report-input integrity).
 
-| AC ID | Test Case | Test Function | File | Priority |
-|---|---|---|---|---|
-| AC8.16.1 | A low-confidence extracted ledger input and a corrected (superseded) manual valuation both reach the report correctly: ledger numbers and the accounting equation hold, the low-confidence line carries the worst-input tier (not laundered), the superseded valuation is excluded from net-worth components, and the manual valuation does not contaminate the ledger balance sheet | `test_AC8_16_1_augmentation_seam_excludes_superseded_and_surfaces_confidence` | `apps/backend/tests/integration/test_augmentation_seam_e2e.py` | P1 |
-| AC8.16.2 | A report aggregates only the requesting user's facts: with posted entries for two users, user A's balance sheet, income statement, and net-worth totals reflect only A's data — user B's accounts never appear and never inflate a total (cross-user leak at the report-number level, now testable since the test schema keeps the `users` FK per #991) | `test_AC8_16_2_reports_exclude_other_users_entries` | `apps/backend/tests/integration/test_cross_user_report_isolation_e2e.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.augmentation.1-2` (migration closeout continuation, #1663 /
+> #1716). The `@ac_proof` decorator, `ac_evidence` records, and the
+> ac-score-baseline entry moved to the new ids with them.
 
 **Traceability Ownership**:
 - This table owns the intended AC-to-proof mapping for EPIC-008.
@@ -729,11 +725,11 @@ Product E2E ownership index:
 | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | Critical proof: AC-extraction.813.10 |
 | `tests/e2e/test_core_journeys.py` | Deployed core journey E2E; AC references live in the test file |
 | `tests/e2e/test_e2e_flows.py` | Deployed extended flow E2E; AC references live in the test file |
-| `tests/e2e/test_four_asset_net_worth_golden_path.py` | Critical proof: AC-testing.product-gates.7, AC-extraction.813.10, AC5.7.3, AC11.9.1-AC11.9.3, AC17.5.4 |
+| `tests/e2e/test_four_asset_net_worth_golden_path.py` | Critical proof: AC-testing.product-gates.7, AC-extraction.813.10, AC5.7.3, AC11.9.1-AC11.9.3, AC-portfolio.valuation.1 |
 | `tests/e2e/test_llm_provider_abstraction_epic023.py` | LLM provider abstraction product owner E2E; EPIC-023 / AC23.1 references live in the test file |
 | `tests/e2e/test_frontend_observability_epic024.py` | EPIC-024 frontend browser observability product owner E2E; AC24.1.1 reference lives in the test file |
 | `tests/e2e/test_market_data_price_paths.py` | Critical proof; ACs live in the `pricing` package roadmap (`AC-pricing.marketdata.7`, `AC-pricing.marketdata.11`, `common/pricing/contract.py`) |
-| `tests/e2e/test_personal_financial_report_package.py` | Critical proof: AC5.1.1, AC5.1.4, AC5.2.3, AC5.3.1, AC5.8.1, AC5.12.4, AC5.13.4-AC5.13.5, AC11.8.3, AC11.9.1-AC11.9.3, AC11.11.1-AC11.11.2, AC17.10.1-AC17.10.2, AC17.12.1-AC17.12.3, AC-testing.product-gates.8, AC-testing.product-gates.9, AC-testing.product-gates.10, AC-testing.product-gates.11, AC-testing.product-gates.12 |
+| `tests/e2e/test_personal_financial_report_package.py` | Critical proof: AC-reporting.balance-sheet.1, AC-reporting.balance-sheet.4, AC-reporting.income-statement.3, AC-reporting.cash-flow.1, AC5.8.1, AC-reporting.package-notes.3, AC-reporting.package-traceability.3, AC-reporting.package-traceability.4, AC11.8.3, AC11.9.1-AC11.9.3, AC11.11.1-AC11.11.2, AC-portfolio.report-schedule.1, AC-portfolio.report-schedule.2, AC-portfolio.fixtures.1, AC-portfolio.fixtures.2, AC-portfolio.fixtures.3, AC-testing.product-gates.8, AC-testing.product-gates.9, AC-testing.product-gates.10, AC-testing.product-gates.11, AC-testing.product-gates.12 |
 | `tests/e2e/test_production_readonly_smoke.py` | Production-readonly smoke E2E; AC references live in the test file |
 | `tests/e2e/test_statement_full_journey.py` | Critical proof: AC-extraction.813.11 |
 | `tests/e2e/test_statement_upload_e2e.py` | Statement upload E2E; AC references live in the test file |

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -82,66 +82,46 @@ code, tests, issues, and git history.
 
 ### AC11.1: Asset Service - Reconciliation Logic
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.1.1 | Reconcile creates new position | `test_reconcile_creates_position()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.2 | Reconcile updates existing position quantity | `test_reconcile_updates_position()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.3 | Reconcile disposes position when quantity is 0 | `test_reconcile_disposes_position()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.4 | Cost basis is set from market_value | `test_reconcile_cost_basis_uses_market_value()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.5 | Reconcile multiple different assets | `test_reconcile_multiple_assets()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.6 | Same asset at different brokers creates separate positions | `test_reconcile_multiple_brokers_same_asset()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.7 | Null broker name handled correctly | `test_reconcile_with_null_broker()` | `assets/test_asset_service.py` | P1 |
-| AC11.1.8 | Disposed position can be reactivated | `test_reconcile_reactivates_disposed_position()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.9 | Get positions returns empty list when no positions exist | `test_get_positions_empty()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.10 | Reconcile with no snapshots does nothing | `test_reconcile_no_snapshots()` | `assets/test_asset_service.py` | P0 |
-| AC11.1.11 | Negative quantities (short positions) handled correctly | `test_reconcile_negative_quantity_short_position()` | `assets/test_asset_service.py` | P1 |
-| AC11.1.12 | Updated and disposed counts are mutually exclusive | `test_reconcile_result_counts_are_mutually_exclusive()` | `assets/test_asset_service.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.reconcile.1-12` (`AC11.1.<s>` becomes
+> `AC-portfolio.reconcile.<s>`; migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.2: Asset Router - List Operations
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.2.1 | GET /assets/positions returns empty list when no positions | `test_list_positions_empty()` | `assets/test_assets_router.py` | P0 |
-| AC11.2.2 | GET /assets/positions returns positions with data | `test_list_positions_with_data()` | `assets/test_assets_router.py` | P0 |
-| AC11.2.3 | GET /assets/positions filters by status correctly | `test_list_positions_filter_by_status()` | `assets/test_assets_router.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.router.1-3` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.3: Asset Router - Single Position Operations
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.3.1 | GET /assets/positions/{id} returns position details | `test_get_position_success()` | `assets/test_assets_router.py` | P0 |
-| AC11.3.2 | GET /assets/positions/{id} returns 404 for non-existent position | `test_get_position_not_found()` | `assets/test_assets_router.py` | P0 |
-| AC11.3.3 | GET /assets/positions/{id} returns 404 for other user's position | `test_get_position_wrong_user()` | `assets/test_assets_router.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.router.4-6` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.4: Asset Router - Reconciliation Endpoint
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.4.1 | POST /assets/reconcile creates positions from snapshots | `test_reconcile_positions_success()` | `assets/test_assets_router.py` | P0 |
-| AC11.4.2 | POST /assets/reconcile with no snapshots returns 0 counts | `test_reconcile_positions_empty()` | `assets/test_assets_router.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.router.7-8` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.5: Asset Router - Authentication
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.5.1 | GET /assets/positions requires authentication | `test_list_positions_requires_auth()` | `assets/test_assets_router.py` | P0 |
-| AC11.5.2 | GET /assets/positions/{id} requires authentication | `test_get_position_requires_auth()` | `assets/test_assets_router.py` | P0 |
-| AC11.5.3 | POST /assets/reconcile requires authentication | `test_reconcile_requires_auth()` | `assets/test_assets_router.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.router.9-11` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.6: Asset Router - Depreciation Endpoint
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.6.1 | GET /assets/positions/{id}/depreciation returns depreciation schedule | `test_get_position_depreciation_success()` | `assets/test_assets_router.py` | P0 |
-| AC11.6.2 | GET /assets/positions/{id}/depreciation returns 400 for non-existent position | `test_get_position_depreciation_not_found()` | `assets/test_assets_router.py` | P0 |
-| AC11.6.3 | GET /assets/positions/{id}/depreciation returns 400 for disposed position | `test_get_position_depreciation_disposed_position()` | `assets/test_assets_router.py` | P0 |
-| AC11.6.4 | GET /assets/positions/{id}/depreciation returns 422 for invalid params | `test_get_position_depreciation_invalid_params()` | `assets/test_assets_router.py` | P1 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.depreciation.1-4` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.7: Security - User Isolation
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.7.1 | Verify position queries are isolated by user_id | `test_get_position_user_isolation()` | `assets/test_assets_router.py` | P0 |
+> This group's row removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.router.12` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC11.10: Daily Market Data Sync
 
@@ -258,10 +238,12 @@ recorded. By default they are restricted assets, included in full net-worth
 views and grouped separately from liquid cash, public equity, property, and
 restricted compensation.
 
+> *(AC11.20.1 removed and AC11.20.2 removed — migrated to the `reporting`
+> package roadmap as `AC-reporting.net-worth-components.1-2`; the frontend
+> row below stays here. Migration closeout continuation, #1663 / #1716.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC11.20.1 | Retirement accounts, social-security personal balances, legacy CPF, and insurance cash value default to restricted assets and contribute to full balance-sheet assets | `test_AC11_20_1_retirement_and_benefit_assets_are_restricted_assets_in_balance_sheet()` | `reporting/test_reporting_net_worth_components.py` | P1 |
-| AC11.20.2 | Net-worth allocation groups retirement accounts, social-security personal balances, legacy CPF, and insurance cash value under the retirement-and-benefit asset class | `test_AC11_20_2_net_worth_allocation_groups_retirement_and_benefit_assets()` | `reporting/test_reporting_net_worth_components.py` | P1 |
 | AC11.20.3 | The assets page labels retirement and benefit asset entry options as assets, with insurance represented only by cash value | `test_AC11_20_3_assets_page_surfaces_retirement_and_benefit_asset_labels()` | `apps/frontend/src/__tests__/assetsPage.test.tsx` | P1 |
 
 ### AC11.21-11.24: Valuation Taxonomy Stack (RETIRED — reinvented existing accounting primitives)

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -97,63 +97,31 @@ be treated as current work.
 
 ### AC17.1: Holdings & P&L Tracking
 
-> **Partially migrated.** The write-side accounting/cost-basis rows formerly
-> tracked in this EPIC are now owned directly by
+> **Fully migrated.** The write-side accounting/cost-basis rows are owned by
 > the `portfolio` package roadmap in
 > [`common/portfolio/contract.py`](../../common/portfolio/contract.py) as
 > `AC-portfolio.1.1` · `AC-portfolio.1.2` ·
 > `AC-portfolio.1.3` · `AC-portfolio.4.1` ·
 > `AC-portfolio.4.2` · `AC-portfolio.2.1` ·
-> `AC-portfolio.2.2` · `AC-portfolio.3.1`. The remaining rows below
-> stay with the legacy EPIC owner until their read-side/package cutover lands.
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.1.1 | Holdings Summary | `test_get_holdings_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
-| AC17.1.5 | Unrealized P&L Calculation | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P0 |
+> `AC-portfolio.2.2` · `AC-portfolio.3.1`.
+>
+> *(AC17.1.1 removed and AC17.1.5 removed and AC17.1.7-9 removed — the remaining read-side rows migrated to the `portfolio` package roadmap as `AC-portfolio.holdings.1-5`, migration closeout continuation, #1663 / #1717)*
 
 > *(AC17.1.6 "Manual Price Update" removed — migrated to the `pricing`
 > package roadmap as `AC-pricing.providers.1`, migration closeout
 > continuation, #1663 / #1710)*
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.1.7 | Portfolio summary happy path returns correct counts and totals. | `test_portfolio_summary_happy` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.1.8 | Summary includes both active and disposed positions. | `test_portfolio_summary_with_disposed` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.1.9 | Zero total cost -> net_pnl_percent = 0. | `test_portfolio_summary_zero_cost` | `portfolio/test_portfolio_service.py` | P1 |
-
 ### AC17.2: Performance Metrics
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.2.1 | XIRR Accuracy (within 0.01% of Excel) | `test_xirr_with_realistic_data` | `portfolio/test_performance_service.py` | P0 |
-| AC17.2.2 | Time-Weighted Return | `test_time_weighted_return_with_period` | `portfolio/test_performance_service.py` | P0 |
-| AC17.2.3 | Money-Weighted Return | `test_money_weighted_return_with_data` | `portfolio/test_performance_service.py` | P1 |
-| AC17.2.4 | Zero cost -> realized_pnl_percent = 0. | `test_realized_pnl_zero_cost` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.2.5 | Disposed position in non-base currency triggers FX conversion. | `test_realized_pnl_fx_conversion` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.2.6 | Unrealized PnL happy path returns correct totals. | `test_unrealized_pnl_happy_path` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.2.7 | Unrealized PnL on empty portfolio raises PortfolioNotFoundError. | `test_unrealized_pnl_no_positions` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.2.8 | Zero cost -> unrealized_pnl_percent in details = 0. | `test_unrealized_pnl_zero_cost` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.2.9 | FX conversion for unrealized PnL. | `test_unrealized_pnl_fx_conversion` | `portfolio/test_portfolio_service.py` | P1 |
+> *(AC17.2.1-5 removed and AC17.2.7-9 removed — migrated to the `portfolio` package roadmap as `AC-portfolio.performance.1-8`, migration closeout continuation, #1663 / #1717)*
+>
+> *(AC17.2.6 removed — duplicate; it re-stated AC17.1.5's fact against the same test, canonical copy is `AC-portfolio.holdings.2`)*
 
 ### AC17.3: Asset Allocation
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.3.1 | Sector Allocation Breakdown | `test_sector_allocation_with_positions` | `portfolio/test_allocation_service.py` | P1 |
-| AC17.3.2 | Geography Allocation Breakdown | `test_geography_allocation_with_positions` | `portfolio/test_allocation_service.py` | P1 |
-| AC17.3.3 | Asset Class Allocation Breakdown | `test_asset_class_allocation_with_positions` | `portfolio/test_allocation_service.py` | P1 |
-| AC17.3.4 | TWR calculates period return within reasonable bounds. | `test_time_weighted_return_with_period` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.5 | MWR raises InsufficientDataError on empty portfolio. | `test_money_weighted_return_insufficient_data` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.6 | MWR calculates money-weighted return for loss scenario. | `test_money_weighted_return_with_data` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.7 | XIRR respects as_of_date parameter. | `test_xirr_with_as_of_date` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.8 | TWR returns zero for same-day period. | `test_time_weighted_return_same_day` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.9 | Performance metrics handle cash-only portfolios. | `test_performance_metrics_with_zero_positions` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.10 | XIRR handles extreme convergence edge cases. | `test_xirr_convergence_edge_case` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.11 | _xirr_bisection raises ValueError when no root exists. | `test_xirr_bisection_no_root_raises` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.12 | _xirr_bisection returns Decimal estimate after max_iter exhaustion. | `test_xirr_bisection_max_iter_returns` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.13 | _xirr_newton falls back to bisection on non-convergence. | `test_xirr_newton_fallthrough_to_bisection` | `portfolio/test_performance_service.py` | P1 |
-| AC17.3.14 | XIRRCalculationError raised when Newton and bisection both fail. | `test_xirr_calculation_error_raised` | `portfolio/test_performance_service.py` | P1 |
+> *(AC17.3.1-3 removed and AC17.3.5 removed and AC17.3.7-14 removed — migrated to the `portfolio` package roadmap as `AC-portfolio.allocation.1-12`, migration closeout continuation, #1663 / #1717)*
+>
+> *(AC17.3.4 removed and AC17.3.6 removed — duplicates; they re-stated AC17.2.2-3's facts against the same tests, canonical copies are `AC-portfolio.performance.2-3`)*
 
 ### AC17.4: Brokerage Statement Parsing
 
@@ -176,52 +144,24 @@ be treated as current work.
 
 ### AC17.5: Investment Accounting (Journal Entries)
 
-> **Partially migrated.** The write-side accounting rows are homed in the
+> **Fully migrated.** The write-side accounting rows are homed in the
 > `portfolio` package roadmap as
 > `AC-portfolio.1.1` · `AC-portfolio.1.2` ·
 > `AC-portfolio.1.3` · `AC-portfolio.4.1` ·
 > `AC-portfolio.4.2` · `AC-portfolio.2.1` ·
 > `AC-portfolio.2.2` · `AC-portfolio.3.1`
-> ([`common/portfolio/contract.py`](../../common/portfolio/contract.py)); the
-> remaining rows below stay with their own owners.
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.5.4 | Unrealized P&L → Balance Sheet | `test_unrealized_pnl_happy_path`, `test_statement_import_flows_to_holdings_and_balance_sheet` | `portfolio/test_portfolio_service.py`, `portfolio/test_brokerage_position_parsing.py` | P0 |
-| AC17.5.5 | Quantity == 0 -> return market_value directly. | `test_get_latest_price_zero_quantity` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.5.6 | No price data -> AssetNotFoundError. | `test_get_latest_price_no_data` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.5.7 | _get_latest_atomic returns the most recent snapshot. | `test_get_latest_atomic_returns_latest` | `portfolio/test_portfolio_service.py` | P1 |
-| AC17.5.8 | _get_latest_atomic returns None when no snapshots exist. | `test_get_latest_atomic_none` | `portfolio/test_portfolio_service.py` | P1 |
+> ([`common/portfolio/contract.py`](../../common/portfolio/contract.py)).
+>
+> *(AC17.5.4-8 removed — the remaining valuation-read rows migrated to the `portfolio` package roadmap as `AC-portfolio.valuation.1-5`, migration closeout continuation, #1663 / #1717)*
 
 ### AC17.6: Integration & End-to-End
 
-> **Partially migrated.** The investment-accounting lifecycle rows are now
+> **Fully migrated.** The investment-accounting lifecycle rows are
 > package-owned as `AC-portfolio.2.1` and
 > `AC-portfolio.4.1`
 > ([`common/portfolio/contract.py`](../../common/portfolio/contract.py)).
-> The API/E2E rows below remain EPIC-owned.
-
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.6.3 | GET /portfolio/holdings with as_of_date filter returns 200. | `test_get_holdings_with_date_filter` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.4 | GET /portfolio/holdings with include_disposed=true returns 200. | `test_get_holdings_include_disposed` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.5 | GET /portfolio/performance without period returns metrics. | `test_get_performance_without_period` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.6 | GET /portfolio/performance with period params returns metrics. | `test_get_performance_with_period` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.7 | GET /portfolio/allocation/sector on empty portfolio returns []. | `test_get_sector_allocation_empty` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.8 | GET /portfolio/allocation/sector with data returns breakdown. | `test_get_sector_allocation_with_data` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.9 | GET /portfolio/allocation/geography on empty portfolio returns []. | `test_get_geography_allocation_empty` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.10 | GET /portfolio/allocation/geography with data returns breakdown. | `test_get_geography_allocation_with_data` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.11 | GET /portfolio/allocation/asset-class on empty portfolio returns []. | `test_get_asset_class_allocation_empty` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.12 | GET /portfolio/allocation/asset-class with data returns breakdown. | `test_get_asset_class_allocation_with_data` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.13 | POST /portfolio/prices/update with single asset returns success. | `test_update_prices_single` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.14 | POST /portfolio/prices/update with batch returns success. | `test_update_prices_batch` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.15 | POST /portfolio/prices/update with invalid payload returns 422. | `test_update_prices_invalid_payload` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.16 | All portfolio endpoints require authentication. | `test_portfolio_endpoints_require_auth` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.17 | GET /portfolio/allocation/sector with as_of_date returns 200. | `test_allocation_with_as_of_date` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.18 | GET /portfolio/performance returns string-formatted metrics. | `test_performance_metrics_response_format` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.19 | InsufficientDataError on empty portfolio -> xirr/mwr default to 0. | `test_get_performance_insufficient_data` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.20 | PerformanceError (non-InsufficientData) on XIRR -> 422. | `test_get_performance_xirr_calculation_error` | `portfolio/test_portfolio_router.py` | P1 |
-| AC17.6.21 | PerformanceError (non-InsufficientData) on MWR -> 422. | `test_get_performance_mwr_calculation_error` | `portfolio/test_portfolio_router.py` | P1 |
+>
+> *(AC17.6.3-21 removed — the API rows migrated to the `portfolio` package roadmap as `AC-portfolio.api.1-19`, migration closeout continuation, #1663 / #1717)*
 
 ### AC17.8: Brokerage Import Completion UI
 
@@ -235,10 +175,12 @@ be treated as current work.
 
 ### AC17.9: Point-in-Time Portfolio Snapshots
 
+> *(AC17.9.1 removed and AC17.9.2 removed — migrated to the `portfolio`
+> package roadmap as `AC-portfolio.as-of.1-2`; the frontend row below stays
+> here. Migration closeout continuation, #1663 / #1717.)*
+
 | ID | Test Case | Test Function | File | Priority |
 |----|-----------|---------------|------|----------|
-| AC17.9.1 | Historical holdings quantity and market value come from the latest AtomicPosition snapshot at or before `as_of_date` | `test_get_holdings_explicit_as_of_uses_historical_atomic_snapshot` | `portfolio/test_portfolio_service.py` | P0 |
-| AC17.9.2 | Portfolio holdings API returns date-bounded snapshot quantities for explicit `as_of_date` requests | `test_get_holdings_explicit_date_uses_historical_snapshot_quantity` | `portfolio/test_portfolio_router.py` | P0 |
 | AC17.9.3 | Portfolio page exposes an as-of date selector and passes it to `/api/portfolio/holdings` | `AC17.9.3 passes selected as-of date to holdings API` | `frontend/src/__tests__/portfolioPage.test.tsx` | P0 |
 
 ### AC17.10: Investment Performance Report Schedule API
@@ -275,23 +217,15 @@ evidence for EPIC-005 packaging, not a mutation or relaxation of historical
 portfolio queries, and the response must disclose the override through notes,
 freshness metadata, and source links.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.10.1 | Investment performance schedule API exposes report-ready metrics and rows | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_AC17_10_1_report_schedule_uses_manual_override_after_period_end`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
-| AC17.10.2 | Investment performance schedule API exposes data freshness, source links, and notes for report traceability | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule`; `test_AC17_10_1_report_schedule_uses_manual_override_after_period_end`; `test_personal_financial_report_package_post_merge_journey`; `test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract` | `apps/backend/tests/portfolio/test_portfolio_router.py`; `tests/e2e/test_personal_financial_report_package.py`; `tests/tooling/test_investment_performance_report_contract.py` | P0 |
-| AC17.10.3 | Investment performance schedule source links preserve brokerage statement, price source, ledger, transaction source, and report-section anchors | `test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
-| AC17.10.4 | Investment performance schedule data freshness marks the schedule stale when any holding lacks current as-of-date price evidence | `test_AC17_10_4_report_schedule_marks_stale_when_any_holding_price_is_stale` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
-| AC17.10.5 | Investment performance XIRR solver does not convert monetary Decimal cash flows to float | `test_AC17_10_5_xirr_solver_does_not_float_monetary_cashflows` | `apps/backend/tests/portfolio/test_performance_service.py` | P0 |
-| AC17.10.6 | Investment performance schedule converts mixed-currency cost basis, market value, realized P&L, and dividend income into presentation currency before aggregation | `test_AC17_10_6_investment_performance_schedule_converts_mixed_currency_amounts` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.report-schedule.1-6` (migration closeout continuation,
+> #1663 / #1717).
 
 ### AC17.11: Portfolio Financial Logic Audit Fixes
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.11.1 | Portfolio XIRR and MWR use investment transactions only, excluding unrelated bank atomic transactions | `test_AC17_11_1_xirr_excludes_unrelated_bank_transactions()` | `portfolio/test_financial_logic_audit.py` | P0 |
-| AC17.11.2 | Portfolio summary YTD realized P&L and dividend income are converted to presentation currency before aggregation | `test_AC17_11_2_summary_ytd_amounts_convert_to_presentation_currency()` | `portfolio/test_financial_logic_audit.py` | P0 |
-| AC17.11.3 | Portfolio TWR excludes unrelated bank atomic transactions from period cash-flow adjustment | `test_AC17_11_3_twr_excludes_unrelated_bank_transactions()` | `portfolio/test_financial_logic_audit.py` | P0 |
-| AC17.11.4 | Non-structured source document payloads produce no audit links | `test_AC17_11_4_source_document_links_ignore_non_structured_payloads()` | `portfolio/test_financial_logic_audit.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.logic-audit.1-4` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC17.12: Portfolio Audit Fixture Expansion
 
@@ -300,17 +234,20 @@ personal financial-report package proof. Local real PDF/CSV inputs may be used
 to learn statement structure, but committed fixtures must be synthetic,
 redacted, and Decimal-safe.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.12.1 | Portfolio audit fixture contract covers multi-broker, multi-currency expected positions and a report period that contains every activity row for Moomoo statement, Moomoo margin history, and Futu statement sources | `test_AC17_12_1_portfolio_fixture_contract_covers_multi_broker_multi_currency_inputs` | `tests/tooling/test_portfolio_audit_fixture_contract.py` | P0 |
-| AC17.12.2 | Portfolio audit fixture contract pins sanitized trade, dividend, fee, and valuation activity rows, derives expected totals from fixture rows and positions, and covers parser support for Moomoo margin history rows | `test_AC17_12_2_portfolio_fixture_pins_activity_rows_without_raw_documents`, `test_AC17_12_2_parse_moomoo_margin_history_rows_as_equity_position_snapshot` | `tests/tooling/test_portfolio_audit_fixture_contract.py`, `portfolio/test_brokerage_position_parsing.py` | P0 |
-| AC17.12.3 | Personal report package fixture consumes expanded portfolio expected outputs instead of keeping one-position brokerage constants inline | `test_AC17_12_3_personal_package_references_expanded_portfolio_fixture_contract` | `tests/tooling/test_portfolio_audit_fixture_contract.py` | P0 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.fixtures.1-3` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC17.13: Portfolio Fact Boundary for Framework Reporting
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.13.1 | Portfolio management owns holdings, lots, dividends, fees, and source links, and relays price/freshness facts (owned by the `pricing` package, #1610) as framework policy inputs, but does not own final US/HK report presentation decisions | `test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions` | `tests/tooling/test_framework_reporting_epic_contract.py` | P0 |
+Portfolio management owns holdings, lots, dividends, fees, and source
+links, and relays price/freshness facts (owned by the `pricing` package,
+#1610) as framework policy inputs, but
+does not own final US/HK report presentation decisions.
+
+> This group's row removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.fact-boundary.1` (migration closeout continuation, #1663 /
+> #1717).
 
 ### AC17.14: Unified Portfolio Allocation Surface
 
@@ -353,14 +290,9 @@ shape is preserved so existing frontend consumers keep working without coordinat
 changes; wrapping these responses in `{items, total}` is deferred to a follow-up
 that also migrates the frontend consumers.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.30.1 | GET /portfolio/holdings caps results at the requested limit when paginating | `test_AC17_30_1_holdings_default_cap_applied` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
-| AC17.30.2 | GET /portfolio/holdings honors limit and offset to page through holdings | `test_AC17_30_2_holdings_limit_offset_honored` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
-| AC17.30.3 | GET /portfolio/holdings rejects out-of-range limit/offset with 422 | `test_AC17_30_3_holdings_rejects_out_of_range_pagination` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
-| AC17.30.4 | GET /portfolio/{ticker}/dividends honors limit/offset and rejects out-of-range | `test_AC17_30_4_dividends_limit_offset_honored` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
-| AC17.30.5 | GET /portfolio/{ticker}/realized honors limit/offset and rejects out-of-range | `test_AC17_30_5_realized_limit_offset_honored` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
-| AC17.30.6 | GET /portfolio/allocation/* honors limit/offset and rejects out-of-range | `test_AC17_30_6_allocation_limit_offset_honored` | `apps/backend/tests/portfolio/test_portfolio_router.py` | P1 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.pagination.1-6` (migration closeout continuation, #1663 /
+> #1717).
 
 ### Brokerage PDF to Asset Report Proof Matrix
 
@@ -372,11 +304,11 @@ EPIC-008 remains the owner of the provider-backed staging AI/OCR gate.
 | Product path step | EPIC owner | AC owner | Executable proof | File | CI tier |
 |---|---|---|---|---|---|
 | Upload Moomoo/Futu brokerage PDF through `/api/statements/upload` | EPIC-008 / EPIC-013 | AC-extraction.813.10 | `test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_portfolio_value` | `tests/e2e/test_brokerage_upload_to_portfolio_value.py` | Post-merge staging AI/OCR gate |
-| Background parse detects brokerage payload and imports positions without a manual API call | EPIC-017 | AC-extraction.304.7 / AC17.5.4 / AC-extraction.813.10 | `test_parse_statement_background_imports_brokerage_positions` | `apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py` | Backend shard |
+| Background parse detects brokerage payload and imports positions without a manual API call | EPIC-017 | AC-extraction.304.7 / AC-portfolio.valuation.1 / AC-extraction.813.10 | `test_parse_statement_background_imports_brokerage_positions` | `apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py` | Backend shard |
 | Brokerage-style OCR balance mismatches remain parsed and visible instead of stalling | EPIC-008 / EPIC-017 | AC-extraction.813.10 | `test_parse_document_routes_brokerage_balance_mismatch_to_parsed` | `apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py` | Backend shard |
 | Concurrent auto parse import and manual statement import share the same deduped position instead of failing with a duplicate-key 500 | EPIC-017 | AC17.4.8 | `test_AC17_4_8_brokerage_import_survives_concurrent_auto_and_manual_import` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
 | Statement-scoped import creates holdings | EPIC-017 | AC17.4.6 / AC-extraction.813.10 | `test_statement_import_flows_to_holdings_and_balance_sheet` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
-| Imported holdings affect balance sheet value | EPIC-005 / EPIC-017 | AC17.5.4 / AC-extraction.813.10 | `test_statement_import_flows_to_holdings_and_balance_sheet` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
+| Imported holdings affect balance sheet value | EPIC-005 / EPIC-017 | AC-portfolio.valuation.1 / AC-extraction.813.10 | `test_statement_import_flows_to_holdings_and_balance_sheet` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
 | User completes import and navigates to portfolio value | EPIC-017 | AC17.8.1 / AC17.8.2 / AC17.8.4 | `AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation` | `apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx` | Frontend test |
 
 Provider-backed gate details live in
@@ -405,7 +337,9 @@ For #521 closure, this EPIC should be sequenced as:
    - traceability appendix (`#572`)
 4. Provide deterministic fixture inputs for the package proof (`#573`).
 5. Done: extend the implemented `#565` post-merge package proof with the
-   report-ready investment schedule (`AC5.8.1`, `AC17.10.1`, `AC17.10.2`).
+   report-ready investment schedule (`AC5.8.1`, now also
+   `AC-reporting.package-investment.1` and
+   `AC-portfolio.report-schedule.1-2` after the package-roadmap migration).
 
 The post-merge proof test is owned by EPIC-008.
 
@@ -418,10 +352,10 @@ scope decisions are:
 | Decision | Current owner |
 |---|---|
 | Portfolio is self-developed, not outsourced to a portfolio SaaS | `vision.md` decision 1 and this EPIC objective |
-| XIRR/TWR/MWR, allocation, dividends, and cost basis are in portfolio scope | AC17.1-AC17.3, AC17.5-AC17.6, AC17.10-AC17.11 |
+| XIRR/TWR/MWR, allocation, dividends, and cost basis are in portfolio scope | `AC-portfolio.holdings/performance/allocation/valuation/api/report-schedule/logic-audit.*` (`common/portfolio/contract.py`) |
 | Brokerage statements are uploaded and parsed through the statement pipeline | AC17.4, EPIC-003/EPIC-013 extraction SSOT |
 | Manual price update remains valid for low-frequency holdings; provider sync is governed separately | `AC-pricing.providers.1`, `AC-pricing.marketdata.1-11` (`common/pricing/contract.py`) — price/valuation data ownership moved to the `pricing` package (#1610); portfolio consumes prices, it does not own them |
-| Report-ready investment schedule is consumed by the personal report package | AC17.10 and EPIC-005 package contract |
+| Report-ready investment schedule is consumed by the personal report package | `AC-portfolio.report-schedule.*` and EPIC-005 package contract |
 | Framework-specific report presentation for portfolio facts is not owned here | [framework-reporting.md](../ssot/framework-reporting.md), EPIC-020, AC17.13 |
 
 Current proof status comes from generated registries, traceability checks, tests,
@@ -457,10 +391,9 @@ declare typed Pydantic responses (`PriceUpdateBatchResponse`,
 `CostBasisMethodUpdateResponse`) instead of raw `dict`, so the response contract is
 visible in OpenAPI and the generated frontend client.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.31.1 | `prices/update` returns the typed `{updated_count, results}` shape | `test_AC17_31_1_prices_update_returns_typed_batch_response` | `api/test_typed_contract_sweep.py` | P2 |
-| AC17.31.2 | `PATCH {ticker}` for an unknown holding returns a structured 404 | `test_AC17_31_2_patch_unknown_holding_returns_404` | `api/test_typed_contract_sweep.py` | P2 |
+> This group's rows removed — migrated to the `portfolio` package roadmap as
+> `AC-portfolio.typed-responses.1-2` (migration closeout continuation,
+> #1663 / #1717).
 
 ### AC17.32: Brokerage CSV Routing — migrated to the `extraction` package ([#1255](https://github.com/wangzitian0/finance_report/issues/1255))
 

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -267,6 +267,11 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 > continuation, #1663 / #1715)*
 >
 > *(AC18.2.1 removed and AC18.2.2 removed and AC18.2.3 removed and AC18.2.4 removed and AC18.2.5 removed — migrated to the `extraction` package roadmap as `AC-extraction.1802.1-5`, migration closeout continuation, #1663 / #1715)*
+>
+> *(AC18.4.1 removed and AC18.4.2 removed and AC18.4.4 removed — migrated to
+> the `reporting` package roadmap as `AC-reporting.layer3.1-3`, migration
+> closeout continuation, #1663 / #1716. AC18.4.3 stays — it is
+> extraction-owned CSV-fallback scope, not reporting.)*
 
 | AC ID | Phase | Description |
 |-------|-------|-------------|
@@ -277,10 +282,7 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 | AC18.3.1 | 3 | `ai_semantic_score()` returns similarity for transaction description pairs. **Not migrated** — `ai_semantic_score` is a genuine LLM call, but `reconciliation` is declared `CODE-ONLY`; migrating this row trips `check_authority_reconcile.py` (a CODE-ONLY package permits no LLM-classified roadmap-AC test). Needs a tier/package-boundary decision before migration, not a silent workaround (found during migration verification, #1663 / #1711) |
 | AC18.3.2 | 3 | Hybrid scoring: `0.7 * algorithmic + 0.3 * AI` for 60-84 range only. **Untested** — no test exercises `calculate_match_score`'s hybrid-AI branch (found during migration verification, #1663 / #1711) |
 | AC18.3.3 | 3 | Feature flag `enable_ai_reconciliation` controls AI scoring. **Untested** — no test toggles `ENABLE_AI_RECONCILIATION` (found during migration verification, #1663 / #1711) |
-| AC18.4.1 | 4 | Reports read Layer 3 `TransactionClassification` for category breakdowns |
-| AC18.4.2 | 4 | `ReportSnapshot` (Layer 4) generated and queryable via API |
 | AC18.4.3 | 4 | AI CSV parsing handles unknown institutions as fallback |
-| AC18.4.4 | 4 | Income statements include applied Layer 3 classification coverage |
 
 ### AC18.7: Evidence Graph Foundation
 
@@ -380,9 +382,12 @@ Dependencies: AC18.7 Evidence Graph foundation, AC18.9 navigation API, and AC18.
 
 ### AC18.6: Framework Measurement and Disclosure Suggestions
 
-| AC ID | Phase | Description |
-|-------|-------|-------------|
-| AC18.6.1 | Framework reporting | AI-generated measurement or disclosure suggestions for US/HK personal report packages must remain structured, source-anchored, confidence-scored, and reviewed before EPIC-020 or EPIC-005 can treat them as trusted report inputs |
+AI-generated measurement or disclosure suggestions for US/HK personal
+report packages must remain
+structured, source-anchored, confidence-scored, and reviewed
+before EPIC-020 or EPIC-005 can treat them as trusted report inputs.
+
+> *(AC18.6.1 removed — duplicate, not migrated; the canonical copy is `AC-reporting.ai.1`, which was AC20.6.1 and pins exactly the criterion above. One criterion, one home — the `reporting` package roadmap, [`common/reporting/contract.py`](../../common/reporting/contract.py). Migration closeout continuation, #1663 / #1716)*
 
 ### AC18.12: North-Star Confidence Metric
 
@@ -394,12 +399,9 @@ ledger facts that back reports (tier derived from journal `source_type` via
 and surfaced read-only via the API. Recording cadence (on report-package
 generation / scheduled) and the per-report-number confidence of #913 are separate.
 
-| AC ID | Phase | Description | Test | File | Priority |
-|-------|-------|-------------|------|------|----------|
-| AC18.12.1 | Metric | The low-confidence proportion is the deterministic LOW-tier share of posted/reconciled journal entries, with a full TRUSTED/HIGH/MEDIUM/LOW breakdown and a defined zero on an empty ledger | `test_AC18_12_1_low_confidence_proportion_and_tier_breakdown_are_deterministic()` | `metrics/test_confidence_north_star_metric.py` | P1 |
-| AC18.12.2 | Trend | The metric is recorded as an append-only series — snapshots accumulate and read newest-first, never overwritten — so the trend over time is observable | `test_AC18_12_2_metric_is_recorded_as_append_only_series_showing_the_trend()` | `metrics/test_confidence_north_star_metric.py` | P1 |
-| AC18.12.3 | Surface | The current metric and its recorded series are exposed read-only via the API | `test_AC18_12_3_north_star_endpoint_returns_current_and_series()` | `metrics/test_confidence_north_star_metric.py` | P1 |
-| AC18.12.4 | Wired | A North-Star snapshot is recorded when a report package is generated, and on demand via a POST endpoint, so the trend actually accumulates in production | `test_AC18_12_4_post_records_a_snapshot_into_the_series()`, `test_generate_personal_report_package_snapshot` | `metrics/test_confidence_north_star_metric.py`, `api/test_reports_router.py` | P1 |
+> This group's rows removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.north-star.1-4` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC18.13: Promotion Gate — Confidence Is Load-Bearing
 

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -349,15 +349,12 @@ workflow state exists.
 
 ### AC19.5 — Report Readiness and Blocker State
 
+> *(AC19.5.1 removed and AC19.5.2 removed and AC19.5.3 removed and AC19.5.6 removed and AC19.5.7 removed — this group's backend readiness rows migrated to the `reporting` package roadmap as `AC-reporting.readiness.1-5`, migration closeout continuation, #1663 / #1716)*. The frontend rows below stay here.
+
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC19.5.1 | Personal report package exposes a user-scoped readiness endpoint that returns deterministic package state, action link, blocker count, and source summary before report output | `test_AC19_5_1_package_readiness_returns_draft_for_empty_user` / `test_AC19_5_1_package_readiness_rejects_unknown_state_and_external_action_links` | P0 |
-| AC19.5.2 | Blocked package readiness lists exact blocker categories for failed parsing, pending review, balance mismatch, reconciliation blockers, consistency checks, unresolved Processing balance, and missing source coverage | `test_AC19_5_2_package_readiness_lists_actionable_blockers` | P0 |
-| AC19.5.3 | Package readiness deterministically promotes through `draft`, `processing`, `blocked`, `ready`, `generated`, and `stale` based on source state and report snapshot freshness | `test_AC19_5_3_package_readiness_state_priority_and_snapshot_freshness` | P0 |
 | AC19.5.4 | Personal report package page renders readiness state and blocker links before package section output | `personalReportPackagePage.test.tsx` | P1 |
 | AC19.5.5 | Personal report package page renders non-blocked readiness states without stale blocker cards | `personalReportPackagePage.test.tsx` | P1 |
-| AC19.5.6 | Package readiness fails deterministically when duplicate Processing system accounts would otherwise make blockers non-deterministic | `test_AC19_5_6_package_readiness_rejects_duplicate_processing_accounts` | P0 |
-| AC19.5.7 | Package readiness converts Processing Account journal lines into base reporting currency before deciding whether the in-transit balance nets to zero | `test_AC19_5_7_package_readiness_converts_processing_balance_before_zero_check` | P0 |
 
 ### AC19.6 — Navigation Folding And Advanced Drill-Down
 
@@ -381,9 +378,15 @@ workflow state exists.
 
 ### AC19.7 — Framework-Aware Evidence Readiness
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.7.1 | Report readiness must evaluate framework-specific evidence blockers from EPIC-020, including missing settlement coverage, unresolved review, stale market data, missing valuation basis, and AI-only unreviewed policy suggestions before marking US/HK personal reports trusted | `test_AC19_7_1_readiness_consumes_framework_specific_evidence_blockers` | P0 |
+Report readiness must evaluate
+framework-specific evidence blockers from EPIC-020 — including
+missing settlement coverage, unresolved review, stale market data,
+missing valuation basis, and AI-only unreviewed policy suggestions —
+before marking US/HK personal reports trusted.
+
+> This group's row removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.readiness.6` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC19.8 — Workflow Session IA Hardening And CR Cleanup
 
@@ -396,20 +399,23 @@ workflow state exists.
 | AC19.8.5 | Navigation IA (superseded by EPIC-022 AC22.21): the bottom tab bar is Home, Chat, Add, Audit, More; the accounting machinery and settings are reached via the Audit hub and More, not a primary/advanced split | `navigation.test.ts`, `sidebarAndTabs.test.tsx`, `bottomTabBar.test.tsx`, `workflow-navigation.spec.ts` | P0 |
 | AC19.8.6 | `/chat` is a simple AI utility page with model selector, active conversation, and session-list drawer; it is not labeled AI Settings | `chatPanelComponent.test.tsx`, `ChatPageClient.test.tsx` | P1 |
 | AC19.8.7 | Report readiness has route-level Playwright smoke coverage before package output | `report-readiness.spec.ts` | P1 |
-| AC19.8.8 | CR cleanup fixes mixed-currency investment schedule fallback, missing Processing FX readiness blocker coverage, stale SSOT paths, and stale navigation docs | `test_AC19_8_8_investment_schedule_fallback_holding_cost_basis_converts_currency`, `test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_fails`, `report-readiness.spec.ts` | P0 |
+| AC19.8.8 | CR cleanup fixes missing Processing FX readiness blocker coverage, stale SSOT paths, and stale navigation docs (the mixed-currency investment-schedule-fallback share migrated to the `portfolio` package roadmap as `AC-portfolio.schedule-fallback.1`, migration closeout continuation, #1663 / #1717) | `test_AC19_8_8_package_readiness_blocks_when_processing_fx_conversion_fails`, `report-readiness.spec.ts` | P0 |
 
 ### AC19.9 — Source Trust Readiness
 
+> *(AC19.9.1 removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.source-trust.1`, migration closeout continuation, #1663 /
+> #1716.)* The frontend row below stays here.
+
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC19.9.1 | Personal report package readiness returns source trust summary by source class, deterministic PR proof availability, post-merge LLM/OCR coverage, manual-trusted classes, gaps, and blocker codes | `test_AC19_9_1_package_readiness_reports_source_trust_summary` | P0 |
 | AC19.9.2 | Personal report package page renders a compact source trust summary before detailed package output | `AC19.9.2 renders compact source trust summary before traceability details` | P0 |
 
 ### AC19.10 — Typed Package Source Anchors
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.10.1 | Personal report package traceability resolves journal source IDs to typed source anchors, exposes amount-level source and ledger details for report lines, and blocks unknown source IDs instead of presenting them as statement transactions | `test_AC19_10_1_unknown_journal_source_ids_are_not_reported_as_statement_transactions`, `test_AC5_13_5_package_traceability_returns_dynamic_current_user_identifiers` | P0 |
+> This group's row removed — migrated to the `reporting` package roadmap as
+> `AC-reporting.source-anchors.1` (migration closeout continuation, #1663 /
+> #1716).
 
 ### AC19.11 — Run-Scoped Stage 2 Review
 

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -172,11 +172,14 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 > any amount on the Balance Sheet / Income Statement drills down to the exact
 > source transactions, reusing the evidence-lineage graph.
 
+> *(AC22.3.3 removed — the account-lineage API row migrated to the
+> `reporting` package roadmap as `AC-reporting.lineage.1`, migration
+> closeout continuation, #1663 / #1716.)*
+
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
 | AC22.3.1 | The `/reports` front section renders exactly four report blocks: Balance Sheet, Income Statement, Annualized Income, and Reconciliation coverage (reconciliation match rate / unmatched count) | `reportsCockpit.test.tsx` | P1 |
 | AC22.3.2 | All other reports (Cash Flow, Personal Report Package, and any future reports) live behind a single "More" control, not the front section | `reportsCockpit.test.tsx` | P1 |
-| AC22.3.3 | `GET /api/reports/account-lineage` returns the user-scoped posted/reconciled journal lines that contribute to an account's balance for the period, each carrying a `journal_line` evidence anchor, with Decimal-safe signed amounts | `test_account_lineage.py` | P1 |
 | AC22.3.4 | A reusable lineage drill-down component lets a user click any amount on the Balance Sheet or Income Statement, list the contributing journal lines, and open the full evidence chain (journal line → bank statement transaction → atomic transaction → source document) | `lineagePanel.test.tsx`, `balanceSheetDrilldown.test.tsx` | P1 |
 | AC22.3.5 | Accounts/amounts with no contributing lines or no graph-compatible anchor degrade gracefully with an explicit empty/"no source linked" state and no crash | `balanceSheetDrilldown.test.tsx` | P1 |
 | AC22.3.6 | Desktop and mobile smoke covers the four-block cockpit and a Balance Sheet drill-down open/close without layout overflow | `reports-cockpit.spec.ts` | P1 |
@@ -241,7 +244,7 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC22.7.1 | Each cash-flow line carries its account anchor (`account_id`), and clicking a cash-flow amount opens the account-lineage drawer for that account's contributing journal lines | `test_reporting.py`, `cashFlowPage.test.tsx` | P1 |
+| AC22.7.1 | Clicking a cash-flow amount opens the account-lineage drawer for that account's contributing journal lines (the backend account-anchor half migrated to the `reporting` package roadmap as `AC-reporting.lineage.2`, migration closeout continuation, #1663 / #1716; the frontend drawer half stays here) | `cashFlowPage.test.tsx` | P1 |
 | AC22.7.2 | The reusable lineage panel renders evidence nodes as an ordered source-to-report path with per-hop source, confidence, and version badges when those fields are available | `lineagePanel.test.tsx` | P1 |
 | AC22.7.3 | The Cash Flow statement renders a reconciliation that ties beginning cash + net cash flow to ending cash, and explicitly flags when it does not reconcile | `cashFlowPage.test.tsx` | P1 |
 | AC22.7.4 | Desktop and mobile Playwright smoke covers Cash Flow amount drill-down opening the account-lineage drawer without document horizontal overflow | `cash-flow-drilldown.spec.ts` | P1 |
@@ -290,7 +293,7 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC22.10.1 | A holding whose latest snapshot is backed by a source document is labeled "Imported"; holdings without document evidence carry no provenance label (manual data is never shown as imported, and import is never claimed without proof) | `test_portfolio_service.py`, `holdingsTable.test.tsx` | P1 |
+| AC22.10.1 | The holdings table renders the "Imported" provenance badge only for holdings with concrete document evidence (the backend labeling half migrated to the `portfolio` package roadmap as `AC-portfolio.provenance.1`, migration closeout continuation, #1663 / #1717; the frontend badge half stays here) | `holdingsTable.test.tsx` | P1 |
 | AC22.10.2 | Manual valuation capture uses a controlled source enum instead of free-text provenance, while existing historical source strings remain displayable in snapshot history | `assetsPage.test.tsx` | P1 |
 | AC22.10.3 | Desktop and mobile Playwright smoke covers portfolio provenance badges only for imported holdings, with unproven holdings unlabeled and no document horizontal overflow | `portfolio-provenance.spec.ts` | P1 |
 
@@ -342,16 +345,10 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 > position paths. This slice also carries forward two #928 accessibility review
 > comments that belong to the same trust-surface baseline.
 
-> **AC22.13.1** is a dual-package row. Its `test_manual_valuation_snapshots.py`
-> share (manual valuation component provenance) migrated to the `pricing`
-> package roadmap as **`AC-pricing.provenance.1`** (migration closeout
-> continuation, #1663 / #1710). The `test_portfolio_service.py` and
-> `test_reporting.py` shares stay here pending the `portfolio`/`reporting`
-> package migrations.
+> *(AC22.13.1 removed — fully distributed; it was a three-package row: its `test_manual_valuation_snapshots.py` share migrated to `AC-pricing.provenance.1` (#1663 / #1710), its `test_portfolio_service.py` share (holdings + explicit as-of holdings) to `AC-portfolio.provenance.2` (#1663 / #1717), and its `test_reporting.py` share (report amount lines) to `AC-reporting.provenance.1` (#1663 / #1716))*
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
-| AC22.13.1 | Portfolio holdings, explicit as-of holdings, manual valuation snapshots, and report amount lines expose a normalized provenance enum (`imported`, `manual`, `derived`) when the source basis is known, while ambiguous holdings remain unlabeled instead of guessed | `test_portfolio_service.py`, `test_reporting.py`, `test_manual_valuation_snapshots.py` | P1 |
 | AC22.13.2 | Portfolio and report surfaces render a shared Imported / Manual / Derived provenance badge; Manual is visually distinct from Imported and unlabeled values remain silent | `provenanceBadge.test.tsx`, `holdingsTable.test.tsx`, `balanceSheetPage.test.tsx`, `incomeStatementPage.test.tsx` | P1 |
 | AC22.13.3 | Carryover accessibility review fixes keep the skip-link target covered by global focus-visible styling and keep report package table-of-contents section status in the accessible link name | `designTokens.test.tsx`, `personalReportPackagePage.test.tsx` | P1 |
 

--- a/docs/ssot/ac-score-baseline.jsonl
+++ b/docs/ssot/ac-score-baseline.jsonl
@@ -15,4 +15,4 @@
 {"ac_id": "AC-reconciliation.fx-transfer.8", "score": 1.0, "metric": "fx_conversion_model_round_trips_decimal_and_iso_currency", "provenance": "deterministic"}
 {"ac_id": "AC-reconciliation.fx-transfer.9", "score": 1.0, "metric": "income_statement_excludes_internal_transfer_legs_fee_only", "provenance": "deterministic"}
 {"ac_id": "AC-reconciliation.matching-core.4", "score": 1.0, "metric": "description_similarity_pct", "provenance": "deterministic"}
-{"ac_id": "AC8.16.1", "score": 1.0, "metric": "superseded_excluded_corrected_total_match", "provenance": "deterministic"}
+{"ac_id": "AC-reporting.augmentation.1", "score": 1.0, "metric": "superseded_excluded_corrected_total_match", "provenance": "deterministic"}

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -277,7 +277,7 @@ def _line_total_by_name(lines: list[dict], token: str) -> Decimal:
         "AC11.9.1",
         "AC11.9.2",
         "AC11.9.3",
-        "AC17.5.4",
+        "AC-portfolio.valuation.1",
     ],
     scope="behavioral",
     ci_tier="post_merge_environment",
@@ -303,7 +303,8 @@ async def test_four_asset_as_of_net_worth_golden_path(
 ) -> None:
     """AC-testing.product-gates.7: EPIC-005 EPIC-008 EPIC-011 EPIC-017.
 
-    AC-testing.product-gates.7 AC-extraction.813.10 AC5.7.3 AC11.9.1 AC11.9.2 AC11.9.3 AC17.5.4:
+    AC-testing.product-gates.7 AC-extraction.813.10 AC5.7.3 AC11.9.1 AC11.9.2 AC11.9.3
+    AC-portfolio.valuation.1:
     four assets produce exact as-of net worth.
     """
     page = authenticated_page_unique

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -324,25 +324,25 @@ async def _create_manual_snapshot(
 @ac_proof(
     "personal-financial-report-package-post-merge",
     ac_ids=[
-        "AC5.1.1",
-        "AC5.1.4",
-        "AC5.2.3",
-        "AC5.3.1",
+        "AC-reporting.balance-sheet.1",
+        "AC-reporting.balance-sheet.4",
+        "AC-reporting.income-statement.3",
+        "AC-reporting.cash-flow.1",
         "AC5.8.1",
-        "AC5.12.4",
-        "AC5.13.4",
-        "AC5.13.5",
+        "AC-reporting.package-notes.3",
+        "AC-reporting.package-traceability.3",
+        "AC-reporting.package-traceability.4",
         "AC11.8.3",
         "AC11.9.1",
         "AC11.9.2",
         "AC11.9.3",
         "AC11.11.1",
         "AC11.11.2",
-        "AC17.10.1",
-        "AC17.10.2",
-        "AC17.12.1",
-        "AC17.12.2",
-        "AC17.12.3",
+        "AC-portfolio.report-schedule.1",
+        "AC-portfolio.report-schedule.2",
+        "AC-portfolio.fixtures.1",
+        "AC-portfolio.fixtures.2",
+        "AC-portfolio.fixtures.3",
         "AC-testing.product-gates.8",
         "AC-testing.product-gates.9",
         "AC-testing.product-gates.10",
@@ -374,9 +374,13 @@ async def test_personal_financial_report_package_post_merge_journey(
 ) -> None:
     """EPIC-005 EPIC-008 EPIC-011 EPIC-017 EPIC-020.
 
-    AC5.1.1 AC5.1.4 AC5.2.3 AC5.3.1 AC5.8.1 AC5.12.4 AC5.13.4 AC5.13.5
-    AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3 AC11.11.1 AC11.11.2 AC17.10.1 AC17.10.2
-    AC17.12.1 AC17.12.2 AC17.12.3
+    AC-reporting.balance-sheet.1 AC-reporting.balance-sheet.4
+    AC-reporting.income-statement.3 AC-reporting.cash-flow.1 AC5.8.1
+    AC-reporting.package-notes.3 AC-reporting.package-traceability.3
+    AC-reporting.package-traceability.4
+    AC11.8.3 AC11.9.1 AC11.9.2 AC11.9.3 AC11.11.1 AC11.11.2
+    AC-portfolio.report-schedule.1 AC-portfolio.report-schedule.2
+    AC-portfolio.fixtures.1 AC-portfolio.fixtures.2 AC-portfolio.fixtures.3
     AC-testing.product-gates.8 AC-testing.product-gates.9 AC-testing.product-gates.10 AC-testing.product-gates.11 AC-testing.product-gates.12:
     one complete fresh-user report package with bank data, brokerage import,
     investment performance schedule, annualized income and restricted

--- a/tests/tooling/test_framework_reporting_epic_contract.py
+++ b/tests/tooling/test_framework_reporting_epic_contract.py
@@ -185,7 +185,7 @@ def test_AC5_14_1_reporting_assembles_framework_policy_results_only() -> None:
 
 
 def test_AC17_13_1_portfolio_supplies_facts_not_framework_conclusions() -> None:
-    """AC17.13.1: Portfolio supplies facts but not US/HK report conclusions."""
+    """AC-portfolio.fact-boundary.1: AC17.13.1: Portfolio supplies facts but not US/HK report conclusions."""
     epic = read("docs/project/EPIC-017.portfolio-management.md")
 
     assert "Framework boundary" in epic

--- a/tests/tooling/test_investment_performance_report_contract.py
+++ b/tests/tooling/test_investment_performance_report_contract.py
@@ -9,7 +9,7 @@ def read(path: str) -> str:
 
 
 def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> None:
-    """AC17.10.1 AC17.10.2: EPIC-017 owns the investment performance schedule API contract."""
+    """AC-portfolio.report-schedule.2: AC17.10.1 AC17.10.2: EPIC-017 owns the investment performance schedule API contract."""
     epic = read("docs/project/EPIC-017.portfolio-management.md")
     # Migrated from docs/ssot/reporting.md into the reporting package readme
     # (migration closeout wave 3, #1664); docs/ssot/reporting.md is now a
@@ -43,7 +43,7 @@ def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> N
 
 
 def test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract() -> None:
-    """AC5.8.1: EPIC-005 owns package consumption of the investment performance schedule."""
+    """AC-reporting.package-investment.1: AC5.8.1: EPIC-005 owns package consumption of the investment performance schedule."""
     epic = read("docs/project/EPIC-005.reporting-visualization.md")
     user_guide = read("docs/user-guide/reports.md")
 

--- a/tests/tooling/test_investment_performance_report_contract.py
+++ b/tests/tooling/test_investment_performance_report_contract.py
@@ -9,7 +9,7 @@ def read(path: str) -> str:
 
 
 def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> None:
-    """AC-portfolio.report-schedule.2: AC17.10.1 AC17.10.2: EPIC-017 owns the investment performance schedule API contract."""
+    """AC-portfolio.report-schedule.2: AC17.10.1 AC17.10.2: the schedule API contract is portfolio-package-owned and stays documented in EPIC-017 and the reporting package readme."""
     epic = read("docs/project/EPIC-017.portfolio-management.md")
     # Migrated from docs/ssot/reporting.md into the reporting package readme
     # (migration closeout wave 3, #1664); docs/ssot/reporting.md is now a
@@ -43,7 +43,7 @@ def test_AC17_10_1_AC17_10_2_investment_performance_schedule_api_contract() -> N
 
 
 def test_AC5_8_1_personal_report_package_consumes_investment_schedule_contract() -> None:
-    """AC-reporting.package-investment.1: AC5.8.1: EPIC-005 owns package consumption of the investment performance schedule."""
+    """AC-reporting.package-investment.1: AC5.8.1: package consumption of the investment performance schedule is reporting-package-owned and stays documented in EPIC-005."""
     epic = read("docs/project/EPIC-005.reporting-visualization.md")
     user_guide = read("docs/user-guide/reports.md")
 

--- a/tests/tooling/test_personal_report_package_fixture_contract.py
+++ b/tests/tooling/test_personal_report_package_fixture_contract.py
@@ -103,13 +103,15 @@ def test_AC8_13_85_personal_package_macro_proof_is_promoted_after_fixture_contra
 
     proof = proofs["personal-financial-report-package-post-merge"]
     assert proof["issue"] == "#573"
+    # AC17.12.1-3 migrated to the portfolio package roadmap as
+    # AC-portfolio.fixtures.1-3 (migration closeout, #1663 / #1717).
     assert {
         "AC-testing.product-gates.8",
         "AC-testing.product-gates.9",
         "AC-testing.product-gates.10",
-        "AC17.12.1",
-        "AC17.12.2",
-        "AC17.12.3",
+        "AC-portfolio.fixtures.1",
+        "AC-portfolio.fixtures.2",
+        "AC-portfolio.fixtures.3",
     } <= set(proof["ac_ids"])
 
 

--- a/tests/tooling/test_portfolio_audit_fixture_contract.py
+++ b/tests/tooling/test_portfolio_audit_fixture_contract.py
@@ -13,7 +13,7 @@ def read(path: str) -> str:
 def test_AC17_12_1_portfolio_fixture_contract_covers_multi_broker_multi_currency_inputs() -> (
     None
 ):
-    """AC17.12.1: Portfolio fixture contract covers multi-broker, multi-currency audit inputs."""
+    """AC-portfolio.fixtures.1: AC17.12.1: Portfolio fixture contract covers multi-broker, multi-currency audit inputs."""
     fixture = PORTFOLIO_AUDIT_FIXTURE
 
     assert fixture.period_start.isoformat() == "2026-01-01"
@@ -55,7 +55,7 @@ def test_AC17_12_1_portfolio_fixture_contract_covers_multi_broker_multi_currency
 
 
 def test_AC17_12_2_portfolio_fixture_pins_activity_rows_without_raw_documents() -> None:
-    """AC17.12.2: Portfolio fixture pins sanitized trade, dividend, fee, and valuation activity rows."""
+    """AC-portfolio.fixtures.2: AC17.12.2: Portfolio fixture pins sanitized trade, dividend, fee, and valuation activity rows."""
     fixture = PORTFOLIO_AUDIT_FIXTURE
 
     assert all(
@@ -141,7 +141,7 @@ def test_AC17_12_2_portfolio_fixture_pins_activity_rows_without_raw_documents() 
 def test_AC17_12_3_personal_package_references_expanded_portfolio_fixture_contract() -> (
     None
 ):
-    """AC17.12.3: Personal package fixture consumes expanded portfolio expected outputs."""
+    """AC-portfolio.fixtures.3: AC17.12.3: Personal package fixture consumes expanded portfolio expected outputs."""
     personal_fixture = read("tools/_lib/fixtures/personal_report_package.py")
 
     assert "from tools._lib.fixtures.portfolio_audit_package import" in personal_fixture


### PR DESCRIPTION
## Summary

Migration closeout 2.10 + 2.11 (Batch-1 PR-C of umbrella #1416's compressed plan): distributes the remaining reporting-owned and portfolio-owned EPIC AC rows into their package `contract.py` roadmaps — 89 rows into `reporting` and 108 rows into `portfolio` — with per-AC atomic moves, docstring backfill, and pointer notes in the source EPICs.

Closes #1716
Closes #1717

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-005/008/011/017/018/019/022 (source tables) → `common/reporting/contract.py` + `common/portfolio/contract.py` roadmaps |
| **AC IDs** | `AC-reporting.*` (89 new: balance-sheet, income-statement, cash-flow, fx, errors, kpis, package-*, logic-audit, integration, trust-signals, csv-export, confidence, year-scale, income-typed, snapshots-typed, journeys, full-year, augmentation, net-worth-components, layer3, north-star, readiness, source-trust, source-anchors, lineage, provenance) · `AC-portfolio.*` (108 new: reconcile, router, depreciation, holdings, performance, allocation, valuation, api, as-of, report-schedule, logic-audit, fixtures, fact-boundary, pagination, typed-responses, metrics, schedule-fallback, provenance) |
| **AC source updated** | Owning package `contract.py` roadmaps; source EPIC rows deleted with pointer notes (dual gate enforced) |

### Row accounting (per issue)

**#1716 — reporting (89 records):**
- EPIC-005 → 61 (AC5.1–5.5, 5.6.4-5/.7-11, 5.8.1, 5.9.1-2, 5.10, 5.11.1/.3, 5.12.1-2/.4, 5.13.1-2/.4-5, 5.15, 5.16.1-2/.4, 5.17.1, 5.18, 5.19.1-3, 5.20, 5.32, 5.36)
- EPIC-008 → 8 (AC8.6.1-4, AC8.15.1-2, AC8.16.1-2)
- EPIC-011 → 2 (AC11.20.1-2)
- EPIC-018 → 7 (AC18.4.1-2/.4, AC18.12.1-4); **AC18.6.1 deduped** into existing `AC-reporting.ai.1` (was AC20.6.1), not re-added
- EPIC-019 → 8 (AC19.5.1-3/.6-7, AC19.7.1, AC19.9.1, AC19.10.1)
- EPIC-022 → 3 (AC22.3.3, AC22.7.1 backend half, AC22.13.1 reporting share)

**#1717 — portfolio (108 records):**
- EPIC-011 → 28 (AC11.1–11.7: the previously drafted reconcile/router/depreciation batch from `stash@{0}`, re-verified test-by-test against current `main`)
- EPIC-017 → 73 (AC17.1 remainder, 17.2, 17.3, 17.5 remainder, 17.6, 17.9.1-2, 17.10, 17.11, 17.12, 17.13, 17.30, 17.31); **3 dedupes**: AC17.2.6 (restated AC17.1.5 vs the same test), AC17.3.4/.6 (restated AC17.2.2/.3)
- EPIC-005 → 4 (AC5.6.1-3/.6 — portfolio-owned XIRR/TWR/MWR/dividend-yield math that lived in the reporting EPIC)
- EPIC-019 → 1 (AC19.8.8 portfolio share: mixed-currency schedule fallback)
- EPIC-022 → 2 (AC22.10.1 backend half, AC22.13.1 portfolio share; AC22.13.1 is now fully distributed across pricing/portfolio/reporting and its row removed)

### Conventions honored

- Per-AC atomic move: EPIC row deleted + `ACRecord` added in the same commit (`check_epic_package_dual` green).
- Every `test` field verified to resolve to a real function (197 refs checked by AST); every cited file verified to classify **CODE** under the authority classifier (both packages are `CODE-ONLY`).
- Dual-proof rows (AC5.6.4, AC5.8.1, AC5.16.1-2, AC5.17.1, AC17.9.3, AC19.8.8, AC22.7.1, AC22.10.1) migrate their backend half only; the frontend/readiness proof stays with the EPIC row per the issue bodies (the #1719 conventions own them later).
- Docstrings backfilled with the new ids (traceability gate requires the id string in a CI-run test file).
- `@ac_proof`/`ac_evidence` anchors repointed for fully-migrated ids (AC5.15.1, AC8.16.1-2, AC19.9.1, AC17.5.4, and the post-merge package journey list); the EPIC-008 critical-proof rows and the fixture-contract tooling test updated to match.
- `docs/ssot/ac-score-baseline.jsonl`: `AC8.16.1` renamed to `AC-reporting.augmentation.1` keeping its score (re-baselined without loss); tier baseline untouched (package ACs are tier-tagged by the package, deleted ids are inert baseline entries).
- #1717's #1643 caveat verified, not assumed: every EPIC-017 read-side row cites a live, CI-run test today, so the AC re-homing is safe; the physical read-side code move stays blocked on #1641/#1643 and is not attempted here.
- Conflict constraint honored: only the `roadmap` lists of `common/portfolio/contract.py` / `common/reporting/contract.py` were appended to; `interface`/`units` and other sections untouched.

---

## SSOT Changes

- [x] `docs/ssot/ac-score-baseline.jsonl` — renamed the `AC8.16.1` ratchet entry to `AC-reporting.augmentation.1` (same score/metric/provenance; no floor loss)
- [x] None otherwise — no `docs/ssot/*.md` concept changes; MANIFEST untouched

---

## TDD Evidence

Documentation/traceability migration — no new behavior, no new tests; every migrated AC re-points at its existing, already-green proving test (the gates verify resolution and CI-stage coverage). Red/green phases N/A per migration-closeout precedent (#1730, #1740, #1742).

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🟢 Green (gates) | `b06a0b4c` | reporting batch — dual/index/traceability/doc-consistency gates green |
| 🟢 Green (gates) | `fd1ec143` | portfolio batch — full preflight green |

---

## Engineering Audit

- [x] `sa.Enum` instances all have explicit `name="..._enum"` parameter (N/A — no schema changes)
- [x] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A)
- [x] `repo/` submodule updated for production config changes (N/A — submodule untouched)
- [x] `tools/check_env_keys.py` passes (N/A — no env vars changed)
- [x] `tools/check_manifest.py` passes
- [x] `tools/lint_doc_consistency.py` passes
- [x] No real financial data — all statements/tests reference synthetic fixtures only.

---

## Testing

```bash
apps/backend/.venv/bin/python tools/preflight.py
# gates: ac-traceability ok · ssot-ownership ok · doc-consistency ok ·
#        taxonomy-drift ok · tooling ok (2020 passed, 1 skipped)
apps/backend/.venv/bin/python tools/check_epic_package_dual.py   # PASSED
apps/backend/.venv/bin/python tools/check_ac_index.py            # INTEGRITY + PROTECTION PASSED (no floor regression)
apps/backend/.venv/bin/python tools/check_ac_proof_kind.py       # PASSED
apps/backend/.venv/bin/python tools/check_ac_tier_baseline.py    # PASSED (no new untagged debt)
apps/backend/.venv/bin/python tools/check_package_contract.py    # portfolio 116 / reporting 107 roadmap ACs — OK
apps/backend/.venv/bin/python tools/check_authority_reconcile.py # PASSED (all cited files classify CODE)
```

Local note: `preflight`'s `backend-format` step fails locally with 64 pre-existing `UP042` findings because the machine's PATH `ruff` is 0.15.17; the same command fails identically on an untouched `main` checkout, and the repo-pinned ruff (0.14.11 venv / 0.9.4 pre-commit) passes both `check` and `format --check` on this diff.

---

## Screenshots / Evidence

_N/A — docs/traceability migration; see gate output above._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
