### PR TITLE
[finance_report_ui] docs: refresh stale CI performance metrics in ci-cd.md

### DIFF
--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -798,8 +798,8 @@ wider coverage scope) regressed the 2026-06-20 ~4m 46s baseline to **~8.5 min** 
   did, so a hang would have run to GitHub's 6h default before failing.
 - The nightly `AI/OCR Audit Replay` gate (`audit-replay.yml`) was red for 5 consecutive nights
   (2026-07-07 through 2026-07-11) with its own alerting destroyed by the same timeout that killed
-  the run (#1767 F1-F4) — fixed in #1767 Phase 0/1; 3 consecutive green nights confirmed since
-  (runs `29181331505`, `29182352126`, `29202152047`).
+  the run (#1767 F1-F4) — fixed in #1767 Phase 0/1; 3 consecutive green nights confirmed since the
+  fix (runs `29181331505`, `29182352126`, `29202152047`).
 
 **Post-merge staging (2026-05-20 observed baseline):**
 - Build and deploy job execution: **~5m 19s**.

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -786,6 +786,21 @@ SSOT edits: [DELIVERY_ENGINE_RECOMMENDATIONS.md](../project/DELIVERY_ENGINE_RECO
 - Phase 2b corrects the backend fast path to 5 seeded shards using `apps/backend/ci/backend-test-durations.json`. Main CI run `27896401849` after PR #1288 completed successfully in about 4m 46s; backend shards finished in the 3m 31s-3m 50s band, frontend split gates stayed below the backend tail, unified coverage took 27s, and AC behavioral ratchet took 25s.
 - `unified-coverage` runs repo-local stdlib Python scripts directly, and `ac-behavioral-ratchet` downloads only JUnit-producing test-context artifacts.
 
+**CI Pipeline (#1767 remediation, 2026-07-12/13 observed baseline):** organic growth (more tests,
+wider coverage scope) regressed the 2026-06-20 ~4m 46s baseline to **~8.5 min** by 2026-07-12
+(#1767 F6) before any single change was to blame. #1767 Phase 3 (#1774, merged) parallelized the
+`tooling-coverage` job with `pytest-xdist`: that job alone dropped from ~451s to ~249s.
+- 16 successful main-push runs sampled after #1774 merged: **mean 5.8 min, median 6.0 min**
+  (range 2.7 min-7.3 min; the 2.7 min low end is the lightweight docs-only path that skips
+  backend/frontend/coverage). Independently measured from `gh run list` timestamps, not just the
+  single-run snapshot #1774's own PR cited.
+- Every `ci.yml` job now carries an explicit `timeout-minutes` (#1773, Phase 2) — previously none
+  did, so a hang would have run to GitHub's 6h default before failing.
+- The nightly `AI/OCR Audit Replay` gate (`audit-replay.yml`) was red for 5 consecutive nights
+  (2026-07-07 through 2026-07-11) with its own alerting destroyed by the same timeout that killed
+  the run (#1767 F1-F4) — fixed in #1767 Phase 0/1; 3 consecutive green nights confirmed since
+  (runs `29181331505`, `29182352126`, `29202152047`).
+
 **Post-merge staging (2026-05-20 observed baseline):**
 - Build and deploy job execution: **~5m 19s**.
 - Automatic AI/OCR gate execution: **~4m 38s**.


### PR DESCRIPTION
## Summary

Found while doing an SRE-lens review of overall CI health: `docs/ssot/ci-cd.md`'s "Current Performance Metrics" section's newest entry was dated 2026-06-20 (~4m 46s) — 3+ weeks stale. Main-push CI had organically regressed to ~8.5min by 2026-07-12 (per #1767's own audit, finding F6), then #1774 (Phase 3 of that audit) parallelized `tooling-coverage` and brought it back down — but the doc never got a follow-up entry reflecting either the regression or the fix.

Closes nothing — pure doc-accuracy fix found during review, not tied to a tracked issue.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | N/A — doc-accuracy fix, no behavior change |
| **AC IDs** | N/A |
| **AC source updated** | N/A |

---

## SSOT Changes

- [x] `docs/ssot/ci-cd.md` — added a dated 2026-07-12/13 "Current Performance Metrics" entry

---

## What changed

Added a new dated entry documenting:
- The organic regression (~4m 46s → ~8.5min) and #1774's fix.
- **Independently re-measured** numbers, not just re-citing #1774's own single-run snapshot: 16 successful main-push runs sampled via `gh run list` after #1774 merged — mean 5.8min, median 6.0min, range 2.7–7.3min.
- Every `ci.yml` job now has `timeout-minutes` (#1773).
- The nightly `AI/OCR Audit Replay` gate's 5-night red streak (#1767 F1-F4) and its confirmed 3-night green streak since the fix, independently re-checked via `gh run list --workflow audit-replay.yml`.

---

## Engineering Audit

- [x] No code changes — doc only
- [x] No real financial data

---

## Testing

```bash
uv run --with pyyaml --with pydantic --with pydantic-settings python3 tools/lint_doc_consistency.py
# exit 0

uv run --with pytest ... pytest tests/tooling/ -k "ci_cd or doc_consistency or manifest" -q
# 153 passed
```

---

## Screenshots / Evidence

_N/A — documentation-only change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)