### PR TITLE
[finance_report_vision] fix(#1791): point-in-time portfolio valuation, not current status

### DIFF
--- a/apps/backend/src/portfolio/extension/allocation.py
+++ b/apps/backend/src/portfolio/extension/allocation.py
@@ -15,8 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import src.config
 from src.audit.ratio import Ratio
+from src.ledger import Account
 from src.models.layer2 import AtomicPosition
-from src.models.layer3 import ManagedPosition, PositionStatus
+from src.models.layer3 import ManagedPosition
 from src.observability import get_logger
 from src.portfolio.extension.performance import batch_latest_atomic_positions
 from src.pricing import convert_amount
@@ -52,33 +53,40 @@ async def _get_active_positions_with_atomics(
     as_of_date: date,
 ) -> list[tuple[AtomicPosition, Decimal]]:
     """
-    Fetch active positions and their latest atomic snapshots in batch.
+    Fetch positions held as of as_of_date and their latest atomic snapshots in batch.
 
     Returns list of (AtomicPosition, value_in_base_currency) tuples for positions
-    that have atomic data.
+    that have atomic data. Point-in-time (#1791 follow-up): as_of_date may be a
+    historical date (callers default to today but may pass an explicit one), so
+    inclusion is decided by each position's own snapshot quantity on that date,
+    not by ManagedPosition.status which reflects today. Positions are keyed by
+    (asset_identifier, broker), not asset_identifier alone -- the same ticker
+    held at two different brokers must not collapse into one.
     """
-    query = select(ManagedPosition).where(
-        ManagedPosition.user_id == user_id,
-        ManagedPosition.status == PositionStatus.ACTIVE,
+    query = (
+        select(ManagedPosition.asset_identifier, Account.name)
+        .join(Account, ManagedPosition.account_id == Account.id)
+        .where(ManagedPosition.user_id == user_id)
     )
     result = await db.execute(query)
-    positions = result.scalars().all()
+    position_keys = result.all()
+    asset_ids = [identifier for identifier, _broker in position_keys]
 
-    asset_ids = [pos.asset_identifier for pos in positions]
     atomic_map = await batch_latest_atomic_positions(db, user_id, asset_ids, as_of_date)
 
     enriched = []
-    for pos in positions:
-        atomic = atomic_map.get(pos.asset_identifier)
-        if atomic:
-            value_base = await convert_amount(
-                db,
-                atomic.market_value or Decimal("0"),
-                atomic.currency,
-                settings.base_currency,
-                as_of_date,
-            )
-            enriched.append((atomic, value_base))
+    for identifier, broker in position_keys:
+        atomic = atomic_map.get((identifier, broker))
+        if atomic is None or atomic.quantity == Decimal("0"):
+            continue
+        value_base = await convert_amount(
+            db,
+            atomic.market_value or Decimal("0"),
+            atomic.currency,
+            settings.base_currency,
+            as_of_date,
+        )
+        enriched.append((atomic, value_base))
 
     return enriched
 

--- a/apps/backend/src/portfolio/extension/performance.py
+++ b/apps/backend/src/portfolio/extension/performance.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import src.config
 from src.audit.ratio import Ratio
 from src.models.layer2 import AtomicPosition
-from src.models.layer3 import ManagedPosition, PositionStatus
+from src.models.layer3 import ManagedPosition
 from src.observability import get_logger
 from src.portfolio.base.errors import InsufficientDataError, XIRRCalculationError
 from src.portfolio.orm.portfolio import DividendIncome, InvestmentTransaction, InvestmentTransactionType
@@ -135,30 +135,34 @@ async def calculate_xirr(
         dates.append(txn.transaction_date)
         amounts.append(amount_base * sign)
 
-    # Get current position value as final cash flow (positive = portfolio value)
-    query = select(ManagedPosition).where(
+    # Get position value as of as_of_date as the final cash flow (positive =
+    # portfolio value). Point-in-time (#1791 follow-up): query every position
+    # this user has ever held, not just ones still ManagedPosition.status ==
+    # ACTIVE *today* -- a position bought before and disposed after as_of_date
+    # was still held on that date and must count. Whether it was held as of
+    # as_of_date is decided below by its own snapshot quantity on that date
+    # (mirrors holdings.py:_get_snapshot_holdings), not by current status.
+    query = select(ManagedPosition.asset_identifier).where(
         ManagedPosition.user_id == user_id,
-        ManagedPosition.status == PositionStatus.ACTIVE,
     )
     result = await db.execute(query)
-    positions = result.scalars().all()
+    asset_ids = list(result.scalars().all())
 
     # Batch-fetch latest atomic positions (fixes N+1)
-    asset_ids = [pos.asset_identifier for pos in positions]
     atomic_map = await batch_latest_atomic_positions(db, user_id, asset_ids, as_of_date)
 
     total_value = Decimal("0")
-    for pos in positions:
-        atomic = atomic_map.get(pos.asset_identifier)
-        if atomic:
-            value_base = await convert_amount(
-                db,
-                atomic.market_value or Decimal("0"),
-                atomic.currency,
-                settings.base_currency,
-                as_of_date,
-            )
-            total_value += value_base
+    for atomic in atomic_map.values():
+        if atomic.quantity == Decimal("0"):
+            continue
+        value_base = await convert_amount(
+            db,
+            atomic.market_value or Decimal("0"),
+            atomic.currency,
+            settings.base_currency,
+            as_of_date,
+        )
+        total_value += value_base
 
     if total_value > Decimal("0"):
         dates.append(as_of_date)
@@ -425,7 +429,13 @@ async def _get_portfolio_value(
     """
     Get total portfolio value as of a specific date.
 
-    Uses batched query to avoid N+1 pattern.
+    Uses batched query to avoid N+1 pattern. Point-in-time (#1791 follow-up):
+    considers every position this user has ever held, not just ones still
+    ManagedPosition.status == ACTIVE *today* -- a position bought before and
+    disposed after as_of_date was still held on that date and must count.
+    Whether it was held as of as_of_date is decided by its own snapshot
+    quantity on that date (mirrors holdings.py:_get_snapshot_holdings), not
+    by current status.
 
     Args:
         db: Database session
@@ -435,28 +445,26 @@ async def _get_portfolio_value(
     Returns:
         Decimal: Total portfolio value in base currency
     """
-    query = select(ManagedPosition).where(
+    query = select(ManagedPosition.asset_identifier).where(
         ManagedPosition.user_id == user_id,
-        ManagedPosition.status == PositionStatus.ACTIVE,
     )
     result = await db.execute(query)
-    positions = result.scalars().all()
+    asset_ids = list(result.scalars().all())
 
     # Batch-fetch latest atomic positions (fixes N+1)
-    asset_ids = [pos.asset_identifier for pos in positions]
     atomic_map = await batch_latest_atomic_positions(db, user_id, asset_ids, as_of_date)
 
     total_value = Decimal("0")
-    for pos in positions:
-        atomic = atomic_map.get(pos.asset_identifier)
-        if atomic:
-            value_base = await convert_amount(
-                db,
-                atomic.market_value or Decimal("0"),
-                atomic.currency,
-                settings.base_currency,
-                as_of_date,
-            )
-            total_value += value_base
+    for atomic in atomic_map.values():
+        if atomic.quantity == Decimal("0"):
+            continue
+        value_base = await convert_amount(
+            db,
+            atomic.market_value or Decimal("0"),
+            atomic.currency,
+            settings.base_currency,
+            as_of_date,
+        )
+        total_value += value_base
 
     return total_value

--- a/apps/backend/src/portfolio/extension/performance.py
+++ b/apps/backend/src/portfolio/extension/performance.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import src.config
 from src.audit.ratio import Ratio
+from src.ledger import Account
 from src.models.layer2 import AtomicPosition
 from src.models.layer3 import ManagedPosition
 from src.observability import get_logger
@@ -32,30 +33,35 @@ async def batch_latest_atomic_positions(
     user_id: UUID,
     asset_identifiers: list[str],
     as_of_date: date,
-) -> dict[str, AtomicPosition]:
+) -> dict[tuple[str, str], AtomicPosition]:
     """
-    Batch-fetch the latest AtomicPosition for each asset_identifier in a single query.
+    Batch-fetch the latest AtomicPosition for each (asset_identifier, broker) pair.
 
-    Uses a window function (ROW_NUMBER) to find the most recent snapshot per asset,
-    avoiding the N+1 pattern of querying one asset at a time.
+    Uses a window function (ROW_NUMBER) to find the most recent snapshot per
+    (asset, broker), avoiding the N+1 pattern of querying one asset at a time.
+    Partitioning by asset_identifier alone would collapse two different
+    brokers' snapshots of the same ticker into one, silently dropping one
+    broker's contribution to the caller's total (mirrors the partition key
+    holdings.py:_get_snapshot_holdings already uses).
 
     Args:
         db: Database session
         user_id: User ID
-        asset_identifiers: List of asset identifiers to fetch
+        asset_identifiers: Asset identifiers to fetch (deduplicated internally)
         as_of_date: Fetch snapshots on or before this date
 
     Returns:
-        dict mapping asset_identifier -> latest AtomicPosition
+        dict mapping (asset_identifier, broker) -> latest AtomicPosition
     """
     if not asset_identifiers:
         return {}
+    unique_identifiers = list(dict.fromkeys(asset_identifiers))
 
-    # Subquery: rank snapshots per asset by date descending
+    # Subquery: rank snapshots per (asset, broker) by date descending
     row_num = (
         func.row_number()
         .over(
-            partition_by=AtomicPosition.asset_identifier,
+            partition_by=[AtomicPosition.asset_identifier, AtomicPosition.broker],
             order_by=AtomicPosition.snapshot_date.desc(),
         )
         .label("rn")
@@ -65,7 +71,7 @@ async def batch_latest_atomic_positions(
         select(AtomicPosition.id, row_num)
         .where(
             AtomicPosition.user_id == user_id,
-            AtomicPosition.asset_identifier.in_(asset_identifiers),
+            AtomicPosition.asset_identifier.in_(unique_identifiers),
             AtomicPosition.snapshot_date <= as_of_date,
         )
         .subquery()
@@ -77,7 +83,7 @@ async def batch_latest_atomic_positions(
     result = await db.execute(query)
     rows = result.scalars().all()
 
-    return {row.asset_identifier: row for row in rows}
+    return {(row.asset_identifier, row.broker): row for row in rows}
 
 
 async def calculate_xirr(
@@ -136,33 +142,8 @@ async def calculate_xirr(
         amounts.append(amount_base * sign)
 
     # Get position value as of as_of_date as the final cash flow (positive =
-    # portfolio value). Point-in-time (#1791 follow-up): query every position
-    # this user has ever held, not just ones still ManagedPosition.status ==
-    # ACTIVE *today* -- a position bought before and disposed after as_of_date
-    # was still held on that date and must count. Whether it was held as of
-    # as_of_date is decided below by its own snapshot quantity on that date
-    # (mirrors holdings.py:_get_snapshot_holdings), not by current status.
-    query = select(ManagedPosition.asset_identifier).where(
-        ManagedPosition.user_id == user_id,
-    )
-    result = await db.execute(query)
-    asset_ids = list(result.scalars().all())
-
-    # Batch-fetch latest atomic positions (fixes N+1)
-    atomic_map = await batch_latest_atomic_positions(db, user_id, asset_ids, as_of_date)
-
-    total_value = Decimal("0")
-    for atomic in atomic_map.values():
-        if atomic.quantity == Decimal("0"):
-            continue
-        value_base = await convert_amount(
-            db,
-            atomic.market_value or Decimal("0"),
-            atomic.currency,
-            settings.base_currency,
-            as_of_date,
-        )
-        total_value += value_base
+    # portfolio value).
+    total_value = await _get_portfolio_value(db, user_id, as_of_date)
 
     if total_value > Decimal("0"):
         dates.append(as_of_date)
@@ -437,6 +418,12 @@ async def _get_portfolio_value(
     quantity on that date (mirrors holdings.py:_get_snapshot_holdings), not
     by current status.
 
+    Looks up each position by (asset_identifier, broker), not asset_identifier
+    alone -- the same ticker can be held at two different brokers (Account.name
+    is the broker key), and collapsing on asset_identifier would silently drop
+    one broker's contribution (or double-count it, depending which side of the
+    lookup collapses).
+
     Args:
         db: Database session
         user_id: User ID
@@ -445,18 +432,22 @@ async def _get_portfolio_value(
     Returns:
         Decimal: Total portfolio value in base currency
     """
-    query = select(ManagedPosition.asset_identifier).where(
-        ManagedPosition.user_id == user_id,
+    query = (
+        select(ManagedPosition.asset_identifier, Account.name)
+        .join(Account, ManagedPosition.account_id == Account.id)
+        .where(ManagedPosition.user_id == user_id)
     )
     result = await db.execute(query)
-    asset_ids = list(result.scalars().all())
+    position_keys = result.all()
+    asset_ids = [identifier for identifier, _broker in position_keys]
 
     # Batch-fetch latest atomic positions (fixes N+1)
     atomic_map = await batch_latest_atomic_positions(db, user_id, asset_ids, as_of_date)
 
     total_value = Decimal("0")
-    for atomic in atomic_map.values():
-        if atomic.quantity == Decimal("0"):
+    for identifier, broker in position_keys:
+        atomic = atomic_map.get((identifier, broker))
+        if atomic is None or atomic.quantity == Decimal("0"):
             continue
         value_base = await convert_amount(
             db,

--- a/apps/backend/src/reporting/extension/balance_sheet.py
+++ b/apps/backend/src/reporting/extension/balance_sheet.py
@@ -102,6 +102,7 @@ async def generate_balance_sheet(
     """
     target_currency = _normalize_currency(currency)
     fx_warnings: list[FxWarning] = []
+    portfolio_warnings: list[FxWarning] = []
     account_types = (AccountType.ASSET, AccountType.LIABILITY, AccountType.EQUITY)
     accounts = await _load_accounts(db, user_id, account_types)
     included_ledger_currencies: set[str] = set()
@@ -175,6 +176,7 @@ async def generate_balance_sheet(
         as_of_date=as_of_date,
         target_currency=target_currency,
         asset_lines=assets,
+        warnings=portfolio_warnings,
     )
     valuation_assets, valuation_liabilities = await _build_manual_valuation_lines(
         db,
@@ -294,6 +296,7 @@ async def generate_balance_sheet(
         "unrealized_fx_gain_loss": unrealized_fx,
         "net_worth_adjustment_gain_loss": net_worth_adjustment,
         "fx_warnings": fx_warnings,
+        "portfolio_warnings": portfolio_warnings,
         "opening_balance_warnings": opening_balance_warnings,
         "equation_delta": equation_delta,
         "is_balanced": abs(equation_delta) < Decimal("0.01"),

--- a/apps/backend/src/reporting/extension/framework_report.py
+++ b/apps/backend/src/reporting/extension/framework_report.py
@@ -268,6 +268,7 @@ async def assemble_framework_balance_sheet(
         "unrealized_fx_gain_loss": unrealized_fx,
         "net_worth_adjustment_gain_loss": net_worth_adjustment,
         "fx_warnings": raw_bs.get("fx_warnings", []),
+        "portfolio_warnings": raw_bs.get("portfolio_warnings", []),
         "opening_balance_warnings": raw_bs.get("opening_balance_warnings", []),
         "equation_delta": equation_delta,
         "is_balanced": abs(equation_delta) < Decimal("0.01"),

--- a/apps/backend/src/reporting/extension/net_worth.py
+++ b/apps/backend/src/reporting/extension/net_worth.py
@@ -283,6 +283,10 @@ async def get_net_worth_allocation_schedule(
         # same opening-balance gate as the balance sheet (AC2.16.4 / #1481).
         "confidence_tier": balance_sheet.get("confidence_tier"),
         "opening_balance_warnings": balance_sheet.get("opening_balance_warnings", []),
+        # Same portfolio point-in-time gaps as the balance sheet (#1791 follow-up)
+        # -- generate_balance_sheet already ran the same as_of_date/currency
+        # through _build_portfolio_market_adjustment_lines above.
+        "portfolio_warnings": balance_sheet.get("portfolio_warnings", []),
     }
 
 

--- a/apps/backend/src/reporting/extension/portfolio_market.py
+++ b/apps/backend/src/reporting/extension/portfolio_market.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit.unit_price import UnitPrice
@@ -16,13 +16,13 @@ from src.ledger import Account, AccountType
 from src.models.layer3 import (
     ManagedPosition,
     ManualValuationLiquidityClass,
-    PositionStatus,
 )
 from src.observability import get_logger
 from src.portfolio import AssetNotFoundError, PortfolioService
 from src.pricing import PricingError
 from src.reporting.extension import fx_gateway
 from src.reporting.extension._core import REPORTING_QUANTITY_UNIT, _single_source_currency
+from src.reporting.extension.fx_gateway import FxWarning
 from src.reporting.extension.reporting_calc import (
     ReportError,
     _quantize_money,
@@ -37,6 +37,7 @@ async def _portfolio_market_basis_by_account(
     *,
     as_of_date: date,
     target_currency: str,
+    warnings: list[FxWarning] | None = None,
 ) -> dict[UUID, dict[str, Any]]:
     """Return converted portfolio market/cost-basis totals by broker account."""
     portfolio_service = PortfolioService()
@@ -44,11 +45,22 @@ async def _portfolio_market_basis_by_account(
     if as_of_date == date.today():
         portfolio_eval_date = await portfolio_service._default_holdings_eval_date(db, user_id)
 
+    # Point-in-time (#1791 follow-up): a position's *current* status reflects
+    # today, not portfolio_eval_date -- a position bought before and disposed
+    # after this date was still held on it and must count. acquisition_date/
+    # disposal_date are ManagedPosition's own validity interval, so query that
+    # directly instead of the current status flag.
     result = await db.execute(
         select(ManagedPosition, Account)
         .join(Account, ManagedPosition.account_id == Account.id)
         .where(ManagedPosition.user_id == user_id)
-        .where(ManagedPosition.status == PositionStatus.ACTIVE)
+        .where(ManagedPosition.acquisition_date <= portfolio_eval_date)
+        .where(
+            or_(
+                ManagedPosition.disposal_date.is_(None),
+                ManagedPosition.disposal_date > portfolio_eval_date,
+            )
+        )
         .where(Account.user_id == user_id)
         .where(Account.is_active.is_(True))
     )
@@ -65,6 +77,19 @@ async def _portfolio_market_basis_by_account(
                 asset_identifier=position.asset_identifier,
                 as_of_date=portfolio_eval_date.isoformat(),
             )
+            if warnings is not None:
+                warnings.append(
+                    {
+                        "type": "missing_portfolio_price_as_of_date",
+                        "asset_identifier": position.asset_identifier,
+                        "account_id": str(position.account_id),
+                        "as_of_date": portfolio_eval_date.isoformat(),
+                        "message": (
+                            f"No price data available for {position.asset_identifier} on or "
+                            f"before {portfolio_eval_date.isoformat()}; excluded from this total."
+                        ),
+                    }
+                )
             continue
         except PricingError as exc:
             # An FX miss inside the price lookup is a report-blocking condition,
@@ -111,6 +136,7 @@ async def _build_portfolio_market_adjustment_lines(
     as_of_date: date,
     target_currency: str,
     asset_lines: Sequence[dict[str, Any]],
+    warnings: list[FxWarning] | None = None,
 ) -> list[dict[str, Any]]:
     """Build market-value adjustment lines for active portfolio positions.
 
@@ -126,6 +152,7 @@ async def _build_portfolio_market_adjustment_lines(
         user_id,
         as_of_date=as_of_date,
         target_currency=target_currency,
+        warnings=warnings,
     )
 
     adjustment_lines: list[dict[str, Any]] = []

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -84,6 +84,11 @@ class BalanceSheetResponse(BaseModel):
     unrealized_fx_gain_loss: Decimal = Decimal("0.00")
     net_worth_adjustment_gain_loss: Decimal = Decimal("0.00")
     fx_warnings: list[dict[str, str]] = Field(default_factory=list)
+    # Point-in-time gap (#1791 follow-up): non-empty when a portfolio position
+    # was excluded from total_assets because no price snapshot exists on or
+    # before as_of_date -- the total is still accurate, just possibly
+    # incomplete for a position with a data gap at this historical date.
+    portfolio_warnings: list[dict[str, str]] = Field(default_factory=list)
     # Opening-balance gate (AC2.16.4 / #1481): non-empty when activity exists with
     # no recorded opening balance; the total then reflects only period movement and
     # confidence_tier is degraded to LOW.
@@ -198,6 +203,10 @@ class NetWorthAllocationResponse(BaseModel):
     )
     opening_balance_warnings: list[dict[str, str]] = Field(
         default_factory=list, description="Non-empty when activity exists without a recorded opening balance."
+    )
+    portfolio_warnings: list[dict[str, str]] = Field(
+        default_factory=list,
+        description="Same portfolio point-in-time gaps as the balance sheet (#1791 follow-up).",
     )
 
 

--- a/apps/backend/tests/portfolio/test_allocation_service.py
+++ b/apps/backend/tests/portfolio/test_allocation_service.py
@@ -17,9 +17,13 @@ from src.portfolio import (
 
 @pytest.fixture
 async def investment_account(db: AsyncSession, test_user):
+    # Name matches the AtomicPosition.broker string used in this file's
+    # fixtures -- point-in-time lookups now key by (asset_identifier, broker)
+    # via Account.name (#1791 follow-up), mirroring how
+    # _get_or_create_broker_account always names the account after the broker.
     account = Account(
         user_id=test_user.id,
-        name="Investment Account",
+        name="Test Broker",
         type=AccountType.ASSET,
         currency="SGD",
     )

--- a/apps/backend/tests/portfolio/test_financial_logic_audit.py
+++ b/apps/backend/tests/portfolio/test_financial_logic_audit.py
@@ -22,7 +22,9 @@ from src.pricing.orm.market_data import FxRate
 
 
 async def _investment_position(db: AsyncSession, test_user, *, asset_identifier: str = "AUDIT") -> ManagedPosition:
-    account = Account(user_id=test_user.id, name="Investment Account", type=AccountType.ASSET, currency="SGD")
+    # Name matches this file's AtomicPosition.broker="Test Broker" -- point-in-time
+    # lookups now key by (asset_identifier, broker) via Account.name (#1791 follow-up).
+    account = Account(user_id=test_user.id, name="Test Broker", type=AccountType.ASSET, currency="SGD")
     db.add(account)
     await db.flush()
     position = ManagedPosition(

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -376,6 +376,67 @@ async def test_AC5_6_3_dividend_yield_uses_trailing_dividends_over_current_value
     assert dividend_yield == Decimal("2.00")
 
 
+async def test_AC5_6_3_dividend_yield_counts_position_disposed_after_as_of_date(
+    db: AsyncSession,
+    test_user,
+    investment_account,
+):
+    """AC-portfolio.metrics.5 (#1791 follow-up): a position held as of
+    as_of_date must count toward that date's portfolio value even though it
+    has since been disposed -- ManagedPosition.status reflects *today*, not
+    as_of_date, so point-in-time inclusion must come from the snapshot
+    quantity on that date (mirrors holdings.py:_get_snapshot_holdings), not
+    from the position's current status."""
+    from src.models.layer2 import AtomicPosition
+
+    today = date.today()
+    as_of_date = today - timedelta(days=60)
+
+    position = ManagedPosition(
+        user_id=test_user.id,
+        account_id=investment_account.id,
+        asset_identifier="SOLD",
+        quantity=Decimal("0"),
+        cost_basis=Decimal("10000.00"),
+        currency="SGD",
+        acquisition_date=today - timedelta(days=90),
+        disposal_date=today - timedelta(days=10),
+        status=PositionStatus.DISPOSED,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
+    db.add(position)
+    await db.flush()
+
+    # Snapshot as of as_of_date: the position was still held then.
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=as_of_date,
+            asset_identifier="SOLD",
+            broker="Test Broker",
+            quantity=Decimal("100"),
+            market_value=Decimal("10000.00"),
+            currency="SGD",
+            dedup_hash="ac5_6_3_disposed_after_as_of_date",
+            source_documents={},
+        )
+    )
+    db.add(
+        DividendIncome(
+            user_id=test_user.id,
+            position_id=position.id,
+            payment_date=as_of_date - timedelta(days=30),
+            amount=Decimal("100.00"),
+            currency="SGD",
+        )
+    )
+    await db.flush()
+
+    dividend_yield = await calculate_dividend_yield(db, test_user.id, as_of_date)
+
+    assert dividend_yield == Decimal("1.00")
+
+
 async def test_AC5_6_3_dividend_yield_empty_portfolio_returns_zero(db: AsyncSession, test_user):
     """AC5.6.3: Dividend yield returns zero when no dividends or holdings exist."""
     dividend_yield = await calculate_dividend_yield(db, test_user.id)

--- a/apps/backend/tests/portfolio/test_performance_service.py
+++ b/apps/backend/tests/portfolio/test_performance_service.py
@@ -29,9 +29,13 @@ from src.portfolio import (
 
 @pytest.fixture
 async def investment_account(db: AsyncSession, test_user):
+    # Name matches the AtomicPosition.broker string used throughout this file's
+    # fixtures/tests -- point-in-time lookups now key by (asset_identifier,
+    # broker) via Account.name (#1791 follow-up), mirroring how
+    # _get_or_create_broker_account always names the account after the broker.
     account = Account(
         user_id=test_user.id,
-        name="Investment Account",
+        name="Test Broker",
         type=AccountType.ASSET,
         currency="SGD",
     )
@@ -730,7 +734,7 @@ async def test_xirr_calculation_error_raised(db: AsyncSession, test_user, invest
         user_id=test_user.id,
         snapshot_date=date.today(),
         asset_identifier="ERR",
-        broker="B",
+        broker="Test Broker",
         quantity=Decimal("1"),
         market_value=Decimal("11000.00"),
         currency="SGD",

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -64,7 +64,9 @@ async def portfolio_with_data(db: AsyncSession, test_user, investment_account):
         user_id=test_user.id,
         snapshot_date=date.today(),
         asset_identifier="AAPL",
-        broker="Test Broker",
+        # Matches investment_account.name -- point-in-time lookups now key by
+        # (asset_identifier, broker) via Account.name (#1791 follow-up).
+        broker="Investment Account",
         quantity=Decimal("100"),
         market_value=Decimal("12000.00"),
         currency="SGD",
@@ -77,7 +79,7 @@ async def portfolio_with_data(db: AsyncSession, test_user, investment_account):
                 {
                     "doc_id": "brokerage-doc-aapl",
                     "doc_type": "brokerage_statement",
-                    "broker": "Test Broker",
+                    "broker": "Investment Account",
                 }
             ]
         },

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -1563,6 +1563,23 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-portfolio.metrics.5",
+            statement=(
+                "A position's contribution to XIRR/TWR/dividend-yield portfolio "
+                "value as of a historical date is decided by whether it was held "
+                "on that date (point-in-time, via its snapshot quantity), not by "
+                "ManagedPosition.status which reflects today -- a position "
+                "disposed after the requested date still counts."
+            ),
+            test=(
+                "apps/backend/tests/portfolio/test_performance_service.py"
+                "::test_AC5_6_3_dividend_yield_counts_position_disposed_after_as_of_date"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
         # ── group schedule-fallback: mixed-currency schedule fallback (was
         # EPIC-019 AC19.8.8's portfolio share — the readiness-FX and Playwright
         # shares stay in EPIC-019; migration closeout continuation,

--- a/common/portfolio/readme.md
+++ b/common/portfolio/readme.md
@@ -132,6 +132,35 @@ the auditable cost-basis trail when structured brokerage transactions
 exist; snapshot-only imports fall back to market value as the cost-basis
 proxy.
 
+**Two independent temporal questions, both point-in-time (#1791)** — a
+historical `as_of_date` query about a position must answer two separate
+questions, and getting either one wrong produces a silently wrong total
+rather than an error:
+
+1. *Was it held on that date?* `ManagedPosition.acquisition_date` /
+   `disposal_date` are the position's own validity interval — held for
+   `as_of_date` iff `acquisition_date <= as_of_date < disposal_date` (or
+   `disposal_date IS NULL`). `acquisition_date` is stamped from the
+   *importing* statement's own snapshot date (`reconcile_positions`,
+   `positions.py`), not a user-entered purchase date — so a position
+   imported today has `acquisition_date = today` regardless of when the
+   underlying shares were actually bought. Querying `as_of_date` before
+   that carries no ownership claim at all, by design: reporting cannot
+   assert a holding existed before the evidence for it does.
+2. *Do we have a price for it as of that date?* Independent of (1) — see
+   `AtomicPosition` snapshot lookup above. A position can be correctly
+   "held" (question 1: yes) yet have no eligible price snapshot (question
+   2: no), e.g. a resync happened after the requested date.
+
+Querying by *current* `ManagedPosition.status` instead of question 1's
+interval is the same class of bug either way it's missed: a position
+disposed after `as_of_date` was still held on it and must count; a
+position not yet acquired as of `as_of_date` must not, even if it is
+`ACTIVE` today. `reporting`'s balance sheet and `portfolio`'s own
+`performance.py` (XIRR/TWR/dividend yield) both had this bug at different
+times — check any *new* `as_of_date`-parameterized query against both
+questions before assuming a current-status filter is equivalent.
+
 **Investment accounting pipeline** (posted through
 `InvestmentAccountingService`): Buy — debit the investment asset account,
 credit brokerage cash, create an `InvestmentTransaction` + `InvestmentLot`,

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -612,6 +612,23 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        ACRecord(
+            id="AC-reporting.balance-sheet.5",
+            statement=(
+                "A historical as_of_date balance sheet excludes a portfolio position "
+                "whose ManagedPosition.acquisition_date postdates that as_of_date "
+                "(consistent with portfolio's documented point-in-time holdings rule: "
+                "future snapshots are never used); the same position appears once "
+                "as_of_date reaches its acquisition_date."
+            ),
+            test=(
+                "tests/e2e/test_personal_financial_report_package.py"
+                "::test_personal_financial_report_package_post_merge_journey"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
         # ── group income-statement (was EPIC-005 AC5.2.1-3, migration
         # closeout continuation, #1663 / #1716) ──
         ACRecord(

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -802,9 +802,9 @@ async def test_personal_financial_report_package_post_merge_journey(
         # fresh on every run) -- so as of fixture_period_end (a fixed
         # historical date from the bank CSV, always earlier), this position
         # was not yet "acquired" per the ledger's own bookkeeping. A
-        # historical balance sheet correctly excludes it (portfolio.md:
-        # "future snapshots are never used"); brokerage inclusion is
-        # verified separately below at as_of_date=today.
+        # historical balance sheet correctly excludes it
+        # (common/portfolio/readme.md: "future snapshots are never used");
+        # brokerage inclusion is verified separately below at as_of_date=today.
         expected_assets = expected.total_assets(Decimal("0.00"))
         expected_liabilities = expected.manual_liability_total
         expected_net_worth_adjustment = expected.net_worth_adjustment_gain_loss

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -796,7 +796,16 @@ async def test_personal_financial_report_package_post_merge_journey(
 
         expected_bank_cash = expected.bank_cash
         expected_manual_assets = expected.manual_asset_total
-        expected_assets = expected.total_assets(brokerage_value)
+        # AC-reporting.balance-sheet.5 (#1791): the brokerage position's own
+        # ManagedPosition.acquisition_date is stamped from the statement's
+        # snapshot date (today, since the moomoo PDF fixture is generated
+        # fresh on every run) -- so as of fixture_period_end (a fixed
+        # historical date from the bank CSV, always earlier), this position
+        # was not yet "acquired" per the ledger's own bookkeeping. A
+        # historical balance sheet correctly excludes it (portfolio.md:
+        # "future snapshots are never used"); brokerage inclusion is
+        # verified separately below at as_of_date=today.
+        expected_assets = expected.total_assets(Decimal("0.00"))
         expected_liabilities = expected.manual_liability_total
         expected_net_worth_adjustment = expected.net_worth_adjustment_gain_loss
 
@@ -833,6 +842,29 @@ async def test_personal_financial_report_package_post_merge_journey(
         assert _line_total(balance["assets"]) == money_amount(balance["total_assets"])
         assert _line_total(balance["liabilities"]) == money_amount(
             balance["total_liabilities"]
+        )
+
+        # AC-reporting.balance-sheet.5 (#1791): a *current* balance sheet (as_of
+        # today, on/after the position's own acquisition_date) must include the
+        # brokerage position's market value -- the historical check above only
+        # proves correct exclusion, not that inclusion ever actually happens.
+        current_balance_payload = await client.get(
+            _api_url(
+                f"/reports/balance-sheet?as_of_date={date.today().isoformat()}&currency=SGD&include_restricted=true"
+            )
+        )
+        assert current_balance_payload.status_code == 200, (
+            f"current balance sheet failed: {current_balance_payload.status_code} "
+            f"{current_balance_payload.text}"
+        )
+        current_balance = current_balance_payload.json()
+        expected_current_assets = expected.total_assets(brokerage_value)
+        assert money_amount(current_balance["total_assets"]) == expected_current_assets
+        assert money_amount(current_balance["total_assets"]) > money_amount(
+            balance["total_assets"]
+        ), (
+            "current balance sheet should exceed the historical one by the "
+            "brokerage position's market value"
         )
 
         income_payload = await client.get(


### PR DESCRIPTION
## Summary

Root-caused the #1791 E2E balance-sheet failure to a test bug (not a product bug), then audited the codebase for the same interval-semantics mistake elsewhere per follow-up request and fixed two real, previously-unknown bugs it found.

- **#1791 itself**: `ManagedPosition.acquisition_date` is stamped from the importing statement's own snapshot date, not a real purchase date. The E2E test's brokerage PDF fixture is generated fresh every run (dated "now"), while the bank CSV fixture uses a fixed historical window — so the brokerage position's `acquisition_date` postdated the historical `as_of_date` the test queried. A historical balance sheet correctly excludes a position not yet "acquired" by the ledger's own bookkeeping; the test's expectation was wrong. Fixed the assertion (excludes brokerage for the historical date) and added a new check confirming a *current*-date balance sheet does include it.
- **Finding 1** (`apps/backend/src/portfolio/extension/performance.py`): `calculate_xirr`/`_get_portfolio_value` (feeds XIRR, TWR, dividend yield) filtered `ManagedPosition.status == ACTIVE` — *today's* status, not point-in-time. A position disposed after the requested historical date silently vanished from every earlier valuation, understating returns/yield with no error. Fixed to derive inclusion from the position's own snapshot quantity as of that date (mirrors `holdings.py`'s already-correct pattern).
- **Finding 2** (`apps/backend/src/reporting/extension/portfolio_market.py`, shared by balance sheet / net-worth-allocation / framework-report): same current-status filter, one layer upstream of the price-lookup #1791 itself surfaced. Fixed to query `acquisition_date`/`disposal_date` (the position's own validity interval) directly. Also added a `portfolio_warnings` field (mirroring the existing `fx_warnings`/`opening_balance_warnings` pattern) so a position dropped for lack of *price* data — a separate, genuinely ambiguous case — is now visible instead of silent.
- **Docs**: `common/portfolio/readme.md` now spells out the two independent temporal questions a historical query must answer ("was it held on that date" vs. "do we have a price for it") so this class of bug is easier to catch by inspection.
- **Deferred**: two smaller, lower-confidence "no warning surfaced" gaps (manual valuations, `holdings.py`) filed as #1796 — assessed as silent-but-correct, not urgent.

New ACs: `AC-reporting.balance-sheet.5`, `AC-portfolio.metrics.5`.

## Test plan
- [x] `pytest tests/portfolio/` — 151 passed
- [x] `pytest tests/reporting/` — 273 passed
- [x] `tools/check_package_contract.py` — PASSED
- [x] `tools/check_ac_index.py` — PASSED (no dangling/missing AC links)
- [x] `tools/check_manifest.py` — clean
- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [ ] CI green on this PR

Closes #1791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>