### PR TITLE
[finance_report_vision] fix(#1767): P4 — split sync schema tests out of the asyncio-marked router test module

### DIFF
--- a/apps/backend/tests/identity/test_user_schemas.py
+++ b/apps/backend/tests/identity/test_user_schemas.py
@@ -1,0 +1,39 @@
+"""AC-identity.1.3: User schema validation unit tests (no database, no event loop).
+
+Split out of test_users_router.py (#1767): that module carries a blanket
+`pytestmark = pytest.mark.asyncio` for its router tests, which was incorrectly
+also applying (and warning on) these synchronous schema-only tests -- a
+module-level pytestmark cannot be overridden per-class, only avoided by
+keeping sync tests out of an asyncio-marked module.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.user import UserCreate, UserUpdate
+
+
+class TestUserSchemas:
+    """Unit tests for user schemas without database."""
+
+    def test_user_create_schema_valid(self) -> None:
+        user = UserCreate(email="test@example.com", password="securepassword123")
+        assert user.email == "test@example.com"
+        assert user.password == "securepassword123"
+
+    def test_user_create_schema_invalid_email(self) -> None:
+        with pytest.raises(ValidationError):
+            UserCreate(email="not-an-email", password="securepassword123")
+
+    def test_user_create_schema_short_password(self) -> None:
+        with pytest.raises(ValidationError):
+            UserCreate(email="test@example.com", password="short")
+
+    def test_user_update_schema_optional_email(self) -> None:
+        update = UserUpdate()
+        assert update.email is None
+
+        update = UserUpdate(email="new@example.com")
+        assert update.email == "new@example.com"

--- a/apps/backend/tests/identity/test_users_router.py
+++ b/apps/backend/tests/identity/test_users_router.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.identity import User
 from src.identity.extension.api.users import get_user, update_user
-from src.schemas.user import UserCreate, UserUpdate
+from src.schemas.user import UserUpdate
 
 pytestmark = pytest.mark.asyncio
 
@@ -149,31 +149,3 @@ async def test_AC1_8_1_update_user_duplicate_email_rejected(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid update data"
-
-
-class TestUserSchemas:
-    """Unit tests for user schemas without database."""
-
-    def test_user_create_schema_valid(self) -> None:
-        user = UserCreate(email="test@example.com", password="securepassword123")
-        assert user.email == "test@example.com"
-        assert user.password == "securepassword123"
-
-    def test_user_create_schema_invalid_email(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            UserCreate(email="not-an-email", password="securepassword123")
-
-    def test_user_create_schema_short_password(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            UserCreate(email="test@example.com", password="short")
-
-    def test_user_update_schema_optional_email(self) -> None:
-        update = UserUpdate()
-        assert update.email is None
-
-        update = UserUpdate(email="new@example.com")
-        assert update.email == "new@example.com"


### PR DESCRIPTION
## Summary
Phase 4 of #1767's CI/CD audit remediation plan (hygiene, independent of Phases 0/2/3).

`tests/identity/test_users_router.py` carries a blanket `pytestmark = pytest.mark.asyncio` for its router tests, which was also incorrectly applying to `TestUserSchemas`' four synchronous Pydantic schema tests, producing a `PytestWarning` on every backend/tooling CI run.

A class-level `pytestmark` override does **not** suppress a module-level mark — verified empirically before shipping (pytest unions marks across module/class/function scope rather than letting a narrower scope cancel a broader one; my first attempt at this fix used exactly that override and I caught it was a no-op via an isolated repro before committing). The only correct fix is keeping sync tests out of an asyncio-marked module entirely.

Moved `TestUserSchemas` to its own `test_user_schemas.py` with no module-level mark; the router file's now-unused `UserCreate` import was dropped.

## Test plan
- [x] Isolated repro (`uv run --with pytest --with pytest-asyncio`, outside this repo's flaky local backend venv) with `-W error::pytest.PytestWarning`: both the async test in the marked module and the sync test in the new unmarked module pass with zero warnings
- [x] `python3 -m py_compile` on both changed files → syntax OK
- [x] `ruff check` / `ruff format --check` (pinned v0.9.4) → clean
- [x] `tools/check_ac_index.py` → PASSED (AC-identity.1.3 traceability intact, no dangling references after the move)
- [x] No other file references `TestUserSchemas` at its old location (grep-verified)
- [ ] CI green on this PR (this repo's actual CI environment, not my locally-flaky venv, is the real verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)