### PR TITLE
[finance_report_vision] fix(#1767): P1 — root-cause PDF fixture path drift (2 of 7 real staging failures)

### DIFF
--- a/common/testing/fixtures/pdf/generate_pdf_fixtures.py
+++ b/common/testing/fixtures/pdf/generate_pdf_fixtures.py
@@ -35,27 +35,8 @@ try:
         TableStyle,
     )
 except ImportError:
-    print(
-        "❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'."
-    )
+    print("❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'.")
     sys.exit(1)
-
-
-def default_output_dir() -> Path:
-    """Single source of truth for where generated fixtures land.
-
-    A function (not a module-level constant) so it re-reads ``__file__`` from
-    this module's namespace on every call, matching what ``main()`` already
-    did inline -- tests that sandbox output by monkeypatching this module's
-    ``__file__`` still redirect correctly. E2E tests that look up an
-    already-generated PDF (test_four_asset_net_worth_golden_path.py,
-    test_personal_financial_report_package.py) must call this rather than
-    recomputing their own path, or a future relocation of this module drifts
-    the two silently apart again (#1767: they still pointed at the pre-move
-    tools/_lib/pdf_fixtures/output/, which hasn't existed since this module's
-    relocation into common/testing/fixtures/pdf/).
-    """
-    return Path(__file__).parent / "output"
 
 
 def generate_legacy_dbs_pdf(output_path: Path):
@@ -118,9 +99,7 @@ def generate_legacy_dbs_pdf(output_path: Path):
     styles = getSampleStyleSheet()
 
     # Header
-    header_style = ParagraphStyle(
-        "Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12
-    )
+    header_style = ParagraphStyle("Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12)
     elements.append(Paragraph("DBS Bank - E-Statement", header_style))
     elements.append(Paragraph(f"Statement Period: {period_str}", styles["Normal"]))
     elements.append(Spacer(1, 20))
@@ -134,9 +113,7 @@ def generate_legacy_dbs_pdf(output_path: Path):
     txns = generate_transactions(start_date, count=15)
     data = [["Date", "Transaction Description", "Withdrawal", "Deposit", "Balance"]]
     for t in txns:
-        data.append(
-            [t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]]
-        )
+        data.append([t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]])
 
     # Table Styling
     t = Table(data, colWidths=[70, 200, 60, 60, 70])
@@ -173,7 +150,7 @@ def main():
         "--output",
         type=Path,
         default=None,
-        help="Directory to save PDFs (default: co-located output/ next to this script)",
+        help="Directory to save PDFs (default: pdf_fixtures/output/)",
     )
     parser.add_argument(
         "output_dir",
@@ -194,7 +171,10 @@ def main():
         return
 
     # New mode: use generators
-    output_dir = args.output if args.output is not None else default_output_dir()
+    output_dir = args.output
+    if output_dir is None:
+        # Default to pdf_fixtures/output/
+        output_dir = Path(__file__).parent / "output"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Import generators
@@ -207,9 +187,7 @@ def main():
         from .generators.pingan_generator import PinganGenerator
     except ImportError as e:
         print(f"❌ Error importing generators: {e}")
-        print(
-            "Make sure common.testing.fixtures.pdf is importable from the repository root."
-        )
+        print("Make sure common.testing.fixtures.pdf is importable from the repository root.")
         sys.exit(1)
 
     # Template paths

--- a/common/testing/fixtures/pdf/generate_pdf_fixtures.py
+++ b/common/testing/fixtures/pdf/generate_pdf_fixtures.py
@@ -35,8 +35,27 @@ try:
         TableStyle,
     )
 except ImportError:
-    print("❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'.")
+    print(
+        "❌ reportlab not installed. Please run 'uv sync' from the repository root or 'pip install reportlab'."
+    )
     sys.exit(1)
+
+
+def default_output_dir() -> Path:
+    """Single source of truth for where generated fixtures land.
+
+    A function (not a module-level constant) so it re-reads ``__file__`` from
+    this module's namespace on every call, matching what ``main()`` already
+    did inline -- tests that sandbox output by monkeypatching this module's
+    ``__file__`` still redirect correctly. E2E tests that look up an
+    already-generated PDF (test_four_asset_net_worth_golden_path.py,
+    test_personal_financial_report_package.py) must call this rather than
+    recomputing their own path, or a future relocation of this module drifts
+    the two silently apart again (#1767: they still pointed at the pre-move
+    tools/_lib/pdf_fixtures/output/, which hasn't existed since this module's
+    relocation into common/testing/fixtures/pdf/).
+    """
+    return Path(__file__).parent / "output"
 
 
 def generate_legacy_dbs_pdf(output_path: Path):
@@ -99,7 +118,9 @@ def generate_legacy_dbs_pdf(output_path: Path):
     styles = getSampleStyleSheet()
 
     # Header
-    header_style = ParagraphStyle("Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12)
+    header_style = ParagraphStyle(
+        "Header", parent=styles["Heading1"], fontSize=18, spaceAfter=12
+    )
     elements.append(Paragraph("DBS Bank - E-Statement", header_style))
     elements.append(Paragraph(f"Statement Period: {period_str}", styles["Normal"]))
     elements.append(Spacer(1, 20))
@@ -113,7 +134,9 @@ def generate_legacy_dbs_pdf(output_path: Path):
     txns = generate_transactions(start_date, count=15)
     data = [["Date", "Transaction Description", "Withdrawal", "Deposit", "Balance"]]
     for t in txns:
-        data.append([t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]])
+        data.append(
+            [t["date"], t["description"], t["withdrawal"], t["deposit"], t["balance"]]
+        )
 
     # Table Styling
     t = Table(data, colWidths=[70, 200, 60, 60, 70])
@@ -150,7 +173,7 @@ def main():
         "--output",
         type=Path,
         default=None,
-        help="Directory to save PDFs (default: pdf_fixtures/output/)",
+        help="Directory to save PDFs (default: co-located output/ next to this script)",
     )
     parser.add_argument(
         "output_dir",
@@ -171,10 +194,7 @@ def main():
         return
 
     # New mode: use generators
-    output_dir = args.output
-    if output_dir is None:
-        # Default to pdf_fixtures/output/
-        output_dir = Path(__file__).parent / "output"
+    output_dir = args.output if args.output is not None else default_output_dir()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Import generators
@@ -187,7 +207,9 @@ def main():
         from .generators.pingan_generator import PinganGenerator
     except ImportError as e:
         print(f"❌ Error importing generators: {e}")
-        print("Make sure common.testing.fixtures.pdf is importable from the repository root.")
+        print(
+            "Make sure common.testing.fixtures.pdf is importable from the repository root."
+        )
         sys.exit(1)
 
     # Template paths

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -84,8 +84,10 @@ def _write_bank_fixture(tmp_path: Path, report_date: date) -> Path:
 def _get_pdf_path(source: str) -> Path:
     from datetime import datetime
 
+    from common.testing.fixtures.pdf.generate_pdf_fixtures import default_output_dir
+
     root = Path(__file__).resolve().parents[2]
-    source_dir = root / "tools" / "_lib" / "pdf_fixtures" / "output" / source
+    source_dir = default_output_dir() / source
     yymm = datetime.now().strftime("%y%m")
     prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
     if prebuilt.exists():

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
-import subprocess
-import sys
 import tempfile
 import time
 import uuid
@@ -26,6 +24,7 @@ import pytest
 from common.testing import money_amount
 from common.testing.ac_proof import ac_proof
 from conftest import fail_or_skip_ai_ocr_gate
+from pdf_fixture_paths import generated_pdf_path
 from playwright.async_api import Page, expect
 
 APP_URL: str = os.getenv("APP_URL", "http://localhost:3000")
@@ -81,40 +80,6 @@ def _write_bank_fixture(tmp_path: Path, report_date: date) -> Path:
     return path
 
 
-def _get_pdf_path(source: str) -> Path:
-    from datetime import datetime
-
-    from common.testing.fixtures.pdf.generate_pdf_fixtures import default_output_dir
-
-    root = Path(__file__).resolve().parents[2]
-    source_dir = default_output_dir() / source
-    yymm = datetime.now().strftime("%y%m")
-    prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
-    if prebuilt.exists():
-        return prebuilt
-    if source_dir.exists():
-        pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf"))
-        if pdfs:
-            return pdfs[-1]
-
-    script = root / "tools" / "generate_pdf_fixtures.py"
-    result = subprocess.run(
-        [sys.executable, str(script), "--source", source],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        pytest.skip(
-            f"PDF fixture generation failed for {source}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-    pdfs = (
-        sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
-    )
-    if not pdfs:
-        pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
-    return pdfs[-1]
-
-
 def _unique_pdf_copy(src: Path) -> Path:
     suffix = int(time.time() * 1000) % 1_000_000
     tmp = Path(tempfile.mkdtemp())
@@ -166,7 +131,7 @@ async def _upload_brokerage_pdf(
     institution: str,
     model: str,
 ) -> str:
-    pdf_path = _unique_pdf_copy(_get_pdf_path(source))
+    pdf_path = _unique_pdf_copy(generated_pdf_path(source))
     with pdf_path.open("rb") as fh:
         response = await client.post(
             _api_url("/statements/upload"),

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -13,8 +13,6 @@ import asyncio
 import csv
 import os
 import shutil
-import subprocess
-import sys
 import tempfile
 from datetime import date
 from decimal import Decimal
@@ -29,6 +27,7 @@ import pytest
 from common.testing import money_amount
 from common.testing.ac_proof import ac_proof
 from conftest import fail_or_skip_ai_ocr_gate
+from pdf_fixture_paths import generated_pdf_path
 from playwright.async_api import Page, expect
 from tools._lib.fixtures.personal_report_package import REPRESENTATIVE_PACKAGE_FIXTURE
 
@@ -143,40 +142,6 @@ async def _default_image_model(client: httpx.AsyncClient) -> str:
     return payload.get("default_model") or payload["models"][0]["id"]
 
 
-def _get_pdf_path(source: str) -> Path:
-    from datetime import datetime
-
-    from common.testing.fixtures.pdf.generate_pdf_fixtures import default_output_dir
-
-    root = Path(__file__).resolve().parents[2]
-    source_dir = default_output_dir() / source
-    yymm = datetime.now().strftime("%y%m")
-    prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
-    if prebuilt.exists():
-        return prebuilt
-    if source_dir.exists():
-        pdfs = sorted(source_dir.glob(f"test_{source}_*.pdf"))
-        if pdfs:
-            return pdfs[-1]
-
-    script = root / "tools" / "generate_pdf_fixtures.py"
-    result = subprocess.run(
-        [sys.executable, str(script), "--source", source],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        pytest.skip(
-            f"PDF fixture generation failed for {source}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-    pdfs = (
-        sorted(source_dir.glob(f"test_{source}_*.pdf")) if source_dir.exists() else []
-    )
-    if not pdfs:
-        pytest.skip(f"PDF generation for {source} produced no files in {source_dir}")
-    return pdfs[-1]
-
-
 def _unique_pdf_copy(src: Path) -> Path:
     tmp = Path(tempfile.mkdtemp())
     suffix = int(time() * 1000) % 1_000_000
@@ -282,7 +247,7 @@ async def _upload_brokerage_pdf(
     institution: str,
     model: str,
 ) -> str:
-    pdf_path = _unique_pdf_copy(_get_pdf_path(source))
+    pdf_path = _unique_pdf_copy(generated_pdf_path(source))
     with pdf_path.open("rb") as fh:
         response = await client.post(
             _api_url("/statements/upload"),

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -146,8 +146,10 @@ async def _default_image_model(client: httpx.AsyncClient) -> str:
 def _get_pdf_path(source: str) -> Path:
     from datetime import datetime
 
+    from common.testing.fixtures.pdf.generate_pdf_fixtures import default_output_dir
+
     root = Path(__file__).resolve().parents[2]
-    source_dir = root / "tools" / "_lib" / "pdf_fixtures" / "output" / source
+    source_dir = default_output_dir() / source
     yymm = datetime.now().strftime("%y%m")
     prebuilt = source_dir / f"test_{source}_{yymm}.pdf"
     if prebuilt.exists():


### PR DESCRIPTION
## Summary
Phase 1 of #1767: root-caused the staging AI/OCR nightly regression by manually dispatching the fail-fast diagnostic entrance ([run 29180789998](https://github.com/wangzitian0/finance_report/actions/runs/29180789998), 27min, completed normally — not killed by timeout) now that Phase 0 (#1771, merged) preserves real tracebacks instead of a diagnostics-blind timeout.

**7 real failures found.** This PR fixes 2 of them; the other 5 are distinct root causes, each needing its own investigation, filed as follow-ups (see below) rather than bundled into one PR.

### Fixed here: PDF fixture path drift

`test_four_asset_as_of_net_worth_golden_path` and `test_personal_financial_report_package_post_merge_journey` both hardcode `_get_pdf_path()` looking in `tools/_lib/pdf_fixtures/output/` — a directory that **no longer exists at all** (confirmed: `tools/_lib/` has no `pdf_fixtures` subdirectory). The real generator (`common/testing/fixtures/pdf/generate_pdf_fixtures.py`, since its relocation out of `tools/_lib/`) writes to its own module-relative `output/` directory instead. The generator succeeds and writes real files; the test's own glob check looks in the wrong place, finds nothing, skips — and the `STRICT_E2E_GATES` critical-skip-to-failure conftest hook (AC8.13.6) converts that skip into a hard failure, **overwriting `report.longrepr` in the process** and destroying the original skip message. That's why this needed local reproduction rather than reading the run's own artifacts — the safety mechanism designed to make critical skips visible also happens to erase the reason they occurred.

**Fix**: extracted `default_output_dir()` as the generator module's single source of truth (a function, not a frozen constant — an existing test monkeypatches `__file__` for output-dir sandboxing, and a function re-reads it at call time so that still redirects correctly) and pointed both E2E test files at it instead of re-deriving their own stale copy of the same path — the exact class of duplicated-path drift #1435 tracks.

### Follow-ups (not fixed here, filed separately)

- FX rate data gap: CMB/Pingan institution journeys fail with HTTP 400 `"FX rate required to create CNY journal entry: No FX rate available for CNY/SGD on 2026-06-13/14"` at the approve step. Extraction succeeds; this is a downstream reconciliation/pricing data gap.
- Statement-status polling assumption: MariBank/GXS/DBS-full-journey all report `"never reached 'parsed' within 480000ms"` even though the *last polled payload* shows `status: 'approved'` with fully valid, balance-validated transactions — the shared `_wait_for_parsed_statement` pattern polls for an exact `'parsed'` value that the pipeline apparently transitions through too fast to observe before advancing to `'approved'`.

## Test plan
- [x] Local repro: confirmed `tools/_lib/pdf_fixtures/` doesn't exist; confirmed the real generator's default output path via `Path(__file__).parent / "output"`
- [x] End-to-end verify (clean E2E venv matching `tests/e2e/requirements.txt`, real subprocess call to the generator): before the fix, the test's glob found 0 files after a successful generation; after the fix, it correctly finds the generated PDF
- [x] `tests/tooling/test_pdf_fixture_tooling_coverage.py` (30 tests, including one that monkeypatches `__file__` for sandboxed output) — full pass, confirming the function-based (not constant) design preserves that isolation pattern
- [x] Full `tests/tooling/` suite: 2024 passed, 1 pre-existing skip
- [x] `tools/check_ac_index.py` → PASSED; `python -m common.testing.mirror_ratchet` → 2917 <= baseline
- [x] `ruff check` / `ruff format --check` (pinned v0.9.4) → clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)