### PR TITLE
[finance_report_audit] Migration closeout: MANIFEST accuracy audit + anti-drift gate (#1664 Part C)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ question, so they never compete for ownership:
 | Concern | Question it answers | Axis |
 |---------|--------------------|------|
 | **vision.md** | *Why* — the overall product goal and culture | north star |
-| **SSOT** (`docs/ssot/`) | *In what shared language* — the canonical base elements, vocabulary, and contracts that everything else reuses | common dictionary |
+| **SSOT** | *In what shared language* — the canonical base elements, vocabulary, and contracts that everything else reuses; a package-owned concept lives in its `common/<pkg>/readme.md`, a cross-cutting/gate-data/generated one lives in `docs/ssot/` — the registry is [docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml) | common dictionary |
 | **EPIC** (`docs/project/`) | *What, horizontally* — a cross-module goal, verified via `EPIC → AC → test` | feature slice |
 | **README** (root, `apps/*`) | *What, per module* — one module's goal and how it is built | module slice |
 
@@ -65,15 +65,21 @@ implementation, or an EPIC redefining a base element that SSOT already owns).
 
 ## 📐 SSOT-First Principle
 
-`docs/ssot/` is the **authoritative source for the shared base elements and
-contracts** — the common language the rest of the repo reuses. It does not own
-goals (vision / EPICs) or module design (READMEs); it owns the *terms* they
-speak in.  
-The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)**
+The shared base elements and contracts — the common language the rest of the
+repo reuses — are **authoritative wherever the package-model migration puts
+them**, not always `docs/ssot/`: a concept a bounded-context package governs
+lives in that package's `common/<pkg>/readme.md`; a concept that is genuinely
+cross-cutting (spans every package), a live gate-data input, or a generated
+artifact lives in `docs/ssot/`. Neither owns goals (vision / EPICs) or module
+design (READMEs); each owns the *terms* those speak in — see
+[docs/ssot/README.md](docs/ssot/README.md) for the current file-by-file map.  
+The ownership registry (which concept lives where) is:
+**[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)**
 
-1. **No SSOT, no work**: Define the shared terms in `docs/ssot/` before writing code.
-2. **No hidden drift**: When code differs from SSOT, sync immediately.
-3. **Single owner**: Each concept has exactly one SSOT file; see MANIFEST.
+1. **No SSOT, no work**: Define the shared terms — in the owning package
+   readme, or `docs/ssot/` if genuinely cross-cutting — before writing code.
+2. **No hidden drift**: When code differs from its owning doc, sync immediately.
+3. **Single owner**: Each concept has exactly one owner file; see MANIFEST.
 
 ---
 
@@ -94,8 +100,10 @@ The SSOT ownership map is: **[docs/ssot/MANIFEST.yaml](docs/ssot/MANIFEST.yaml)*
 2. Define ACs where they live: a **migrated package** owns its ACs as
    `AC-<pkg>.<group>.<seq>` in that package's `contract.py` `roadmap` — never
    mirrored back into an EPIC table. Only legacy, not-yet-migrated modules
-   still register ACs in `docs/ac_registry.yaml` (feature) or
-   `docs/infra_registry.yaml` (infra)
+   still add ACs as explicitly residue-marked rows in a
+   `docs/project/EPIC-*.md` table (`<!-- epic-owned: ... -->`);
+   `docs/ac_registry.yaml` / `docs/infra_registry.yaml` are generated index
+   stubs (`tools/generate_ac_registry.py`), never hand-edited
 3. Write **failing** tests referencing AC IDs (🔴 red)
 4. Write minimal code to pass tests (🟢 green)
 5. Update the owning package contract/readme (or SSOT docs for legacy modules)
@@ -172,6 +180,6 @@ tracking. Do not duplicate phase status in this quick-reference file.
 |----------|------|---------|
 | **Agent governance** | `docs/agents/` | Red lines, orchestration |
 | **Contributor guide** | `docs/contributing/` | Branch policy, pre-commit |
-| **SSOT** | `docs/ssot/` | Shared base-element language & contracts |
+| **SSOT** | `docs/ssot/` | Cross-cutting infra docs, live gate-data inputs, generated artifacts, and the concept-ownership registry (`MANIFEST.yaml`) — package-owned concepts live in `common/<pkg>/readme.md` instead |
 | **Project EPICs** | `docs/project/` | Horizontal (cross-module) goals & tracking |
 | **Module READMEs** | `apps/*/README.md` | Per-module goal & design guide |

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -1016,5 +1016,33 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── manifest: docs/ssot/MANIFEST.yaml stays hand-authored (a full
+        # computed concept index is a follow-up, #1799), but every file it
+        # governs must be explicitly classified — anti-drift in the same
+        # spirit as the residue markers above (#1664 "retire the center",
+        # Part C). ──
+        ACRecord(
+            id="AC-meta.manifest.1",
+            statement=(
+                "Every file physically present in docs/ssot/ is referenced "
+                "by name in docs/ssot/README.md — the pointer page "
+                "classifying each surviving file as cross-cutting infra "
+                "(Cross-Cutting Classification table), live gate data (Gate "
+                "Data Directory section), a generated artifact, or a "
+                "migrated pointer stub. A file dropped into docs/ssot/ "
+                "without a matching README entry is silent, unclassified "
+                "drift and fails CI. This stands in for the full computed "
+                "concept-ownership index (no `concepts` field exists on "
+                "PackageContract yet to project from — see docs/ssot/"
+                "README.md § 'MANIFEST.yaml Status' and follow-up #1799) "
+                "without forcing that larger rewrite under time pressure."
+            ),
+            test=(
+                "tests/tooling/test_check_manifest.py"
+                "::test_AC_meta_manifest_1_real_docs_ssot_is_fully_classified"
+            ),
+            priority="P2",
+            status="done",
+        ),
     ],
 )

--- a/common/meta/extension/check_manifest.py
+++ b/common/meta/extension/check_manifest.py
@@ -3,6 +3,7 @@
 
 Validates ``docs/ssot/MANIFEST.yaml`` against the following rules:
 
+  0. Every concept value must be a YAML mapping, not null or a scalar.
   1. No two concepts may share the same owner (file + optional anchor).
   2. Every owner *file* path (ignoring ``#anchor``) MUST exist on disk.
   3. Every cross_ref *file* path (ignoring ``#anchor``) MUST exist on disk.

--- a/common/meta/extension/check_manifest.py
+++ b/common/meta/extension/check_manifest.py
@@ -269,7 +269,9 @@ def check_anchor_refs_exist(concepts: dict) -> list[Violation]:
 
 # Files that are the registry/index itself, not a concept the registry
 # classifies — excluded from check5 so the check doesn't self-flag.
-DOCS_SSOT_CLASSIFICATION_EXEMPT: frozenset[str] = frozenset({"README.md", "MANIFEST.yaml"})
+DOCS_SSOT_CLASSIFICATION_EXEMPT: frozenset[str] = frozenset(
+    {"README.md", "MANIFEST.yaml"}
+)
 
 
 def check_docs_ssot_files_classified() -> list[Violation]:
@@ -291,6 +293,13 @@ def check_docs_ssot_files_classified() -> list[Violation]:
     """
     violations: list[Violation] = []
     ssot_dir = REPO_ROOT / "docs" / "ssot"
+    if not ssot_dir.is_dir():
+        return [
+            Violation(
+                check="check5_docs_ssot_classified",
+                message=f"{ssot_dir.relative_to(REPO_ROOT)} is missing.",
+            )
+        ]
     readme_path = ssot_dir / "README.md"
     if not readme_path.exists():
         return [

--- a/common/meta/extension/check_manifest.py
+++ b/common/meta/extension/check_manifest.py
@@ -8,6 +8,12 @@ Validates ``docs/ssot/MANIFEST.yaml`` against the following rules:
   3. Every cross_ref *file* path (ignoring ``#anchor``) MUST exist on disk.
   4. Every ``#anchor`` in owner and cross_ref entries MUST resolve to an
      explicit HTML id or Markdown heading slug in the referenced file.
+  5. (AC-meta.manifest.1) Every file physically present in ``docs/ssot/``
+     MUST be referenced by name in ``docs/ssot/README.md`` — the pointer
+     page that classifies every surviving file (cross-cutting infra, live
+     gate data, generated artifact, or migrated pointer stub, #1664). This
+     is the anti-drift check that stands in for a full computed concept
+     index (tracked as a follow-up, see docs/ssot/README.md).
 
 The script exits 0 on success and 1 on any violation.
 
@@ -261,6 +267,61 @@ def check_anchor_refs_exist(concepts: dict) -> list[Violation]:
     return violations
 
 
+# Files that are the registry/index itself, not a concept the registry
+# classifies — excluded from check5 so the check doesn't self-flag.
+DOCS_SSOT_CLASSIFICATION_EXEMPT: frozenset[str] = frozenset({"README.md", "MANIFEST.yaml"})
+
+
+def check_docs_ssot_files_classified() -> list[Violation]:
+    """Rule 5 (AC-meta.manifest.1, anti-drift): every file physically present
+    in ``docs/ssot/`` must be referenced by name in ``docs/ssot/README.md``.
+
+    ``docs/ssot/README.md`` is the pointer page recording *why* each
+    surviving file is there (cross-cutting infra doc, live gate-data input,
+    generated artifact, or a migrated-domain-doc pointer stub — migration
+    closeout wave 3, #1664). A file dropped into ``docs/ssot/`` without a
+    matching README entry is exactly the silent, unclassified drift #1664
+    closed out; this check keeps it closed without requiring the full
+    computed-concept-index rewrite (tracked as a follow-up).
+
+    This does not replace ``check_owner_files_exist`` / ``check_anchor_refs_exist``
+    (which validate MANIFEST *concept* entries) — it validates the directory
+    listing directly, so it also catches a file that has no MANIFEST concept
+    pointing at it at all.
+    """
+    violations: list[Violation] = []
+    ssot_dir = REPO_ROOT / "docs" / "ssot"
+    readme_path = ssot_dir / "README.md"
+    if not readme_path.exists():
+        return [
+            Violation(
+                check="check5_docs_ssot_classified",
+                message=f"{readme_path.relative_to(REPO_ROOT)} is missing.",
+            )
+        ]
+    readme_text = readme_path.read_text(encoding="utf-8", errors="ignore")
+
+    for path in sorted(ssot_dir.iterdir()):
+        if not path.is_file() or path.name in DOCS_SSOT_CLASSIFICATION_EXEMPT:
+            continue
+        if path.name not in readme_text:
+            violations.append(
+                Violation(
+                    check="check5_docs_ssot_classified",
+                    message=(
+                        f"docs/ssot/{path.name} is not referenced anywhere in "
+                        "docs/ssot/README.md. Every surviving docs/ssot/ file "
+                        "must be classified there — as cross-cutting infra "
+                        "(Cross-Cutting Classification table), live gate data "
+                        "(Gate Data Directory section), a generated artifact, "
+                        "or a migrated pointer stub — so ownership stays "
+                        "explicit and machine-greppable (#1664)."
+                    ),
+                )
+            )
+    return violations
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Validate docs/ssot/MANIFEST.yaml consistency."
@@ -286,6 +347,7 @@ def main() -> int:
     violations.extend(check_owner_files_exist(concepts))
     violations.extend(check_crossref_files_exist(concepts))
     violations.extend(check_anchor_refs_exist(concepts))
+    violations.extend(check_docs_ssot_files_classified())
 
     if args.verbose or violations:
         print("=" * 72)

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -166,6 +166,16 @@ the *computed* index (Part C of #1664) is the point at which physically
 relocating these makes sense — retiring `MANIFEST.yaml`/the registry and
 moving the gate-data files are the same cutover, not two.
 
+**Three more ratchet baselines follow the identical decision**, though they
+postdate the original 13-file enumeration above: `fk-cascade-baseline.json`
+(cross-domain FK-cascade shrink-only ratchet, read by
+`tests/tooling/test_fk_cascade_ratchet.py`), `delivery-layer-baseline.json`
+(app-delivery-layer line-count ratchet, `AC-meta.delivery.1`, read by
+`tests/tooling/test_delivery_layer_ratchet.py`), and
+[epic-residue-baseline.json](./epic-residue-baseline.json) (EPIC AC residue
+census, `AC-meta.residue.1`, referenced below). Same reasoning, same
+decision: they stay in `docs/ssot/` by name-hardcoded consumer path.
+
 ## AC Index Is Computed (migration closeout, #1719 — #1664 Part C status)
 
 Since #1719 the **AC index is fully computed** by
@@ -181,12 +191,50 @@ Since #1719 the **AC index is fully computed** by
 `docs/ac_registry.yaml` / `docs/infra_registry.yaml` are checked-in **index
 stubs only** (`generated_from_epics: true` triggers materialization on load);
 `docs/ac_registry_overrides.yaml` is empty. That completes the "reduced to
-generated artifacts of meta's data layer" half of #1664 Part C. The still-open
-half — retiring `MANIFEST.yaml` + `tools/check_manifest.py` +
-`check_ssot_ownership` in favor of computed concept ownership, turning this
-README into a pure pointer page, and the matching CLAUDE.md navigation edit
-(which requires explicit user authorization) — is the same cutover as the
-gate-data relocation above and stays tracked on #1664.
+generated artifacts of meta's data layer" half of #1664 Part C.
+
+## MANIFEST.yaml Status (migration closeout wave 3, #1664 Part C — final)
+
+The other half of Part C — retiring `MANIFEST.yaml` + `tools/check_manifest.py`
++ `check_ssot_ownership` in favor of a fully **computed** concept-ownership
+index (the same "governance computed, not authored" principle the AC index
+above now follows) — turned out to be the same class of cutover as the
+gate-data relocation: high blast-radius for a single PR. #1664 closed it out
+to the safely-deliverable half instead of forcing a risky rewrite:
+
+1. **Accuracy audit (done)** — every one of MANIFEST's 76 concepts was
+   checked against its owner: the 27 `common/<pkg>`-owned concepts all
+   correctly point at their post-migration package readme (Part A); the 46
+   `docs/ssot/`-owned concepts are all genuinely cross-cutting infra, live
+   gate data, or generated (classified in the tables above); the remaining
+   3 are governance docs outside both `docs/ssot/` and `common/`
+   (`docs/agents/red-lines.md`, `docs/agents/orchestration.md`,
+   `docs/contributing/branch-policy.md`). No stale owner found.
+2. **New anti-drift gate (done)** — `AC-meta.manifest.1`
+   (`common/meta/extension/check_manifest.py`, check5,
+   `check_docs_ssot_files_classified`): every file physically present in
+   `docs/ssot/` must be referenced by name somewhere in this README. A file
+   dropped into `docs/ssot/` without being classified here now fails CI —
+   this is what caught `fk-cascade-baseline.json` /
+   `delivery-layer-baseline.json` missing from the Gate Data Directory
+   section above during #1664 itself.
+3. **Full computed-index rewrite (deferred)** — filed as
+   [#1799](https://github.com/wangzitian0/finance_report/issues/1799).
+   `common/meta/data/projection.py` (meta's existing computed-index layer)
+   has no structured "concepts" field on `PackageContract` to project from
+   yet; adding one touches ~20 package contracts, and the ~49
+   no-package-owner concepts (cross-cutting/gate-data/generated) need a
+   residual-manifest idiom mirroring the EPIC residue markers below rather
+   than disappearing outright. Per umbrella #1416's 2026-07-12 scope-freeze
+   rule, #1799 is explicitly a post-migration backlog item, not part of the
+   frozen child set — MANIFEST.yaml is accurate and gated today, so this is
+   architecture debt, not a correctness gap.
+4. **CLAUDE.md navigation (done)** — updated in the same PR (explicit user
+   authorization for this task lifted the file's edit prohibition) to
+   describe the post-migration reality: domain concepts live in package
+   readmes, `docs/ssot/` holds cross-cutting infra docs / gate data /
+   generated artifacts, and `MANIFEST.yaml` is the ownership registry for
+   both halves rather than a claim that `docs/ssot/` itself is the source.
 
 | Report | Purpose |
 |---|---|

--- a/tests/tooling/test_check_manifest.py
+++ b/tests/tooling/test_check_manifest.py
@@ -1,11 +1,13 @@
 """Tests for tools/check_manifest.py.
 
-Covers all five checks:
+Covers all six checks:
   0. Per-concept schema validation (concept value must be a mapping/dict)
   1. No duplicate owners (same file#anchor)
   2. Owner files must exist on disk
   3. Cross-ref files must exist on disk
   4. Owner and cross-ref anchors must exist in referenced Markdown files
+  5. Every docs/ssot/ file is referenced in docs/ssot/README.md
+     (AC-meta.manifest.1, anti-drift — #1664)
 
 Also covers main() and helper functions.
 """
@@ -355,6 +357,78 @@ class TestCheckAnchorRefsExist:
 
 
 # ---------------------------------------------------------------------------
+# Tests: check_docs_ssot_files_classified (check5, AC-meta.manifest.1)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDocsSsotFilesClassified:
+    def test_all_files_referenced_passes(self, tmp_path: Path) -> None:
+        ssot_dir = tmp_path / "docs" / "ssot"
+        ssot_dir.mkdir(parents=True)
+        (ssot_dir / "foo.md").write_text("content")
+        (ssot_dir / "bar.yaml").write_text("content")
+        (ssot_dir / "README.md").write_text(
+            "Classified here: foo.md is horizontal infra; bar.yaml is gate data.\n"
+        )
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            assert cm.check_docs_ssot_files_classified() == []
+
+    def test_unreferenced_file_fails(self, tmp_path: Path) -> None:
+        ssot_dir = tmp_path / "docs" / "ssot"
+        ssot_dir.mkdir(parents=True)
+        (ssot_dir / "orphan.md").write_text("content")
+        (ssot_dir / "README.md").write_text("Nothing links to the orphan.\n")
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            violations = cm.check_docs_ssot_files_classified()
+        assert len(violations) == 1
+        assert violations[0].check == "check5_docs_ssot_classified"
+        assert "orphan.md" in violations[0].message
+
+    def test_readme_and_manifest_self_exempt(self, tmp_path: Path) -> None:
+        """README.md and MANIFEST.yaml are the registry itself, not a
+        concept it classifies — they must not have to reference themselves.
+        """
+        ssot_dir = tmp_path / "docs" / "ssot"
+        ssot_dir.mkdir(parents=True)
+        (ssot_dir / "README.md").write_text("Nothing here mentions itself.\n")
+        (ssot_dir / "MANIFEST.yaml").write_text("concepts: {}\n")
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            assert cm.check_docs_ssot_files_classified() == []
+
+    def test_missing_readme_fails(self, tmp_path: Path) -> None:
+        ssot_dir = tmp_path / "docs" / "ssot"
+        ssot_dir.mkdir(parents=True)
+        (ssot_dir / "foo.md").write_text("content")
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            violations = cm.check_docs_ssot_files_classified()
+        assert len(violations) == 1
+        assert "is missing" in violations[0].message
+
+    def test_multiple_unreferenced_files_all_reported(self, tmp_path: Path) -> None:
+        ssot_dir = tmp_path / "docs" / "ssot"
+        ssot_dir.mkdir(parents=True)
+        (ssot_dir / "a.md").write_text("content")
+        (ssot_dir / "b.json").write_text("{}")
+        (ssot_dir / "README.md").write_text("Neither file is mentioned.\n")
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            violations = cm.check_docs_ssot_files_classified()
+        assert len(violations) == 2
+        messages = {v.message for v in violations}
+        assert any("a.md" in m for m in messages)
+        assert any("b.json" in m for m in messages)
+
+
+def test_AC_meta_manifest_1_real_docs_ssot_is_fully_classified() -> None:
+    """AC-meta.manifest.1 (#1664): every file physically present in the real
+    docs/ssot/ directory must be referenced in docs/ssot/README.md — the
+    anti-drift check that stands in for a full computed concept index
+    (tracked as a follow-up, see docs/ssot/README.md § "MANIFEST.yaml Status").
+    """
+    violations = cm.check_docs_ssot_files_classified()
+    assert violations == [], "\n".join(v.message for v in violations)
+
+
+# ---------------------------------------------------------------------------
 # Tests: _file_part helper
 # ---------------------------------------------------------------------------
 
@@ -405,6 +479,9 @@ class TestMain:
         ssot_dir.mkdir(parents=True)
         (ssot_dir / "foo.md").write_text("## Section A\n")
         (ssot_dir / "bar.md").write_text("## Section B\n")
+        # check5_docs_ssot_classified requires every docs/ssot/ file to be
+        # referenced in docs/ssot/README.md.
+        (ssot_dir / "README.md").write_text("Pointer page: foo.md, bar.md\n")
 
         manifest = tmp_path / "MANIFEST.yaml"
         manifest.write_text(
@@ -432,6 +509,9 @@ class TestMain:
         ssot_dir = tmp_path / "docs" / "ssot"
         ssot_dir.mkdir(parents=True)
         (ssot_dir / "foo.md").write_text("# Foo\n", encoding="utf-8")
+        # check5_docs_ssot_classified requires every docs/ssot/ file to be
+        # referenced in docs/ssot/README.md.
+        (ssot_dir / "README.md").write_text("Pointer page: foo.md\n", encoding="utf-8")
         manifest = tmp_path / "MANIFEST.yaml"
         manifest.write_text(
             "concepts:\n"

--- a/tests/tooling/test_check_manifest.py
+++ b/tests/tooling/test_check_manifest.py
@@ -412,7 +412,7 @@ class TestCheckDocsSsotFilesClassified:
         with mock.patch.object(cm, "REPO_ROOT", tmp_path):
             violations = cm.check_docs_ssot_files_classified()
         assert len(violations) == 1
-        assert "is missing" in violations[0].message
+        assert violations[0].check == "check5_docs_ssot_classified"
 
     def test_multiple_unreferenced_files_all_reported(self, tmp_path: Path) -> None:
         ssot_dir = tmp_path / "docs" / "ssot"

--- a/tests/tooling/test_check_manifest.py
+++ b/tests/tooling/test_check_manifest.py
@@ -301,7 +301,7 @@ class TestCheckAnchorRefsExist:
         ssot = tmp_path / "docs" / "ssot"
         ssot.mkdir(parents=True)
         (ssot / "accounting.md").write_text(
-            "# Accounting\n\n<a id=\"decimal-rule\"></a>\n\n## Entry Balance\n",
+            '# Accounting\n\n<a id="decimal-rule"></a>\n\n## Entry Balance\n',
             encoding="utf-8",
         )
 
@@ -399,6 +399,16 @@ class TestCheckDocsSsotFilesClassified:
         ssot_dir = tmp_path / "docs" / "ssot"
         ssot_dir.mkdir(parents=True)
         (ssot_dir / "foo.md").write_text("content")
+        with mock.patch.object(cm, "REPO_ROOT", tmp_path):
+            violations = cm.check_docs_ssot_files_classified()
+        assert len(violations) == 1
+        assert "is missing" in violations[0].message
+
+    def test_missing_ssot_dir_reports_violation_instead_of_crashing(
+        self, tmp_path: Path
+    ) -> None:
+        """docs/ssot/ absent entirely must not reach ``ssot_dir.iterdir()``."""
+        (tmp_path / "docs").mkdir()
         with mock.patch.object(cm, "REPO_ROOT", tmp_path):
             violations = cm.check_docs_ssot_files_classified()
         assert len(violations) == 1


### PR DESCRIPTION
## Summary

Closes #1664's remaining scope (Part C) by verifying Parts A/B/half-of-C were
already completed by #1783, auditing `MANIFEST.yaml` for accuracy, and adding
a new anti-drift gate that immediately caught two real documentation gaps.
The full "compute concept ownership from package contracts" rewrite is
assessed as too large for one PR and deferred to a scoped follow-up (#1799).

Closes #1664

---

## What was already done (verified, not re-done)

Per this task's instruction to verify rather than trust prior "already done"
claims, I independently checked repo state before writing any code:

- **Part A** (5 domain docs → package readmes): confirmed done. `docs/ssot/{reconciliation,ai,reporting,assets,market_data}.md` are all short pointer stubs with an explicit "**Migrated**" marker to their owning package readme (`common/reconciliation`, `common/advisor`, `common/reporting`, `common/portfolio`+`common/pricing`, `common/pricing`). Every other `docs/ssot/*.md` is explicitly classified (horizontal infra / future package candidate / generated) in `docs/ssot/README.md`'s Cross-Cutting Classification table.
- **Part B** (gate-data files): confirmed done. `docs/ssot/README.md`'s "Gate Data Directory" section explicitly declares `docs/ssot/` the permanent home for the 13 listed files, with a documented cross-repo-convention reason for `ci-gate-inventory.yaml`.
- **Part C, half 1** (`docs/ac_registry.yaml` / `docs/infra_registry.yaml`): confirmed done via PR #1783 — both are now 7-line generated stubs (`generated_from_epics: true`), materialized by `common/meta/extension/generate_ac_registry.py` from package roadmaps + explicitly EPIC-residue-marked rows. `docs/ac_registry_overrides.yaml` is empty. Verified with `tools/generate_ac_registry.py --check` → `OK`.

## What this PR adds (Part C, half 2)

1. **MANIFEST.yaml accuracy audit** (all 76 concepts, by hand, cross-checked against Part A/B's classification):
   - 27 `common/<pkg>`-owned concepts — all correctly repoint to their post-migration package readme. No stale pointer found.
   - 46 `docs/ssot/`-owned concepts — every one is genuinely cross-cutting infra, a live gate-data ratchet/baseline, or a generated artifact (all classified in `docs/ssot/README.md`'s tables).
   - 3 governance-doc-owned concepts (`docs/agents/red-lines.md`, `docs/agents/orchestration.md`, `docs/contributing/branch-policy.md`) — correctly outside both `docs/ssot/` and `common/`.
   - **Found and fixed a real gap**: `fk-cascade-baseline.json` and `delivery-layer-baseline.json` (2 ratchet baselines that postdate Part B's original 13-file enumeration) were not mentioned anywhere in `docs/ssot/README.md`, even though `epic-residue-baseline.json` (added by #1783) was. Added a short paragraph documenting all three.

2. **New anti-drift gate** — `AC-meta.manifest.1` (`common/meta/extension/check_manifest.py`, new check5 `check_docs_ssot_files_classified`): every file physically present in `docs/ssot/` must be referenced by name in `docs/ssot/README.md`. This is what caught the gap above — I ran the new check against the real repo *before* fixing the README and it correctly reported exactly those 2 files as violations (see TDD Evidence). It's cheap (one directory listing + one file read, no network) and it's the safe, narrow version of what the issue actually asked for (see below).

3. **Assessed the full computed-index rewrite and deferred it** — the issue wants concept ownership *computed* from package contracts, not hand-authored, mirroring how `docs/ac_registry.yaml` now works. I checked `common/meta/data/projection.py` (meta's existing computed-index layer): it has `contract_index()` projecting `registry`/`ac_index`/`consumers`/`units_by_layer` from `PackageContract.roadmap`/`depends_on`/`units` — but **no structured field for "concepts" exists on `PackageContract` today**. Building the real thing needs: (a) a new declaration on `PackageContract` for the 27 package-owned concepts (touches ~20 contracts), (b) a `concept_index()` projection, (c) a residual-manifest mechanism for the ~49 concepts with no owning package (same idiom as the EPIC residue markers from #1719/#1783). That's a multi-package refactor, not a doc cleanup — filed as **#1799**, explicitly marked as post-migration backlog (not part of umbrella #1416's 2026-07-12 scope-freeze set) since `MANIFEST.yaml` is accurate and gated today; this is architecture debt, not a correctness gap.

4. **`docs/ssot/README.md`** — added a new "MANIFEST.yaml Status" section recording all four points above (audit done / gate added / rewrite deferred to #1799 / CLAUDE.md updated), so the PR's reasoning is discoverable from the doc itself, not just this PR description.

5. **`AGENTS.md`** (= `CLAUDE.md`, a symlink to it) — updated per this task's **explicit user authorization** to lift the file's edit-prohibition for this specific change:
   - "Four Orthogonal Concerns" table: SSOT row now states a concept lives in its owning package readme *or* `docs/ssot/` for cross-cutting/gate-data/generated ones, rather than implying `docs/ssot/` alone is authoritative.
   - "SSOT-First Principle" section: rewritten to match (package-owned concepts live in package readmes; `docs/ssot/` is for genuinely cross-cutting content; MANIFEST.yaml is the registry, not necessarily the content).
   - "Mandatory Work Order" step 2: corrected a stale claim that legacy modules "register ACs in `docs/ac_registry.yaml`" — that file is now a **generated** stub (per #1783), never hand-edited; legacy ACs are added as residue-marked EPIC rows instead.
   - "Documentation Map" table: SSOT row now describes the post-migration contents (cross-cutting infra + gate data + generated artifacts + the registry), not "shared base-element language & contracts."
   - No other part of `AGENTS.md`/`CLAUDE.md` touched.

## What is explicitly NOT done (deferred, not silently dropped)

- Full computed concept-ownership index (retiring `MANIFEST.yaml`'s hand-authored YAML in favor of a `concept_index()` projection like `contract_index()`) — **#1799**, post-migration backlog.
- `tools/check_manifest.py`'s existing checks (duplicate-owner / owner-exists / anchor-exists) are **not** retired — they still validate real structure and stay useful even after #1799 lands (the residual-manifest half will still need them).
- `check_ssot_ownership.py` — no logic changes; MANIFEST's schema didn't change, so its checks remain valid as-is (verified green).

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | Umbrella #1416 (migration closeout, Batch-3) / Issue #1664 |
| **AC IDs** | `AC-meta.manifest.1` (new) |
| **AC source updated** | `common/meta/contract.py` roadmap |

---

## SSOT Changes

- [x] `docs/ssot/MANIFEST.yaml` — audited only, no changes needed (verified accurate)
- [x] `docs/ssot/README.md` — added 2 missing gate-data-file mentions + new "MANIFEST.yaml Status" section
- [ ] None — existing SSOT already covers this change

---

## TDD Evidence

This PR is primarily a verification + narrow-addition task, so the red/green
pair was captured by direct invocation during development (documented here
verbatim) rather than as two separate preserved commits:

| Phase | Evidence | Description |
|-------|-----------|-------------|
| 🔴 Red | Direct invocation of `check_docs_ssot_files_classified()` against the real repo, **before** editing `docs/ssot/README.md` | Returned exactly 2 violations: `docs/ssot/delivery-layer-baseline.json is not referenced anywhere in docs/ssot/README.md` and `docs/ssot/fk-cascade-baseline.json is not referenced anywhere in docs/ssot/README.md` |
| 🟢 Green | `8f6f78ad` (this PR's single commit) | `docs/ssot/README.md` fixed in the same commit as the new check; `tests/tooling/test_check_manifest.py::test_AC_meta_manifest_1_real_docs_ssot_is_fully_classified` passes; full `tools/check_manifest.py` run reports 0 violations across all 76 concepts |

---

## Engineering Audit

- [ ] `sa.Enum` instances all have explicit `name="..._enum"` parameter (N/A — no schema changes)
- [ ] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (N/A)
- [ ] `repo/` submodule updated for production config changes (N/A — untouched)
- [ ] `tools/check_env_keys.py` passes (N/A — no env vars changed)
- [x] `tools/check_manifest.py` passes (76 concepts, 0 violations)
- [x] `tools/lint_doc_consistency.py` passes
- [x] No real financial data

---

## Testing

```bash
# venv: apps/backend/.venv/bin/python, run from repo root

# the new gate + its tests
apps/backend/.venv/bin/python -m pytest tests/tooling/test_check_manifest.py -q
# → 46 passed

# central SSOT/registry gates
python tools/check_manifest.py --verbose        # 76 concepts, OK
python tools/check_ssot_ownership.py --verbose   # OK
python tools/lint_doc_consistency.py             # exit 0
python tools/check_package_contract.py           # PASSED, meta: 63 roadmap AC(s)
python tools/generate_ac_registry.py --check     # OK: AC registries include every EPIC-defined AC

# full tooling suite (fast enough to run in full, ~2.5 min)
apps/backend/.venv/bin/python -m pytest tests/tooling/ -q
# → 2058 passed, 1 skipped

# diff-aware preflight
apps/backend/.venv/bin/python tools/preflight.py --base origin/main
# → ssot-ownership, doc-consistency, taxonomy-drift, tooling: all [ok]
```

---

## Screenshots / Evidence

_N/A (governance/tooling PR; no UI changes)._

---

## Follow-up filed

**#1799** — "Compute SSOT concept ownership from package contracts (retire
MANIFEST.yaml hand-authoring)". Explicitly scoped as post-migration backlog,
not blocking umbrella #1416's closure per its own 2026-07-12 scope-freeze
rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
