### PR TITLE
[finance_report_ui] fix(P0): PR review-thread merge gate never actually blocked Copilot comments

### DIFF
--- a/common/testing/check_pr_review_threads.py
+++ b/common/testing/check_pr_review_threads.py
@@ -44,11 +44,18 @@ from typing import Any
 
 # Authors whose review threads are treated as blocking by default. GitHub has
 # spelled the Copilot reviewer login differently over time; cover the known
-# variants (compared case-insensitively).
+# variants (compared case-insensitively). "copilot-pull-request-reviewer"
+# (no "[bot]" suffix) is the actual login the GraphQL reviewThreads API
+# returns today (confirmed 2026-07-12 against real threads on #1776/#1782/
+# #1786) -- the "[bot]"-suffixed form was never observed in the wild and this
+# gate silently misclassified every real Copilot thread as non-blocking
+# until this was added. Kept both forms since REST/GraphQL or a future
+# GitHub-side change could plausibly use either.
 COPILOT_AUTHORS: frozenset[str] = frozenset(
     {
         "copilot",
         "github-copilot[bot]",
+        "copilot-pull-request-reviewer",
         "copilot-pull-request-reviewer[bot]",
     }
 )
@@ -157,7 +164,9 @@ def _wrap_nodes(nodes: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _graphql_page(owner: str, name: str, pr_number: int, after: str | None) -> dict[str, Any]:
+def _graphql_page(
+    owner: str, name: str, pr_number: int, after: str | None
+) -> dict[str, Any]:
     """Run one `gh api graphql` page request and return the parsed JSON."""
     cmd = [
         "gh",
@@ -255,7 +264,9 @@ def run(
     for thread in lower_unresolved:
         body = (_first_comment(thread).get("body") or "").strip().splitlines()
         snippet = body[0] if body else ""
-        print(f"  [report] lower-severity unresolved: {_thread_url(thread)} :: {snippet}")
+        print(
+            f"  [report] lower-severity unresolved: {_thread_url(thread)} :: {snippet}"
+        )
 
     if blocking:
         print(

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -705,6 +705,23 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-testing.review-threads.4",
+            statement=(
+                "A Copilot thread classifies as blocking using the real "
+                "author.login the GraphQL reviewThreads API actually returns "
+                '("copilot-pull-request-reviewer", no "[bot]" suffix) -- '
+                'not only a synthetic "[bot]"-suffixed fixture value '
+                "(2026-07-12 regression: this mismatch let every real "
+                "Copilot thread silently classify as non-blocking)."
+            ),
+            test=(
+                "tests/tooling/test_check_pr_review_threads.py"
+                "::test_copilot_thread_real_login_without_bot_suffix_is_blocking"
+            ),
+            priority="P0",
+            status="done",
+        ),
         # ── group seeded-journey: seeded no-LLM statement journey (was
         # EPIC-008 AC8.21), migration closeout, #1663 / #1718 ──
         ACRecord(

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -409,8 +409,10 @@ For each review thread the gate inspects the **first comment**:
     (case-insensitive), OR
   - the first comment is **Copilot-authored** (`author.login` in
     `copilot`, `github-copilot[bot]`,
-    `copilot-pull-request-reviewer[bot]`) AND the body is **not** explicitly
-    marked a lower severity (it does not contain `P2`, `P3`, or `nit`).
+    `copilot-pull-request-reviewer` — the actual login the GraphQL API
+    returns today, no `[bot]` suffix — or `copilot-pull-request-reviewer[bot]`)
+    AND the body is **not** explicitly marked a lower severity (it does not
+    contain `P2`, `P3`, or `nit`).
 - Every other thread is **lower severity**.
 
 ### Decision

--- a/tests/tooling/test_check_pr_review_threads.py
+++ b/tests/tooling/test_check_pr_review_threads.py
@@ -97,16 +97,31 @@ class TestClassifyThread:
         thread = _thread(author="copilot-pull-request-reviewer[bot]", body="suggestion")
         assert gate.classify_thread(thread) == gate.Severity.BLOCKING
 
+    def test_copilot_thread_real_login_without_bot_suffix_is_blocking(self) -> None:
+        """AC-testing.review-threads.4: regression (2026-07-12) -- the GraphQL
+        reviewThreads API returns author.login as
+        "copilot-pull-request-reviewer" with NO "[bot]" suffix, confirmed
+        against real threads on #1776/#1782/#1786. The allowlist only had the
+        "[bot]"-suffixed form, so every real Copilot thread silently
+        classified as non-blocking and this gate never actually blocked a
+        Copilot-flagged issue in practice."""
+        thread = _thread(author="copilot-pull-request-reviewer", body="suggestion")
+        assert gate.classify_thread(thread) == gate.Severity.BLOCKING
+
     def test_copilot_alias_github_copilot_bot_is_blocking(self) -> None:
         thread = _thread(author="github-copilot[bot]", body="consider this")
         assert gate.classify_thread(thread) == gate.Severity.BLOCKING
 
     def test_copilot_thread_marked_nit_is_not_blocking(self) -> None:
-        thread = _thread(author="copilot-pull-request-reviewer[bot]", body="nit: rename var")
+        thread = _thread(
+            author="copilot-pull-request-reviewer[bot]", body="nit: rename var"
+        )
         assert gate.classify_thread(thread) == gate.Severity.LOWER
 
     def test_copilot_thread_marked_p2_is_not_blocking(self) -> None:
-        thread = _thread(author="copilot-pull-request-reviewer[bot]", body="P2: minor style")
+        thread = _thread(
+            author="copilot-pull-request-reviewer[bot]", body="P2: minor style"
+        )
         assert gate.classify_thread(thread) == gate.Severity.LOWER
 
     def test_plain_human_nit_is_lower(self) -> None:
@@ -131,10 +146,14 @@ class TestBlocking:
 
     def test_AC8_20_1_unresolved_copilot_blocks(self) -> None:
         """AC8.20.1: an unresolved Copilot review thread exits 1."""
-        payload = _payload(_thread(author="copilot-pull-request-reviewer[bot]", is_resolved=False))
+        payload = _payload(
+            _thread(author="copilot-pull-request-reviewer[bot]", is_resolved=False)
+        )
         assert _run(payload) == 1
 
-    def test_AC8_20_1_blocking_thread_url_is_printed(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_AC8_20_1_blocking_thread_url_is_printed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """AC8.20.1: the blocking thread's url is named in the summary."""
         url = "https://github.com/o/r/pull/1#discussion_r999"
         payload = _payload(_thread(body="P1: bug", url=url, is_resolved=False))
@@ -156,10 +175,14 @@ class TestNonBlocking:
 
     def test_AC8_20_2_outdated_p0_passes(self) -> None:
         """AC8.20.2: an outdated (unresolved) P0 thread does not block."""
-        payload = _payload(_thread(body="P0: stale", is_resolved=False, is_outdated=True))
+        payload = _payload(
+            _thread(body="P0: stale", is_resolved=False, is_outdated=True)
+        )
         assert _run(payload) == 0
 
-    def test_AC8_20_2_unresolved_nit_passes_but_reported(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_AC8_20_2_unresolved_nit_passes_but_reported(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """AC8.20.2: an unresolved nit does not block but is reported."""
         payload = _payload(_thread(body="nit: rename", is_resolved=False))
         assert _run(payload) == 0
@@ -216,16 +239,22 @@ class TestSeamAndSafety:
 
 
 class TestMain:
-    def test_main_skips_without_pr_number(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_main_skips_without_pr_number(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("PR_NUMBER", raising=False)
         assert gate.main(["--repo", "o/r"]) == 0
 
-    def test_main_blocks_with_injected_blocking_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_main_blocks_with_injected_blocking_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         payload = _payload(_thread(body="P0: bug", is_resolved=False))
         monkeypatch.setattr(gate, "fetch_threads", lambda pr_number, repo: payload)
         assert gate.main(["--repo", "o/r", "--pr-number", "1"]) == 1
 
-    def test_main_fails_closed_when_pr_present_but_repo_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_main_fails_closed_when_pr_present_but_repo_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A PR number with no resolvable repo is a misconfig — fail closed (1)."""
         monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
         called = False
@@ -272,7 +301,9 @@ def _page(nodes: list[dict[str, Any]], *, has_next: bool, cursor: str | None) ->
 
 
 class TestFetchPagination:
-    def test_fetch_threads_follows_all_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_fetch_threads_follows_all_pages(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """fetch_threads concatenates every page until hasNextPage is false."""
         pages = [
             _page([_thread(body="t1")], has_next=True, cursor="c1"),
@@ -294,7 +325,9 @@ class TestFetchPagination:
         assert any("after=c1" in part for part in calls[1])
         assert any("after=c2" in part for part in calls[2])
 
-    def test_fetch_threads_fails_closed_when_cursor_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_fetch_threads_fails_closed_when_cursor_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """hasNextPage true but no endCursor must raise (never silently drop)."""
         page = _page([_thread(body="t1")], has_next=True, cursor=None)
         monkeypatch.setattr(gate.subprocess, "run", lambda cmd, **kw: page)


### PR DESCRIPTION
## Summary

**P0 — live bug, not scoped to any single PR.** The "PR Review Thread Merge Gate" CI step has never actually blocked a merge on an unresolved Copilot review comment, since the day it was added. Discovered while auditing #1776 and #1782 (both merged with unresolved Copilot comments the gate should have caught) — traced to the gate's own author-matching logic, not to those PRs specifically. A third, unrelated open PR (#1786) is currently affected by the same bug right now.

Closes nothing directly — this is a merge-gate/tooling fix, found via a user-requested audit of already-merged PRs, not tied to a single issue.

---

## Root cause

`COPILOT_AUTHORS` in `common/testing/check_pr_review_threads.py` only listed the `"[bot]"`-suffixed login form:

```python
COPILOT_AUTHORS = {"copilot", "github-copilot[bot]", "copilot-pull-request-reviewer[bot]"}
```

But the GitHub GraphQL `reviewThreads` API actually returns the author login as `"copilot-pull-request-reviewer"` — **no `[bot]` suffix** — confirmed directly against real data on #1776, #1782, and #1786:

```json
{"author": {"login": "copilot-pull-request-reviewer"}, ...}
```

`author in COPILOT_AUTHORS` was therefore always `False` for a real Copilot comment, so every real Copilot thread fell through to `Severity.LOWER` (reported, non-blocking) instead of `Severity.BLOCKING`. Verified in the actual CI log for #1776's final run:

```
PR review thread gate (PR #1776, wangzitian0/finance_report): 3 thread(s); 0 unresolved blocking (P0/P1), 3 unresolved lower-severity (reported, non-blocking).
PR review thread gate OK: no unresolved P0/P1 review threads.
```

The test suite's own fixtures (`tests/tooling/test_check_pr_review_threads.py`) all used the same wrong `"[bot]"`-suffixed string, so nothing was ever validated against GitHub's real, actual format — a synthetic-fixture blind spot.

## Fix

Added the real login string to the allowlist (kept the `[bot]` variant too — GitHub's exact format isn't guaranteed stable, and REST vs GraphQL could plausibly differ). New regression test uses the exact real author string and would fail against the old allowlist.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | Was EPIC-008 AC8.20 (migrated to `common/testing/contract.py`) |
| **AC IDs** | AC-testing.review-threads.4 (new) |
| **AC source updated** | `common/testing/contract.py` |

---

## TDD Evidence

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴/🟢 | `8df9b3c0` | `test_copilot_thread_real_login_without_bot_suffix_is_blocking` — fails against the pre-fix allowlist, passes after |

---

## Engineering Audit

- [x] No `sa.Enum`, env var, or submodule changes
- [x] No real financial data

### CI/CD, Runtime, and VPS Infra Audit

- [x] No workflow files touched — only the gate's Python logic, its SSOT doc, and its test.

---

## Testing

```bash
uv run --with pytest --with pytest-cov --with pytest-asyncio --with anyio --with pyyaml \
  --with pydantic --with pydantic-settings --with email-validator --with structlog \
  --with sqlalchemy --with asyncpg --with fastapi --with httpx --with pdfplumber \
  --with reportlab --with boto3 \
  pytest tests/tooling/ -q --no-header -p no:cacheprovider
# 2041 passed, 1 skipped
```

Also caught and fixed along the way: my first attempt at this AC used a `file::Class::method` test reference, which broke the package-contract gate across ~14 unrelated package tests (they share a common cross-package validator) — the correct convention here is `file::method_name` even for class-nested tests. Second miss: the new test's docstring needed the literal `AC-testing.review-threads.4:` marker for the separate AC-traceability gate. Both caught by the local full-suite sweep before push, not left for CI to find.

---

## Screenshots / Evidence

_N/A — merge-gate tooling fix, verified via behavioral unit tests against real GraphQL data shape._

🤖 Generated with [Claude Code](https://claude.com/claude-code)