### PR TITLE
[finance_report_vision] fix(#1780): statement status poll accepts auto-approved terminal state

### DIFF
--- a/tests/e2e/test_institution_statement_journeys.py
+++ b/tests/e2e/test_institution_statement_journeys.py
@@ -76,12 +76,16 @@ def _unique_pdf_copy(src: Path) -> Path:
 
 async def _default_image_model(client: httpx.AsyncClient) -> str:
     response = await client.get(_api_url("/llm/catalog?modality=image"))
-    assert response.status_code == 200, f"model catalog request failed: {response.status_code} {response.text}"
+    assert response.status_code == 200, (
+        f"model catalog request failed: {response.status_code} {response.text}"
+    )
     payload = response.json()
     return payload.get("default_model") or payload["models"][0]["id"]
 
 
-async def _upload_statement_pdf(client: httpx.AsyncClient, *, pdf_path: Path, institution: str, model: str) -> str:
+async def _upload_statement_pdf(
+    client: httpx.AsyncClient, *, pdf_path: Path, institution: str, model: str
+) -> str:
     with pdf_path.open("rb") as fh:
         response = await client.post(
             _api_url("/statements/upload"),
@@ -96,7 +100,17 @@ async def _upload_statement_pdf(client: httpx.AsyncClient, *, pdf_path: Path, in
     return str(statement_id)
 
 
-async def _wait_for_parsed(client: httpx.AsyncClient, statement_id: str, *, model: str) -> dict:
+async def _wait_for_parsed(
+    client: httpx.AsyncClient, statement_id: str, *, model: str
+) -> dict:
+    """Wait for the statement to reach a reviewable-or-further terminal state.
+
+    A high-confidence, balance-valid parse with a detected account skips
+    'parsed' entirely and lands directly on 'approved' (route_by_threshold,
+    #1780) -- this is intentional auto-post behavior (#1467), not a race, so
+    both states count as success. The caller must branch on which one it got:
+    an already-'approved' statement must not be posted again.
+    """
     deadline = asyncio.get_event_loop().time() + PARSING_TIMEOUT_MS / 1000
     last_payload: dict | None = None
     while asyncio.get_event_loop().time() < deadline:
@@ -112,12 +126,12 @@ async def _wait_for_parsed(client: httpx.AsyncClient, statement_id: str, *, mode
                 statement=last_payload,
                 model=model,
             )
-        if status == "parsed":
+        if status in ("parsed", "approved"):
             return last_payload
         await asyncio.sleep(5)
 
     pytest.fail(
-        f"statement {statement_id} never reached 'parsed' within {PARSING_TIMEOUT_MS}ms; last payload: {last_payload}"
+        f"statement {statement_id} never reached 'parsed' or 'approved' within {PARSING_TIMEOUT_MS}ms; last payload: {last_payload}"
     )
 
 
@@ -130,10 +144,15 @@ async def _run_institution_journey(
 ) -> dict:
     """Upload → parse → approve → balance sheet; returns the parsed payload."""
     headers = await _auth_headers(page)
-    async with httpx.AsyncClient(headers=headers, verify=False, timeout=120.0) as client:
+    async with httpx.AsyncClient(
+        headers=headers, verify=False, timeout=120.0
+    ) as client:
         model = await _default_image_model(client)
         statement_id = await _upload_statement_pdf(
-            client, pdf_path=_unique_pdf_copy(pdf_path), institution=institution, model=model
+            client,
+            pdf_path=_unique_pdf_copy(pdf_path),
+            institution=institution,
+            model=model,
         )
         parsed = await _wait_for_parsed(client, statement_id, model=model)
 
@@ -142,15 +161,28 @@ async def _run_institution_journey(
             f"{institution}: expected >= {min_transactions} extracted transactions, got {len(transactions)}"
         )
 
-        approve = await client.post(
-            _api_url(f"/statements/{statement_id}/review/approve"),
-            json={"create_account_if_missing": True},
-        )
-        assert approve.status_code == 200, f"{institution} approve failed: {approve.status_code} {approve.text}"
-        assert approve.json().get("journal_entries_created", 0) >= min_transactions
+        if parsed.get("status") == "approved":
+            # High-confidence auto-post (#1467) already approved and posted this
+            # statement before we ever observed 'parsed' (#1780) -- calling
+            # /review/approve again is safe (auto_create_posted_entries_for_
+            # statement is idempotent) but would report journal_entries_created=0
+            # since nothing new is left to post, which would fail the assertion
+            # below for no real reason. Nothing further to do here.
+            pass
+        else:
+            approve = await client.post(
+                _api_url(f"/statements/{statement_id}/review/approve"),
+                json={"create_account_if_missing": True},
+            )
+            assert approve.status_code == 200, (
+                f"{institution} approve failed: {approve.status_code} {approve.text}"
+            )
+            assert approve.json().get("journal_entries_created", 0) >= min_transactions
 
         report = await client.get(_api_url("/reports/balance-sheet"))
-        assert report.status_code == 200, f"{institution} balance sheet failed: {report.status_code} {report.text}"
+        assert report.status_code == 200, (
+            f"{institution} balance sheet failed: {report.status_code} {report.text}"
+        )
         assert report.json().get("is_balanced") is True
 
         return parsed
@@ -266,9 +298,13 @@ async def test_gxs_statement_journey_matches_expected_balances(
         min_transactions=expected_count,
     )
 
-    assert Decimal(str(parsed["opening_balance"])) == Decimal(expected_stmt["opening_balance"]), (
+    assert Decimal(str(parsed["opening_balance"])) == Decimal(
+        expected_stmt["opening_balance"]
+    ), (
         f"GXS opening balance drifted: {parsed['opening_balance']} != {expected_stmt['opening_balance']}"
     )
-    assert Decimal(str(parsed["closing_balance"])) == Decimal(expected_stmt["closing_balance"]), (
+    assert Decimal(str(parsed["closing_balance"])) == Decimal(
+        expected_stmt["closing_balance"]
+    ), (
         f"GXS closing balance drifted: {parsed['closing_balance']} != {expected_stmt['closing_balance']}"
     )

--- a/tests/e2e/test_institution_statement_journeys.py
+++ b/tests/e2e/test_institution_statement_journeys.py
@@ -111,9 +111,9 @@ async def _wait_for_parsed(
     both states count as success. The caller must branch on which one it got:
     an already-'approved' statement must not be posted again.
     """
-    deadline = asyncio.get_event_loop().time() + PARSING_TIMEOUT_MS / 1000
+    deadline = asyncio.get_running_loop().time() + PARSING_TIMEOUT_MS / 1000
     last_payload: dict | None = None
-    while asyncio.get_event_loop().time() < deadline:
+    while asyncio.get_running_loop().time() < deadline:
         response = await client.get(_api_url(f"/statements/{statement_id}"))
         assert response.status_code == 200, (
             f"statement poll failed for {statement_id}: {response.status_code} {response.text}"

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -105,6 +105,14 @@ async def _wait_for_parsed_statement(
     gate_name: str,
     require_transactions: bool = True,
 ) -> dict:
+    """Wait for the statement to reach a reviewable-or-further terminal state.
+
+    A high-confidence, balance-valid parse with a detected account skips
+    'parsed' entirely and lands directly on 'approved' (route_by_threshold,
+    #1780) -- this is intentional auto-post behavior (#1467), not a race, so
+    both states count as success. The caller must branch on which one it got:
+    an already-'approved' statement must not be posted again.
+    """
     deadline = asyncio.get_running_loop().time() + PARSING_TIMEOUT_MS / 1000
     last_payload: dict | None = None
     while asyncio.get_running_loop().time() < deadline:
@@ -119,7 +127,7 @@ async def _wait_for_parsed_statement(
                 f"{gate_name} gate rejected statement {statement_id}: {last_payload.get('validation_error')}",
                 statement=last_payload,
             )
-        if status == "parsed":
+        if status in ("parsed", "approved"):
             if require_transactions:
                 assert isinstance(last_payload.get("transactions"), list), (
                     f"parsed statement {statement_id} has no transactions payload"
@@ -374,15 +382,25 @@ async def test_personal_financial_report_package_post_merge_journey(
         )
         assert len(parsed_bank.get("transactions") or []) == expected.transaction_count
 
-        approve_response = await client.post(
-            _api_url(f"/statements/{bank_statement_id}/review/approve"),
-            json={"create_account_if_missing": True},
-        )
-        assert approve_response.status_code == 200, (
-            f"bank stage 1 approve failed: {approve_response.status_code} {approve_response.text}"
-        )
-        approve_payload = approve_response.json()
-        assert approve_payload["journal_entries_created"] == expected.transaction_count
+        if parsed_bank.get("status") != "approved":
+            # High-confidence auto-post (#1467) may already have approved and
+            # posted this statement before we ever observed 'parsed' (#1780).
+            # Calling /review/approve again is safe (idempotent posting) but
+            # would report journal_entries_created=0 with nothing left to
+            # post, which would fail the exact-count assertion below for no
+            # real reason. The journal-entries count check right after this
+            # still verifies the right entries exist either way.
+            approve_response = await client.post(
+                _api_url(f"/statements/{bank_statement_id}/review/approve"),
+                json={"create_account_if_missing": True},
+            )
+            assert approve_response.status_code == 200, (
+                f"bank stage 1 approve failed: {approve_response.status_code} {approve_response.text}"
+            )
+            approve_payload = approve_response.json()
+            assert (
+                approve_payload["journal_entries_created"] == expected.transaction_count
+            )
 
         journal_response = await client.get(_api_url("/journal-entries?limit=20"))
         assert journal_response.status_code == 200, (

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -165,9 +165,9 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     # This avoids waiting the full PARSING_TIMEOUT_MS when the AI service fails.
     import asyncio
 
-    deadline = asyncio.get_event_loop().time() + PARSING_TIMEOUT_MS / 1000
+    deadline = asyncio.get_running_loop().time() + PARSING_TIMEOUT_MS / 1000
     last_statement: dict | None = None
-    while asyncio.get_event_loop().time() < deadline:
+    while asyncio.get_running_loop().time() < deadline:
         api_resp = await page.request.get(
             _get_url(f"/api/statements/{statement_id}"),
         )

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -107,26 +107,36 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     await page.wait_for_load_state("domcontentloaded")
 
     if "/login" in page.url:
-        pytest.fail(f"Redirected to /login despite authenticated_page fixture. URL: {page.url}")
+        pytest.fail(
+            f"Redirected to /login despite authenticated_page fixture. URL: {page.url}"
+        )
 
-    await page.locator('[data-testid="uploader-institution-statement"]').fill(INSTITUTION_LABEL)
+    await page.locator('[data-testid="uploader-institution-statement"]').fill(
+        INSTITUTION_LABEL
+    )
     # Fetch the default model from the backend API and select it explicitly.
     # Selecting by value ensures we always use the backend-configured OCR model.
     models_resp = await page.evaluate(
         "async () => { const r = await fetch('/api/llm/catalog?modality=image'); return r.json(); }"
     )
-    default_model: str = models_resp.get("default_model") or models_resp["models"][0]["id"]
+    default_model: str = (
+        models_resp.get("default_model") or models_resp["models"][0]["id"]
+    )
     model_select = page.locator('[data-testid="uploader-model-statement"]')
     await expect(model_select).to_be_visible(timeout=15_000)
     await expect(model_select).not_to_have_value("", timeout=15_000)
     await model_select.select_option(value=default_model)
     await page.set_input_files('[data-testid="uploader-file-statement"]', str(pdf_path))
-    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(timeout=5_000)
+    await expect(page.locator("p.font-medium", has_text=pdf_path.name)).to_be_visible(
+        timeout=5_000
+    )
 
-    async with page.expect_response(
-        lambda r: "/api/statements/upload" in r.url,
-        timeout=120_000,  # Upload + AI model validation may take up to 120s on cold-start
-    ) as resp_info:
+    async with (
+        page.expect_response(
+            lambda r: "/api/statements/upload" in r.url,
+            timeout=120_000,  # Upload + AI model validation may take up to 120s on cold-start
+        ) as resp_info
+    ):
         await page.get_by_role("button", name="Upload & Parse Statement").click()
     upload_resp = await resp_info.value
     assert upload_resp.status in (200, 201, 202), (
@@ -142,7 +152,12 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     await expect(statement_row).to_be_visible(timeout=15_000)
 
     parsed_badge = statement_row.locator("span.badge", has_text=PARSED_STATUS_BADGE_RE)
-    rejected_badge = statement_row.locator("span.badge", has_text=re.compile(r"^Rejected$", re.I))
+    approved_badge = statement_row.locator(
+        "span.badge", has_text=re.compile(r"^Approved$", re.I)
+    )
+    rejected_badge = statement_row.locator(
+        "span.badge", has_text=re.compile(r"^Rejected$", re.I)
+    )
     # Poll the statement API by ID until parsed, but fail fast with the stored
     # validation error if the AI/OCR provider rejects parsing.
     # This avoids waiting the full PARSING_TIMEOUT_MS when the AI service fails.
@@ -158,22 +173,36 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
             f"GET /api/statements/{statement_id} returned {api_resp.status} — response body: {await api_resp.text()}"
         )
         last_statement = await api_resp.json()
-        if last_statement.get("status") == "rejected" or await rejected_badge.is_visible():
+        if (
+            last_statement.get("status") == "rejected"
+            or await rejected_badge.is_visible()
+        ):
             fail_or_skip_ai_ocr_gate(
                 "Statement parsing failed (status=rejected) — AI service may be "
                 "unavailable or misconfigured on the test environment.",
                 statement=last_statement,
                 model=default_model,
             )
-        if last_statement.get("status") == "parsed":
+        # A high-confidence, balance-valid parse with a detected account skips
+        # 'parsed' entirely and auto-posts straight to 'approved'
+        # (route_by_threshold + #1467 auto-account-create, #1780) -- both
+        # states are success; the review section below branches on which one
+        # actually happened.
+        status = last_statement.get("status")
+        if status == "parsed":
             await expect(parsed_badge).to_be_visible(timeout=15_000)
+            break
+        if status == "approved":
+            await expect(approved_badge).to_be_visible(timeout=15_000)
             break
         await page.wait_for_timeout(3_000)
     else:
         pytest.fail(
-            f"Statement never reached 'parsed' status within {PARSING_TIMEOUT_MS}ms. "
+            f"Statement never reached 'parsed' or 'approved' status within {PARSING_TIMEOUT_MS}ms. "
             f"Last statement payload: {last_statement}"
         )
+
+    already_approved = last_statement.get("status") == "approved"
 
     # === AC8.13.3: Detail page shows transactions ===
     await page.goto(_get_url(f"/statements/{statement_id}"))
@@ -181,32 +210,52 @@ async def test_dbs_statement_full_journey(authenticated_page_unique: Page) -> No
     # waits can resolve before the Next.js router commits the URL change.
     await expect(page).to_have_url(re.compile(r"/statements/[^/]+$"), timeout=15_000)
 
-    await expect(page.get_by_text("Transactions", exact=False)).to_be_visible(timeout=10_000)
+    await expect(page.get_by_text("Transactions", exact=False)).to_be_visible(
+        timeout=10_000
+    )
     await expect(page.locator("table tbody tr").first).to_be_visible(timeout=10_000)
 
-    # === AC8.13.4: Start Review → approve via ConfirmDialog ===
-    await page.get_by_role("link", name=re.compile("Start Review")).click()
-    await expect(page).to_have_url(re.compile(r"/statements/[^/]+/review$"), timeout=15_000)
-    await page.get_by_role("button", name="Approve").click()
-    dialog = page.locator('[role="dialog"]')
-    await expect(dialog).to_be_visible(timeout=5_000)
-    confirm_button = dialog.get_by_role("button", name="Approve")
-    await expect(confirm_button).to_be_visible(timeout=3_000)
-    await confirm_button.click()
-    await expect(page).to_have_url(re.compile(r"/statements/[^/?]+(?:\?.*)?$"), timeout=15_000)
-    await expect(page.locator("span.badge", has_text="approved")).to_be_visible(timeout=15_000)
+    if already_approved:
+        # Auto-posted before we ever observed 'parsed' -- nothing left to
+        # review/approve through the UI; just confirm the detail page already
+        # reflects the approved state.
+        await expect(page.locator("span.badge", has_text="approved")).to_be_visible(
+            timeout=15_000
+        )
+    else:
+        # === AC8.13.4: Start Review → approve via ConfirmDialog ===
+        await page.get_by_role("link", name=re.compile("Start Review")).click()
+        await expect(page).to_have_url(
+            re.compile(r"/statements/[^/]+/review$"), timeout=15_000
+        )
+        await page.get_by_role("button", name="Approve").click()
+        dialog = page.locator('[role="dialog"]')
+        await expect(dialog).to_be_visible(timeout=5_000)
+        confirm_button = dialog.get_by_role("button", name="Approve")
+        await expect(confirm_button).to_be_visible(timeout=3_000)
+        await confirm_button.click()
+        await expect(page).to_have_url(
+            re.compile(r"/statements/[^/?]+(?:\?.*)?$"), timeout=15_000
+        )
+        await expect(page.locator("span.badge", has_text="approved")).to_be_visible(
+            timeout=15_000
+        )
 
     await page.goto(_get_url("/upload"))
     await expect(page).to_have_url(re.compile(r"/upload$"), timeout=15_000)
     approved_row = _statement_row(page, INSTITUTION_LABEL)
     await expect(approved_row).to_be_visible(timeout=15_000)
-    await expect(approved_row.locator("span.badge", has_text=re.compile(r"^Approved$", re.I))).to_be_visible(
-        timeout=15_000
-    )
+    await expect(
+        approved_row.locator("span.badge", has_text=re.compile(r"^Approved$", re.I))
+    ).to_be_visible(timeout=15_000)
 
     # === AC8.13.5: Balance sheet report loads ===
     await page.goto(_get_url("/reports/balance-sheet"))
     await page.wait_for_load_state("domcontentloaded")
 
-    await expect(page.get_by_text("Balance Sheet", exact=False).first).to_be_visible(timeout=10_000)
-    await expect(page.get_by_text("Assets", exact=False).first).to_be_visible(timeout=10_000)
+    await expect(page.get_by_text("Balance Sheet", exact=False).first).to_be_visible(
+        timeout=10_000
+    )
+    await expect(page.get_by_text("Assets", exact=False).first).to_be_visible(
+        timeout=10_000
+    )

--- a/tests/e2e/test_statement_full_journey.py
+++ b/tests/e2e/test_statement_full_journey.py
@@ -40,7 +40,9 @@ def _statement_row(page: Page, institution: str):
     return page.locator(".relative.block").filter(has_text=institution).first
 
 
-def test_parsed_status_badge_pattern_accepts_user_facing_ready_to_review_label() -> None:
+def test_parsed_status_badge_pattern_accepts_user_facing_ready_to_review_label() -> (
+    None
+):
     """EPIC-003 EPIC-004 EPIC-008 EPIC-013 EPIC-016 EPIC-018.
 
     Parsed upload rows may use the user-facing review label.


### PR DESCRIPTION
## Summary
Fixes #1780, one of the two issues filed while root-causing the #1767 staging AI/OCR regression.

Three E2E tests (MariBank, GXS, DBS full journey) intermittently fail with `"never reached 'parsed' within 480000ms"` even though the poll's own last-captured payload already shows `status: 'approved'`, `balance_validated: True`, and a complete, correct transactions list — **the pipeline succeeds; only the test's poll assumption is stale.**

**Root cause (confirmed by code investigation, not just symptom):** `route_by_threshold` (`apps/backend/src/extraction/base/validation.py:513-537`) routes a high-confidence, balance-valid parse with a detected account straight to `APPROVED`, skipping `PARSED` entirely — no polling interval, however tight, could observe an intermediate state that's never written. This is intentional behavior introduced by #1467 ("auto-create+link the physical bank account so high-confidence statements auto-post," merged 2026-06-27): before that change, a first-ever statement upload always had `account_id=None`, which forced a `PARSED`-only safety valve (`service.py:624-625`); #1467 auto-creates the account *before* routing runs, so that valve no longer fires for real bank-statement layouts. Not a regression to revert — a stale test assumption to widen.

## Changes
Widened all three duplicated `_wait_for_parsed*` poll helpers to accept `'approved'` as a terminal success alongside `'parsed'`, and made each caller branch on which one it actually got:
- **Institution journeys / personal report package** (HTTP `/review/approve`): skip the redundant approve call when already approved. Posting is idempotent (`auto_create_posted_entries_for_statement` filters out already-posted transactions, verified by reading the function) but a second call reports `journal_entries_created=0`, which would fail the `>=`/`==` count assertions for no real reason.
- **DBS full journey** (Playwright UI click-through): skip the "Start Review → Approve → confirm dialog" flow entirely when already approved and assert the "Approved" badge directly — there's nothing left to review.

Brokerage PDF imports in `test_personal_financial_report_package.py` are unaffected and untouched: brokerage payloads are always forced to `PARSED` (`service.py:621-622`), never auto-approved, confirmed by reading the code path.

## Test plan
- [x] `python3 -m py_compile` on all three files → syntax OK
- [x] `ruff check` / `ruff format --check` (pinned v0.9.4) → clean
- [x] `tools/check_ac_index.py` → PASSED
- [x] Root cause traced end-to-end in the actual backend source (routing logic, idempotent posting guard, git blame on the behavior change) before writing the fix — not inferred from the test failure alone
- [ ] CI green on this PR
- [ ] Real staging verification: staging is currently on `v0.1.33`, which predates this fix — the next staging deploy + audit-replay run (nightly or manual, with an explicit `version_ref` matching the new deploy) will be the first live confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)