### PR TITLE
[finance_report_vision] perf(#1767): P3 — parallelize tooling-coverage with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1069,13 +1069,19 @@ jobs:
         run: |
           mkdir -p coverage
           printf '[run]\nomit =\n    tests/tooling/*\n    common/__init__.py\n    common/**/__init__.py\n    tools/__init__.py\n    tools/**/__init__.py\n    tools/wait_for_cheap_ci.py\n    common/testing/wait_for_cheap_ci.py\n' > /tmp/tooling-coveragerc
-          uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with email-validator --with structlog --with sqlalchemy --with asyncpg --with fastapi --with httpx --with pdfplumber --with reportlab --with boto3 pytest tests/tooling/ \
+          # #1767: -n auto (pytest-xdist) parallelizes across the runner's cores;
+          # pytest-cov auto-combines each worker's coverage data at session end
+          # (no [tool.coverage.run] parallel=true needed -- verified locally: -n
+          # auto produced identical common.lcov/tools.lcov content to a serial
+          # run, just ~3.5x faster: 2022 tests in ~58s vs ~205s). This was the
+          # critical-path job (~451s of the ~510s main-push pipeline).
+          uv run --with pytest --with pytest-cov --with pytest-xdist --with pytest-asyncio --with anyio --with pyyaml --with pydantic --with pydantic-settings --with email-validator --with structlog --with sqlalchemy --with asyncpg --with fastapi --with httpx --with pdfplumber --with reportlab --with boto3 pytest tests/tooling/ \
             --cov=common \
             --cov=tools \
             --cov=apps/backend/src \
             --cov-config=/tmp/tooling-coveragerc \
             --cov-report= \
-            -x -q
+            -n auto -x -q
           COVERAGE_RCFILE=/tmp/tooling-coveragerc uv run --with coverage coverage lcov -o coverage/common.lcov --include='common/*'
           COVERAGE_RCFILE=/tmp/tooling-coveragerc uv run --with coverage coverage lcov -o coverage/tools.lcov --include='tools/*'
           # #1669 moved env_keys.py/schema_validation.py from common/config into


### PR DESCRIPTION
## Summary
Phase 3 of #1767's CI/CD audit remediation plan (independent of Phase 0/#1771 and Phase 2/#1773).

`Tooling/Common Coverage` was the main-push critical path — ~451s of the ~510s pipeline per the delivery audit — running `tests/tooling/`'s 2022 tests serially. `pytest-xdist` is already a pinned backend dependency and `pytest-cov` auto-combines each worker's coverage data at session end for a plain `--cov=` invocation (no `[tool.coverage.run] parallel = true` needed — that's a different config path used by the backend's own `pyproject.toml`-driven suite, not this bare `uv run --with X pytest` job).

Verified locally with the **exact** CI command (all three `--cov` targets, `-x`, plus `-n auto` added): 2022 passed, 1 skipped, ~58s vs ~205s serial (~3.5x on the test-execution portion; the job's remaining ~250s is checkout/uv-install/lcov-generation overhead that doesn't parallelize). `common.lcov` and `tools.lcov` content was identical between serial and parallel local runs — only wall clock changed.

## Test plan
- [x] Local: exact CI command + `-n auto` → 2022 passed, 1 skipped, 58s (vs 205s serial baseline, same command minus `-n auto`)
- [x] Local: `common.lcov` (14361 lines) / `tools.lcov` (4018 lines) content verified non-empty and consistent between serial and parallel runs
- [x] `tools/check_workflow_contract.py`, `tools/lint_doc_consistency.py`, `tools/check_manifest.py` → all OK
- [x] `tests/tooling/test_ci_metrics_contract.py` + the two `test_post_merge_e2e_gates.py` assertions referencing this job's step name → 116 passed (step name unchanged, only the command inside it)
- [ ] CI green on this PR — will report the real observed `Tooling/Common Coverage` job duration once this run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)