### PR TITLE
[finance_report_ui] fix(#1796): disclose valuation/holdings data gaps in API responses

### DIFF
--- a/apps/backend/src/portfolio/extension/holdings.py
+++ b/apps/backend/src/portfolio/extension/holdings.py
@@ -106,6 +106,7 @@ class PortfolioService:
         user_id: UUID,
         as_of_date: date | None = None,
         include_disposed: bool = False,
+        warnings: list[dict[str, str]] | None = None,
     ) -> Sequence[HoldingResponse]:
         """
         Get portfolio holdings summary.
@@ -118,6 +119,9 @@ class PortfolioService:
             user_id: User UUID
             as_of_date: Date to evaluate positions as of (default: today)
             include_disposed: Include disposed positions in results
+            warnings: Optional accumulator; a snapshot skipped for lack of a
+                reconciled position is disclosed here instead of only logged
+                (#1796), so the caller's response never silently omits it
 
         Returns:
             List of holdings with market values and P&L calculations
@@ -131,6 +135,7 @@ class PortfolioService:
                 user_id=user_id,
                 as_of_date=as_of_date,
                 include_disposed=include_disposed,
+                warnings=warnings,
             )
 
         eval_date = await self._default_holdings_eval_date(db, user_id)
@@ -226,6 +231,7 @@ class PortfolioService:
         user_id: UUID,
         as_of_date: date,
         include_disposed: bool,
+        warnings: list[dict[str, str]] | None = None,
     ) -> Sequence[HoldingResponse]:
         """Return point-in-time holdings from immutable AtomicPosition snapshots."""
         latest_snapshot_subquery = (
@@ -268,6 +274,19 @@ class PortfolioService:
                     asset_identifier=snapshot.asset_identifier,
                     as_of_date=as_of_date.isoformat(),
                 )
+                if warnings is not None:
+                    warnings.append(
+                        {
+                            "type": "unreconciled_snapshot_skipped",
+                            "asset_identifier": snapshot.asset_identifier,
+                            "as_of_date": as_of_date.isoformat(),
+                            "message": (
+                                f"Snapshot for {snapshot.asset_identifier} has no reconciled "
+                                f"managed position and is excluded from holdings as of "
+                                f"{as_of_date.isoformat()}."
+                            ),
+                        }
+                    )
                 continue
 
             synced_price = await self._get_latest_synced_stock_price(db, snapshot.asset_identifier, as_of_date)

--- a/apps/backend/src/pricing/extension/valuation.py
+++ b/apps/backend/src/pricing/extension/valuation.py
@@ -6,7 +6,7 @@ Valuation snapshots and their versioned read models are pricing-owned facts
 """
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
 from typing import Any
@@ -50,12 +50,19 @@ class ValuationComponentItem:
 
 @dataclass
 class ValuationComponentsResult:
-    """Aggregated latest manual valuation components."""
+    """Aggregated latest manual valuation components.
+
+    ``warnings`` discloses (component_type, source) combinations that exist for
+    the user but have no snapshot on or before the requested ``as_of_date`` —
+    their value is absent from the totals, and without the disclosure a
+    historical total would silently read as complete (#1796, Axiom B).
+    """
 
     items: list[ValuationComponentItem]
     total_assets: Decimal
     total_liabilities: Decimal
     net_worth_delta: Decimal
+    warnings: list[dict[str, str]] = field(default_factory=list)
 
 
 _DEFAULT_LIQUIDITY_CLASS: dict[ManualValuationComponentType, ManualValuationLiquidityClass] = {
@@ -359,6 +366,40 @@ class ValuationService:
         )
         snapshots = result.scalars().all()
 
+        # Disclose combos whose only snapshots postdate as_of_date: they are
+        # absent from the totals below, and "we did not own it yet" vs "we had
+        # not recorded it yet" is inherently ambiguous for a manual component
+        # (#1796) — so the gap is warned about, never guessed at. Liquidity
+        # class is not consulted: a combo excluded here is absent regardless of
+        # include_restricted.
+        gap_rows = await db.execute(
+            select(
+                ManualValuationSnapshot.component_type,
+                ManualValuationSnapshot.source,
+                func.min(ManualValuationSnapshot.as_of_date).label("earliest_as_of_date"),
+            )
+            .where(ManualValuationSnapshot.user_id == user_id)
+            .where(ManualValuationSnapshot.superseded_by_id.is_(None))
+            .group_by(ManualValuationSnapshot.component_type, ManualValuationSnapshot.source)
+            .having(func.min(ManualValuationSnapshot.as_of_date) > as_of_date)
+            .order_by(ManualValuationSnapshot.component_type, ManualValuationSnapshot.source)
+        )
+        warnings: list[dict[str, str]] = [
+            {
+                "type": "valuation_component_not_yet_recorded",
+                "component_type": row.component_type.value,
+                "source": row.source,
+                "as_of_date": as_of_date.isoformat(),
+                "earliest_as_of_date": row.earliest_as_of_date.isoformat(),
+                "message": (
+                    f"Manual valuation '{row.source}' ({row.component_type.value}) has no "
+                    f"snapshot on or before {as_of_date.isoformat()} (earliest is "
+                    f"{row.earliest_as_of_date.isoformat()}); it is excluded from these totals."
+                ),
+            }
+            for row in gap_rows
+        ]
+
         total_assets = Decimal("0.00")
         total_liabilities = Decimal("0.00")
         items: list[ValuationComponentItem] = []
@@ -396,6 +437,7 @@ class ValuationService:
             total_assets=total_assets,
             total_liabilities=total_liabilities,
             net_worth_delta=to_money(total_assets - total_liabilities),
+            warnings=warnings,
         )
 
 
@@ -449,8 +491,14 @@ async def build_manual_valuation_lines(
     as_of_date: date,
     target_currency: str,
     include_restricted: bool = True,
+    warnings: list[dict[str, str]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Build balance sheet lines from latest manual valuation components.
+
+    ``warnings`` is an optional accumulator (same pattern as the portfolio
+    market-adjustment builder): components whose only snapshot postdates
+    ``as_of_date`` are absent from the lines, and the caller's report should
+    disclose that instead of presenting a silently incomplete total (#1796).
 
     Raises the pricing error family
     (:class:`~src.pricing.base.errors.PricingError`) when a required FX rate
@@ -472,6 +520,8 @@ async def build_manual_valuation_lines(
         as_of_date=as_of_date,
         include_restricted=include_restricted,
     )
+    if warnings is not None:
+        warnings.extend(components.warnings)
     asset_lines: list[dict[str, Any]] = []
     liability_lines: list[dict[str, Any]] = []
 

--- a/apps/backend/src/pricing/extension/valuation.py
+++ b/apps/backend/src/pricing/extension/valuation.py
@@ -13,6 +13,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import Select, func, select
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit.money import to_money
@@ -369,20 +370,31 @@ class ValuationService:
         # Disclose combos whose only snapshots postdate as_of_date: they are
         # absent from the totals below, and "we did not own it yet" vs "we had
         # not recorded it yet" is inherently ambiguous for a manual component
-        # (#1796) — so the gap is warned about, never guessed at. Liquidity
-        # class is not consulted: a combo excluded here is absent regardless of
-        # include_restricted.
+        # (#1796) — so the gap is warned about, never guessed at. A view that
+        # excludes restricted/illiquid components must not have their existence
+        # disclosed by a warning either, so the combo's latest liquidity class
+        # rides along and is filtered under include_restricted=False.
+        latest_liquidity = aggregate_order_by(
+            ManualValuationSnapshot.liquidity_class,
+            ManualValuationSnapshot.as_of_date.desc(),
+            ManualValuationSnapshot.created_at.desc(),
+        )
         gap_rows = await db.execute(
             select(
                 ManualValuationSnapshot.component_type,
                 ManualValuationSnapshot.source,
                 func.min(ManualValuationSnapshot.as_of_date).label("earliest_as_of_date"),
+                func.array_agg(latest_liquidity)[1].label("latest_liquidity_class"),
             )
             .where(ManualValuationSnapshot.user_id == user_id)
             .where(ManualValuationSnapshot.superseded_by_id.is_(None))
             .group_by(ManualValuationSnapshot.component_type, ManualValuationSnapshot.source)
             .having(func.min(ManualValuationSnapshot.as_of_date) > as_of_date)
             .order_by(ManualValuationSnapshot.component_type, ManualValuationSnapshot.source)
+        )
+        hidden_classes = (
+            ManualValuationLiquidityClass.RESTRICTED,
+            ManualValuationLiquidityClass.ILLIQUID,
         )
         warnings: list[dict[str, str]] = [
             {
@@ -398,6 +410,7 @@ class ValuationService:
                 ),
             }
             for row in gap_rows
+            if include_restricted or row.latest_liquidity_class not in hidden_classes
         ]
 
         total_assets = Decimal("0.00")

--- a/apps/backend/src/reporting/extension/balance_sheet.py
+++ b/apps/backend/src/reporting/extension/balance_sheet.py
@@ -67,6 +67,7 @@ async def _build_manual_valuation_lines(
     as_of_date: date,
     target_currency: str,
     include_restricted: bool = True,
+    warnings: list[FxWarning] | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """Dispatch to the registered manual-valuation lines provider."""
     if _manual_valuation_lines_provider is None:
@@ -81,6 +82,7 @@ async def _build_manual_valuation_lines(
         as_of_date=as_of_date,
         target_currency=target_currency,
         include_restricted=include_restricted,
+        warnings=warnings,
     )
 
 
@@ -186,6 +188,7 @@ async def generate_balance_sheet(
             as_of_date=as_of_date,
             target_currency=target_currency,
             include_restricted=include_restricted,
+            warnings=portfolio_warnings,
         )
     except fx_gateway.FxRateError as exc:
         # pricing.build_manual_valuation_lines (registered above) raises its

--- a/apps/backend/src/routers/assets.py
+++ b/apps/backend/src/routers/assets.py
@@ -255,6 +255,7 @@ async def list_valuation_components(
         total_assets=result.total_assets,
         total_liabilities=result.total_liabilities,
         net_worth_delta=result.net_worth_delta,
+        warnings=result.warnings,
     )
 
 

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -136,18 +136,20 @@ async def get_holdings(
 
     warnings: list[dict[str, str]] = []
     try:
-        holdings = await _portfolio_service.get_holdings(
-            db=db,
-            user_id=user_id,
-            as_of_date=as_of_date,
-            include_disposed=include_disposed,
-            warnings=warnings,
+        holdings = list(
+            await _portfolio_service.get_holdings(
+                db=db,
+                user_id=user_id,
+                as_of_date=as_of_date,
+                include_disposed=include_disposed,
+                warnings=warnings,
+            )
         )
     except (PortfolioNotFoundError, AssetNotFoundError):
         # No holdings found — return an empty page instead of an error
         return HoldingsListResponse(items=[], total=0, warnings=warnings)
 
-    page = list(holdings)[offset : offset + limit]
+    page = holdings[offset : offset + limit]
     logger.info("Retrieved holdings", count=len(page), total=len(holdings))
     return HoldingsListResponse(items=page, total=len(holdings), warnings=warnings)
 

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -37,7 +37,7 @@ from src.schemas.portfolio import (
     CostBasisMethodUpdateRequest,
     CostBasisMethodUpdateResponse,
     DividendEventResponse,
-    HoldingResponse,
+    HoldingsListResponse,
     InvestmentPerformanceReportScheduleResponse,
     PortfolioSummaryDashboardResponse,
     PriceUpdateBatchResponse,
@@ -110,7 +110,7 @@ async def import_brokerage_positions(
     return BrokerageImportResponse(**result.__dict__)
 
 
-@router.get("/holdings", response_model=list[HoldingResponse])
+@router.get("/holdings", response_model=HoldingsListResponse)
 async def get_holdings(
     db: DbSession,
     user_id: CurrentUserId,
@@ -118,8 +118,13 @@ async def get_holdings(
     include_disposed: bool = Query(False, description="Include disposed positions"),
     limit: int = Query(_DEFAULT_LIST_LIMIT, ge=1, le=_MAX_LIST_LIMIT, description="Maximum items to return"),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
-) -> list[HoldingResponse]:
-    """Get portfolio holdings with P&L (bounded by limit/offset; see AC17.30)."""
+) -> HoldingsListResponse:
+    """Get portfolio holdings with P&L (bounded by limit/offset; see AC17.30).
+
+    AC-portfolio.holdings.6 (#1796): responds in the repo-standard items+total
+    wrapper plus ``warnings`` — a snapshot excluded from the page (no reconciled
+    managed position as of the date) is disclosed to the caller, not just logged.
+    """
     logger.info(
         "Getting holdings",
         user_id=str(user_id),
@@ -129,20 +134,22 @@ async def get_holdings(
         offset=offset,
     )
 
+    warnings: list[dict[str, str]] = []
     try:
         holdings = await _portfolio_service.get_holdings(
             db=db,
             user_id=user_id,
             as_of_date=as_of_date,
             include_disposed=include_disposed,
+            warnings=warnings,
         )
     except (PortfolioNotFoundError, AssetNotFoundError):
-        # No holdings found — return empty list instead of error
-        return []
+        # No holdings found — return an empty page instead of an error
+        return HoldingsListResponse(items=[], total=0, warnings=warnings)
 
     page = list(holdings)[offset : offset + limit]
     logger.info("Retrieved holdings", count=len(page), total=len(holdings))
-    return page
+    return HoldingsListResponse(items=page, total=len(holdings), warnings=warnings)
 
 
 @router.get("/summary", response_model=PortfolioSummaryDashboardResponse)

--- a/apps/backend/src/schemas/assets.py
+++ b/apps/backend/src/schemas/assets.py
@@ -167,6 +167,13 @@ class ValuationComponentsResponse(BaseModel):
     total_assets: MoneyAmount
     total_liabilities: MoneyAmount
     net_worth_delta: MoneyAmount
+    warnings: list[dict[str, str]] = Field(
+        default_factory=list,
+        description=(
+            "Components excluded because their only snapshot postdates as_of_date — "
+            "disclosed so a historical total never silently reads as complete (#1796)."
+        ),
+    )
 
 
 class RestrictedHoldingResponse(BaseModel):

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -68,6 +68,24 @@ class HoldingResponse(BaseResponse):
         return self.cost_basis
 
 
+class HoldingsListResponse(ListResponse[HoldingResponse]):
+    """Holdings page in the repo-standard items+total wrapper (#1796).
+
+    ``warnings`` discloses point-in-time snapshots excluded from the page (e.g.
+    no reconciled managed position as of the requested date) — previously only
+    logged, so the response silently read as complete.
+    """
+
+    warnings: list[dict[str, str]] = Field(
+        default_factory=list,
+        description=(
+            "Point-in-time snapshots excluded from the page (e.g. no reconciled "
+            "managed position as of the requested date) — disclosed instead of "
+            "silently omitted (#1796)."
+        ),
+    )
+
+
 class RealizedPnLResponse(BaseModel):
     """Schema for realized P&L response."""
 

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -563,7 +563,7 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     # Holdings stay empty until the user triggers the explicit import endpoint.
     pre_import_holdings = await client.get("/portfolio/holdings", params={"as_of_date": "2026-05-18"})
     assert pre_import_holdings.status_code == 200
-    assert pre_import_holdings.json() == []
+    assert pre_import_holdings.json()["items"] == []
 
     # #1408: the explicit, user-initiated endpoint is the only path that creates positions.
     import_response = await client.post(f"/statements/{statement_id}/brokerage/import")
@@ -583,7 +583,7 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
         params={"as_of_date": "2026-05-18"},
     )
     assert holdings_response.status_code == 200
-    holdings = holdings_response.json()
+    holdings = holdings_response.json()["items"]
     assert len(holdings) == 1
     assert holdings[0]["asset_identifier"] == _BRIDGE_ASSET_IDENTIFIER
     assert holdings[0]["account_name"] == "Moomoo"

--- a/apps/backend/tests/portfolio/test_brokerage_import_gated_on_review.py
+++ b/apps/backend/tests/portfolio/test_brokerage_import_gated_on_review.py
@@ -132,14 +132,14 @@ async def test_AC1_AC2_pending_review_absent_from_holdings_until_explicit_import
 
     before = await client.get("/portfolio/holdings")
     assert before.status_code == 200
-    assert before.json() == [], "pending-review brokerage positions must not appear in holdings"
+    assert before.json()["items"] == [], "pending-review brokerage positions must not appear in holdings"
 
     imported = await client.post(f"/statements/{stmt.id}/brokerage/import")
     assert imported.status_code == 200, imported.text
 
     after = await client.get("/portfolio/holdings")
     assert after.status_code == 200
-    identifiers = {h.get("asset_identifier") or h.get("ticker") for h in after.json()}
+    identifiers = {h.get("asset_identifier") or h.get("ticker") for h in after.json()["items"]}
     assert _ASSET in identifiers, "explicit brokerage import should surface the positions in holdings"
 
 

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -759,7 +759,7 @@ async def test_statement_import_flows_to_holdings_and_balance_sheet(client, db, 
     )
 
     assert holdings_response.status_code == 200
-    holdings = holdings_response.json()
+    holdings = holdings_response.json()["items"]
     assert len(holdings) == 1
     assert holdings[0]["asset_identifier"] == "Fullerton SGD Money Market Fund"
     assert holdings[0]["account_name"] == "Moomoo"

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -90,23 +90,23 @@ async def portfolio_with_data(db: AsyncSession, test_user, investment_account):
 
 
 async def test_get_holdings_empty_portfolio(client: AsyncClient):
-    """AC17.6.1: GET /portfolio/holdings on empty portfolio returns 200 with empty list.
+    """AC17.6.1: GET /portfolio/holdings on empty portfolio returns 200 with empty page.
 
     Verify that the holdings endpoint gracefully handles no positions.
     """
     response = await client.get("/portfolio/holdings")
     assert response.status_code == 200
-    assert response.json() == []
+    assert response.json() == {"items": [], "total": 0, "warnings": []}
 
 
 async def test_get_holdings_with_data(client: AsyncClient, portfolio_with_data):
-    """AC17.6.2: GET /portfolio/holdings with data returns non-empty list.
+    """AC17.6.2: GET /portfolio/holdings with data returns non-empty items page.
 
     Verify that the holdings endpoint returns portfolio data when positions exist.
     """
     response = await client.get("/portfolio/holdings")
     assert response.status_code == 200
-    data = response.json()
+    data = response.json()["items"]
     assert isinstance(data, list)
     assert len(data) > 0
 
@@ -289,7 +289,7 @@ async def test_get_holdings_defaults_to_future_imported_snapshot(
     response = await client.get("/portfolio/holdings")
 
     assert response.status_code == 200
-    data = response.json()
+    data = response.json()["items"]
     assert len(data) == 1
     assert data[0]["asset_identifier"] == "FULLERTON-SGD-MMF"
     assert Decimal(data[0]["market_value"]) == Decimal("1234.00")
@@ -331,7 +331,7 @@ async def test_get_holdings_explicit_date_does_not_use_future_snapshot(
     response = await client.get(f"/portfolio/holdings?as_of_date={date.today().isoformat()}")
 
     assert response.status_code == 200
-    assert response.json() == []
+    assert response.json()["items"] == []
 
 
 async def test_get_holdings_explicit_date_uses_historical_snapshot_quantity(
@@ -382,11 +382,46 @@ async def test_get_holdings_explicit_date_uses_historical_snapshot_quantity(
     response = await client.get(f"/portfolio/holdings?as_of_date={historical_date.isoformat()}")
 
     assert response.status_code == 200
-    data = response.json()
+    data = response.json()["items"]
     assert len(data) == 1
     assert data[0]["asset_identifier"] == "VWRA"
     assert Decimal(data[0]["quantity"]) == Decimal("10.000000")
     assert Decimal(data[0]["market_value"]) == Decimal("1200.00")
+
+
+async def test_AC_portfolio_holdings_6_unreconciled_snapshot_disclosed_in_warnings(
+    client: AsyncClient,
+    db: AsyncSession,
+    test_user,
+):
+    """AC-portfolio.holdings.6: a point-in-time snapshot with no reconciled
+    managed position is excluded from the holdings page AND disclosed in the
+    response's warnings list (#1796) — previously it was only logged, so the
+    response silently read as complete."""
+    snapshot_date = date(2025, 1, 31)
+    db.add(
+        AtomicPosition(
+            user_id=test_user.id,
+            snapshot_date=snapshot_date,
+            asset_identifier="ORPHAN-FUND",
+            broker="Test Broker",
+            quantity=Decimal("10"),
+            market_value=Decimal("1000.00"),
+            currency="SGD",
+            dedup_hash="orphan_snapshot_warning",
+            source_documents={},
+        )
+    )
+    await db.commit()
+
+    response = await client.get(f"/portfolio/holdings?as_of_date={snapshot_date.isoformat()}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert [w["type"] for w in body["warnings"]] == ["unreconciled_snapshot_skipped"]
+    assert body["warnings"][0]["asset_identifier"] == "ORPHAN-FUND"
+    assert body["warnings"][0]["as_of_date"] == snapshot_date.isoformat()
 
 
 async def test_get_holdings_include_disposed(client: AsyncClient, portfolio_with_data):
@@ -1104,7 +1139,10 @@ async def test_AC17_30_1_holdings_default_cap_applied(
     # No `limit` param -> the (patched) default cap of 2 must apply, not all 3.
     response = await client.get("/portfolio/holdings")
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    body = response.json()
+    assert len(body["items"]) == 2
+    # total reports the full match count, not the capped page size
+    assert body["total"] == 3
 
 
 async def test_AC17_30_2_holdings_limit_offset_honored(
@@ -1146,12 +1184,12 @@ async def test_AC17_30_2_holdings_limit_offset_honored(
 
     full = await client.get("/portfolio/holdings")
     assert full.status_code == 200
-    full_assets = [row["asset_identifier"] for row in full.json()]
+    full_assets = [row["asset_identifier"] for row in full.json()["items"]]
     assert len(full_assets) == 3
 
     page = await client.get("/portfolio/holdings?limit=1&offset=1")
     assert page.status_code == 200
-    page_assets = [row["asset_identifier"] for row in page.json()]
+    page_assets = [row["asset_identifier"] for row in page.json()["items"]]
     assert page_assets == full_assets[1:2]
 
 

--- a/apps/backend/tests/portfolio/test_position_valuation_consistency.py
+++ b/apps/backend/tests/portfolio/test_position_valuation_consistency.py
@@ -98,7 +98,7 @@ async def test_ac1_reporting_cost_basis_reconciles_on_base(client, db, test_user
 
     holdings_resp = await client.get("/portfolio/holdings")
     assert holdings_resp.status_code == 200
-    holding = _find_holding(holdings_resp.json(), str(position.id))
+    holding = _find_holding(holdings_resp.json()["items"], str(position.id))
 
     # /assets/positions exposes the base-converted cost basis ...
     assert item["reporting_currency"] == "SGD"
@@ -119,7 +119,7 @@ async def test_ac2_native_values_reconcile(client, db, test_user):
 
     holdings_resp = await client.get("/portfolio/holdings")
     assert holdings_resp.status_code == 200
-    holding = _find_holding(holdings_resp.json(), str(position.id))
+    holding = _find_holding(holdings_resp.json()["items"], str(position.id))
 
     assert item["currency"] == "HKD"
     assert Decimal(str(item["cost_basis"])) == _NATIVE_COST
@@ -166,7 +166,7 @@ async def test_native_and_reporting_currency_fields_are_identically_named_across
 
     holdings_resp = await client.get("/portfolio/holdings")
     assert holdings_resp.status_code == 200
-    holding = _find_holding(holdings_resp.json(), str(position.id))
+    holding = _find_holding(holdings_resp.json()["items"], str(position.id))
 
     # Both endpoints now carry BOTH explicit, identically-named currency fields.
     assert item["native_currency"] == holding["native_currency"] == "HKD"

--- a/apps/backend/tests/pricing/test_valuation_lines.py
+++ b/apps/backend/tests/pricing/test_valuation_lines.py
@@ -157,3 +157,17 @@ async def test_AC_pricing_manualvaluation_4_component_recorded_after_as_of_is_wa
     assert warning["as_of_date"] == "2026-05-31"
     assert warning["earliest_as_of_date"] == "2026-06-15"
     assert "cpf statement" in warning["message"]
+
+    # A view that excludes restricted/illiquid components must not disclose
+    # their existence via gap warnings either (#1796 CR follow-up): the CPF
+    # combo is RESTRICTED, so the exclusive view carries no warning for it.
+    exclusive_warnings: list[dict[str, str]] = []
+    await build_manual_valuation_lines(
+        db,
+        test_user.id,
+        as_of_date=date(2026, 5, 31),
+        target_currency="SGD",
+        include_restricted=False,
+        warnings=exclusive_warnings,
+    )
+    assert exclusive_warnings == []

--- a/apps/backend/tests/pricing/test_valuation_lines.py
+++ b/apps/backend/tests/pricing/test_valuation_lines.py
@@ -106,3 +106,54 @@ async def test_AC_pricing_manualvaluation_3_fx_miss_raises_pricing_error(db: Asy
             as_of_date=date(2026, 5, 31),
             target_currency="SGD",
         )
+
+
+async def test_AC_pricing_manualvaluation_4_component_recorded_after_as_of_is_warned(
+    db: AsyncSession, test_user
+) -> None:
+    """AC-pricing.manualvaluation.4: a (component_type, source) combination whose
+    only snapshot postdates as_of_date is absent from the lines and totals, and
+    is disclosed through the warnings accumulator instead of vanishing silently
+    (#1796); combinations with an eligible snapshot produce no warning."""
+    await record_manual_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+        as_of=date(2026, 5, 1),
+        value=Decimal("1000000.00"),
+        currency="SGD",
+        source="appraisal",
+    )
+    # Recorded for the first time only after the report date below.
+    await record_manual_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.CPF_BALANCE,
+        liquidity_class=ManualValuationLiquidityClass.RESTRICTED,
+        as_of=date(2026, 6, 15),
+        value=Decimal("50000.00"),
+        currency="SGD",
+        source="cpf statement",
+    )
+    await db.commit()
+
+    warnings: list[dict[str, str]] = []
+    asset_lines, liability_lines = await build_manual_valuation_lines(
+        db,
+        test_user.id,
+        as_of_date=date(2026, 5, 31),
+        target_currency="SGD",
+        warnings=warnings,
+    )
+
+    assert [line["name"] for line in asset_lines] == ["Valuation: appraisal (property value)"]
+    assert liability_lines == []
+    assert len(warnings) == 1
+    warning = warnings[0]
+    assert warning["type"] == "valuation_component_not_yet_recorded"
+    assert warning["component_type"] == "cpf_balance"
+    assert warning["source"] == "cpf statement"
+    assert warning["as_of_date"] == "2026-05-31"
+    assert warning["earliest_as_of_date"] == "2026-06-15"
+    assert "cpf statement" in warning["message"]

--- a/apps/backend/tests/reporting/test_reporting_net_worth_components.py
+++ b/apps/backend/tests/reporting/test_reporting_net_worth_components.py
@@ -840,3 +840,31 @@ async def test_income_statement_includes_applied_classification_breakdown(db: As
             "avg_confidence": 95.0,
         }
     ]
+
+
+async def test_AC_reporting_balance_sheet_6_valuation_gap_disclosed_in_portfolio_warnings(db: AsyncSession, test_user):
+    """AC-reporting.balance-sheet.6: a manual valuation recorded only after the
+    report's as_of_date stays out of the totals AND is disclosed in
+    portfolio_warnings, so a historical balance sheet never silently reads as
+    complete (#1796)."""
+    report_date = date(2025, 3, 31)
+    await _create_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType.PROPERTY_VALUE,
+        component_name="Singapore Condo",
+        liquidity_class=ManualValuationLiquidityClass.ILLIQUID,
+        value=Decimal("1200000.00"),
+        currency="SGD",
+        as_of_date=date(2025, 6, 30),
+    )
+    await db.commit()
+
+    report = await generate_balance_sheet(db, test_user.id, as_of_date=report_date, currency="SGD")
+
+    assert report["total_assets"] == 0
+    warnings = report["portfolio_warnings"]
+    assert [w["type"] for w in warnings] == ["valuation_component_not_yet_recorded"]
+    assert warnings[0]["component_type"] == "property_value"
+    assert warnings[0]["source"] == "Singapore Condo"
+    assert warnings[0]["earliest_as_of_date"] == "2025-06-30"

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -1482,6 +1482,16 @@
             "title": "Opening Balance Warnings",
             "type": "array"
           },
+          "portfolio_warnings": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Portfolio Warnings",
+            "type": "array"
+          },
           "total_assets": {
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
             "title": "Total Assets",
@@ -3921,6 +3931,39 @@
         "title": "HoldingResponse",
         "type": "object"
       },
+      "HoldingsListResponse": {
+        "description": "Holdings page in the repo-standard items+total wrapper (#1796).\n\n``warnings`` discloses point-in-time snapshots excluded from the page (e.g.\nno reconciled managed position as of the requested date) — previously only\nlogged, so the response silently read as complete.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/HoldingResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "warnings": {
+            "description": "Point-in-time snapshots excluded from the page (e.g. no reconciled managed position as of the requested date) — disclosed instead of silently omitted (#1796).",
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "HoldingsListResponse",
+        "type": "object"
+      },
       "IncomeStatementResponse": {
         "description": "Income statement response schema.",
         "properties": {
@@ -6067,6 +6110,17 @@
               "type": "object"
             },
             "title": "Opening Balance Warnings",
+            "type": "array"
+          },
+          "portfolio_warnings": {
+            "description": "Same portfolio point-in-time gaps as the balance sheet (#1791 follow-up).",
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Portfolio Warnings",
             "type": "array"
           },
           "rows": {
@@ -9611,6 +9665,17 @@
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d{0,2}0*$",
             "title": "Total Liabilities",
             "type": "string"
+          },
+          "warnings": {
+            "description": "Components excluded because their only snapshot postdates as_of_date — disclosed so a historical total never silently reads as complete (#1796).",
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": "Warnings",
+            "type": "array"
           }
         },
         "required": [
@@ -17593,7 +17658,7 @@
     },
     "/portfolio/holdings": {
       "get": {
-        "description": "Get portfolio holdings with P&L (bounded by limit/offset; see AC17.30).",
+        "description": "Get portfolio holdings with P&L (bounded by limit/offset; see AC17.30).\n\nAC-portfolio.holdings.6 (#1796): responds in the repo-standard items+total\nwrapper plus ``warnings`` — a snapshot excluded from the page (no reconciled\nmanaged position as of the date) is disclosed to the caller, not just logged.",
         "operationId": "get_holdings_portfolio_holdings_get",
         "parameters": [
           {
@@ -17660,11 +17725,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/HoldingResponse"
-                  },
-                  "title": "Response Get Holdings Portfolio Holdings Get",
-                  "type": "array"
+                  "$ref": "#/components/schemas/HoldingsListResponse"
                 }
               }
             },

--- a/apps/frontend/playwright/epic022-bottom-tab-ia.spec.ts
+++ b/apps/frontend/playwright/epic022-bottom-tab-ia.spec.ts
@@ -22,7 +22,7 @@ async function installMocks(page: Page) {
         } else if (path === "/api/workflow/events") {
             body = { items: [], total: 0, sessions: [] };
         } else if (path === "/api/portfolio/holdings") {
-            body = { holdings: [] };
+            body = { items: [], total: 0, warnings: [] };
         } else if (path.startsWith("/api/journal-entries")) {
             body = { items: [], total: 0 };
         } else if (path === "/api/confidence/north-star") {

--- a/apps/frontend/playwright/portfolio-provenance.spec.ts
+++ b/apps/frontend/playwright/portfolio-provenance.spec.ts
@@ -71,7 +71,7 @@ async function installPortfolioMocks(page: Page) {
         event_counts: { unread: 0, action_required: 0, blocked: 0 },
       };
     } else if (path === "/api/portfolio/holdings") {
-      body = holdings;
+      body = { items: holdings, total: holdings.length, warnings: [] };
     } else if (path === "/api/portfolio/summary") {
       body = {
         total_market_value: "1775.00",

--- a/apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx
+++ b/apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx
@@ -169,7 +169,7 @@ describe("Brokerage import completion route flow", () => {
         } as any)
       }
       if (path.startsWith("/api/portfolio/holdings")) {
-        return Promise.resolve([importedHolding] as any)
+        return Promise.resolve({ items: [importedHolding], total: 1, warnings: [] } as any)
       }
       return Promise.reject(new Error(`Unhandled API path: ${path}`))
     })

--- a/apps/frontend/src/__tests__/holdingDetailPage.test.tsx
+++ b/apps/frontend/src/__tests__/holdingDetailPage.test.tsx
@@ -93,7 +93,8 @@ function mockHoldingDetailApi(options: {
   const mockedApiFetch = vi.mocked(apiFetch)
   mockedApiFetch.mockImplementation((path: string, init?: RequestInit) => {
     if (path === "/api/portfolio/holdings?include_disposed=true") {
-      return Promise.resolve(options.holdings ?? [mockActiveHolding])
+      const items = options.holdings ?? [mockActiveHolding]
+      return Promise.resolve({ items, total: items.length, warnings: [] })
     }
     if (path === "/api/portfolio/AAPL/dividends") {
       return Promise.resolve(options.dividends ?? [mockDividend])

--- a/apps/frontend/src/__tests__/morePage.test.tsx
+++ b/apps/frontend/src/__tests__/morePage.test.tsx
@@ -23,7 +23,7 @@ describe("More overflow (EPIC-022 AC22.21.5)", () => {
     });
 
     it("lists Settings, Advanced/Accounts, and Logout, and logs out", async () => {
-        mockedApiFetch.mockResolvedValue({ holdings: [] });
+        mockedApiFetch.mockResolvedValue({ items: [], total: 0, warnings: [] });
         render(<MorePage />);
 
         expect(screen.getByRole("link", { name: /Settings/i })).toHaveAttribute("href", "/settings");
@@ -35,14 +35,14 @@ describe("More overflow (EPIC-022 AC22.21.5)", () => {
     });
 
     it("hides Portfolio when the user holds no securities", async () => {
-        mockedApiFetch.mockResolvedValue({ holdings: [] });
+        mockedApiFetch.mockResolvedValue({ items: [], total: 0, warnings: [] });
         render(<MorePage />);
         await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
         expect(screen.queryByRole("link", { name: /Portfolio/i })).toBeNull();
     });
 
     it("shows Portfolio once the user holds securities", async () => {
-        mockedApiFetch.mockResolvedValue({ holdings: [{ ticker: "AAPL" }] });
+        mockedApiFetch.mockResolvedValue({ items: [{ ticker: "AAPL" }], total: 1, warnings: [] });
         render(<MorePage />);
         await waitFor(() =>
             expect(screen.getByRole("link", { name: /Portfolio/i })).toHaveAttribute("href", "/portfolio"),

--- a/apps/frontend/src/__tests__/portfolioPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPage.test.tsx
@@ -238,8 +238,9 @@ function mockPortfolioApi(
       })
     }
     if (path.startsWith("/api/portfolio/holdings")) {
-      if (path.includes("include_disposed=true")) return Promise.resolve([mockHolding, mockHolding2])
-      return Promise.resolve(holdings)
+      if (path.includes("include_disposed=true"))
+        return Promise.resolve({ items: [mockHolding, mockHolding2], total: 2, warnings: [] })
+      return Promise.resolve({ items: holdings, total: holdings.length, warnings: [] })
     }
     return Promise.reject(new Error(`unhandled path ${path}`))
   })

--- a/apps/frontend/src/__tests__/portfolioPricesPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPricesPage.test.tsx
@@ -66,6 +66,8 @@ const mockHoldings: PortfolioHolding[] = [
   },
 ]
 
+const mockHoldingsResponse = { items: mockHoldings, total: mockHoldings.length, warnings: [] }
+
 describe("PricesPage", () => {
   const mockedApiFetch = vi.mocked(apiFetch)
 
@@ -79,7 +81,7 @@ describe("PricesPage", () => {
   })
 
   it("renders page header and back link", async () => {
-    mockedApiFetch.mockResolvedValue(mockHoldings)
+    mockedApiFetch.mockResolvedValue(mockHoldingsResponse)
 
     render(<PricesPage />, { wrapper: createWrapper() })
 
@@ -91,7 +93,7 @@ describe("PricesPage", () => {
   })
 
   it("renders price update form with known tickers from holdings", async () => {
-    mockedApiFetch.mockResolvedValue(mockHoldings)
+    mockedApiFetch.mockResolvedValue(mockHoldingsResponse)
 
     render(<PricesPage />, { wrapper: createWrapper() })
 
@@ -101,7 +103,7 @@ describe("PricesPage", () => {
   })
 
   it("renders ticker select with known tickers", async () => {
-    mockedApiFetch.mockResolvedValue(mockHoldings)
+    mockedApiFetch.mockResolvedValue(mockHoldingsResponse)
 
     render(<PricesPage />, { wrapper: createWrapper() })
 
@@ -114,7 +116,7 @@ describe("PricesPage", () => {
   })
 
   it("adds and removes rows", async () => {
-    mockedApiFetch.mockResolvedValue(mockHoldings)
+    mockedApiFetch.mockResolvedValue(mockHoldingsResponse)
     render(<PricesPage />, { wrapper: createWrapper() })
     await waitFor(() => {
       const options = screen.getAllByRole("option")
@@ -148,7 +150,7 @@ describe("PricesPage", () => {
       if (path === "/api/portfolio/prices/update" && options?.method === "POST") {
         return Promise.resolve(mockResponse)
       }
-      return Promise.resolve(mockHoldings)
+      return Promise.resolve(mockHoldingsResponse)
     })
 
     render(<PricesPage />, { wrapper: createWrapper() })
@@ -180,7 +182,7 @@ describe("PricesPage", () => {
   })
 
   it("shows error toast when submitting empty form", async () => {
-    mockedApiFetch.mockResolvedValue(mockHoldings)
+    mockedApiFetch.mockResolvedValue(mockHoldingsResponse)
     render(<PricesPage />, { wrapper: createWrapper() })
 
     await waitFor(() => {

--- a/apps/frontend/src/app/(main)/more/page.tsx
+++ b/apps/frontend/src/app/(main)/more/page.tsx
@@ -9,11 +9,7 @@ import { advancedItems, moreItems, type NavItem } from "@/components/navigation"
 import { PageHeader } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { clearUser } from "@/lib/auth";
-
-interface HoldingsResponse {
-    holdings?: unknown[];
-    items?: unknown[];
-}
+import type { HoldingsListResponse } from "@/lib/types";
 
 // EPIC-022 AC22.21.5: the More overflow holds low-frequency destinations. The
 // Portfolio entry is shown only when the user actually holds securities, so a
@@ -24,10 +20,10 @@ export default function MorePage() {
 
     useEffect(() => {
         let active = true;
-        apiFetch<HoldingsResponse>("/api/portfolio/holdings")
+        apiFetch<HoldingsListResponse>("/api/portfolio/holdings")
             .then((data) => {
-                const list = data.holdings ?? data.items ?? [];
-                if (active) setHasHoldings(Array.isArray(list) && list.length > 0);
+                const list = data.items ?? [];
+                if (active) setHasHoldings(list.length > 0);
             })
             .catch(() => {
                 if (active) setHasHoldings(false);

--- a/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
@@ -6,7 +6,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
 import { apiFetch } from "@/lib/api";
-import { DividendEvent, PortfolioHolding, RealizedLot } from "@/lib/types";
+import {
+  DividendEvent,
+  HoldingsListResponse,
+  RealizedLot,
+} from "@/lib/types";
 import { compareAmounts, formatCurrencyLocale } from "@/lib/audit/money";
 import { formatQuantity } from "@/lib/audit/quantity";
 import { formatDateDisplay } from "@/lib/date";
@@ -34,9 +38,9 @@ export default function HoldingDetailPage() {
   } = useQuery({
     queryKey: ["portfolio-holdings-all"],
     queryFn: () =>
-      apiFetch<PortfolioHolding[]>(
+      apiFetch<HoldingsListResponse>(
         "/api/portfolio/holdings?include_disposed=true",
-      ),
+      ).then((response) => response.items),
   });
   const { data: dividends = [], refetch: refetchDividends } = useQuery({
     queryKey: ["portfolio-dividends", ticker],

--- a/apps/frontend/src/app/(main)/portfolio/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/page.tsx
@@ -7,7 +7,10 @@ import { CalendarDays, X } from "lucide-react";
 
 import { apiFetch } from "@/lib/api";
 import { useBaseCurrency } from "@/hooks/useBaseCurrency";
-import { PortfolioHolding, PortfolioSummaryResponse } from "@/lib/types";
+import {
+  HoldingsListResponse,
+  PortfolioSummaryResponse,
+} from "@/lib/types";
 import { PerformanceCard } from "@/components/portfolio/PerformanceCard";
 import { LoadingState } from "@/components/ui";
 import { HoldingsTable } from "@/components/portfolio/HoldingsTable";
@@ -89,9 +92,9 @@ export default function PortfolioPage() {
         params.set("as_of_date", asOfDate);
       }
       const query = params.toString();
-      return apiFetch<PortfolioHolding[]>(
+      return apiFetch<HoldingsListResponse>(
         `/api/portfolio/holdings${query ? `?${query}` : ""}`,
-      );
+      ).then((response) => response.items);
     },
   });
   const { data: summary } = useQuery({

--- a/apps/frontend/src/app/(main)/portfolio/prices/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/prices/page.tsx
@@ -4,13 +4,16 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiFetch } from "@/lib/api";
-import { PortfolioHolding } from "@/lib/types";
+import { HoldingsListResponse } from "@/lib/types";
 import { PriceUpdateForm } from "@/components/portfolio/PriceUpdateForm";
 
 export default function PricesPage() {
     const { data: holdings, refetch } = useQuery({
         queryKey: ["portfolio-holdings-for-prices"],
-        queryFn: () => apiFetch<PortfolioHolding[]>("/api/portfolio/holdings"),
+        queryFn: () =>
+            apiFetch<HoldingsListResponse>("/api/portfolio/holdings").then(
+                (response) => response.items,
+            ),
     });
 
     const knownTickers = holdings

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -524,6 +524,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/classifications/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Backfill Transaction Classifications
+         * @description Classify the caller's not-yet-classified transactions (duplicate-free; the tail is re-attempted).
+         */
+        post: operations["backfill_transaction_classifications_classifications_backfill_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/corrections": {
         parameters: {
             query?: never;
@@ -601,6 +621,12 @@ export interface paths {
          *
          *     Returns 200 if all critical services are healthy, 503 otherwise.
          *     This endpoint is used by Docker healthcheck and deployment verification.
+         *
+         *     The default (frequent Docker healthcheck) stays light: database + S3.
+         *     ``?full=1`` asserts the FULL manifest-declared dependency set for this
+         *     environment's tier (smoke ↔ declaration parity, invariant 6 / #1578): every
+         *     dependency in ``DEPENDENCY_MANIFEST.required_for(tier)`` must be present or
+         *     the endpoint returns 503. The smoke test calls this form.
          */
         get: operations["health_check_health_get"];
         put?: never;
@@ -1077,6 +1103,10 @@ export interface paths {
         /**
          * Get Holdings
          * @description Get portfolio holdings with P&L (bounded by limit/offset; see AC17.30).
+         *
+         *     AC-portfolio.holdings.6 (#1796): responds in the repo-standard items+total
+         *     wrapper plus ``warnings`` — a snapshot excluded from the page (no reconciled
+         *     managed position as of the date) is disclosed to the caller, not just logged.
          */
         get: operations["get_holdings_portfolio_holdings_get"];
         put?: never;
@@ -3091,6 +3121,13 @@ export interface components {
              */
             token_type: string;
         };
+        /** BackfillClassificationsResponse */
+        BackfillClassificationsResponse: {
+            /** Candidates */
+            candidates: number;
+            /** Classified */
+            classified: number;
+        };
         /**
          * BalanceSheetResponse
          * @description Balance sheet response schema.
@@ -3129,6 +3166,14 @@ export interface components {
              * @default 0.00
              */
             net_worth_adjustment_gain_loss: string;
+            /** Opening Balance Warnings */
+            opening_balance_warnings?: {
+                [key: string]: string;
+            }[];
+            /** Portfolio Warnings */
+            portfolio_warnings?: {
+                [key: string]: string;
+            }[];
             /** Total Assets */
             total_assets: string;
             /** Total Equity */
@@ -3392,6 +3437,8 @@ export interface components {
          * @description Response for brokerage position import.
          */
         BrokerageImportResponse: {
+            /** Account Id */
+            account_id?: string | null;
             /** Broker */
             broker: string;
             /** Created Atomic Positions */
@@ -4185,6 +4232,16 @@ export interface components {
             provenance?: ("imported" | "manual" | "derived") | null;
             /** Quantity */
             quantity: string;
+            /**
+             * Reporting Cost Basis
+             * @description Explicit reporting cost-basis alias of `cost_basis`.
+             */
+            readonly reporting_cost_basis: string;
+            /**
+             * Reporting Currency
+             * @description Explicit reporting-currency alias of `currency` (identical across endpoints).
+             */
+            readonly reporting_currency: string;
             /** Sector */
             sector?: string | null;
             status: components["schemas"]["PositionStatus"];
@@ -4197,6 +4254,27 @@ export interface components {
              * Format: uuid
              */
             user_id: string;
+        };
+        /**
+         * HoldingsListResponse
+         * @description Holdings page in the repo-standard items+total wrapper (#1796).
+         *
+         *     ``warnings`` discloses point-in-time snapshots excluded from the page (e.g.
+         *     no reconciled managed position as of the requested date) — previously only
+         *     logged, so the response silently read as complete.
+         */
+        HoldingsListResponse: {
+            /** Items */
+            items: components["schemas"]["HoldingResponse"][];
+            /** Total */
+            total: number;
+            /**
+             * Warnings
+             * @description Point-in-time snapshots excluded from the page (e.g. no reconciled managed position as of the requested date) — disclosed instead of silently omitted (#1796).
+             */
+            warnings?: {
+                [key: string]: string;
+            }[];
         };
         /**
          * IncomeStatementResponse
@@ -4819,6 +4897,16 @@ export interface components {
              * Format: uuid
              */
             id: string;
+            /**
+             * Native Cost Basis
+             * @description Explicit native cost-basis alias of `cost_basis`.
+             */
+            readonly native_cost_basis: string;
+            /**
+             * Native Currency
+             * @description Explicit native-currency alias of `currency` (identical across endpoints).
+             */
+            readonly native_currency: string;
             /** Position Metadata */
             position_metadata?: {
                 [key: string]: unknown;
@@ -5040,6 +5128,11 @@ export interface components {
              */
             as_of_date: string;
             /**
+             * Confidence Tier
+             * @description Aggregate confidence tier; LOW when an opening balance is missing.
+             */
+            confidence_tier?: string | null;
+            /**
              * Currency
              * @description Report presentation currency.
              */
@@ -5054,6 +5147,20 @@ export interface components {
              * @description Total assets minus total liabilities.
              */
             net_worth: string;
+            /**
+             * Opening Balance Warnings
+             * @description Non-empty when activity exists without a recorded opening balance.
+             */
+            opening_balance_warnings?: {
+                [key: string]: string;
+            }[];
+            /**
+             * Portfolio Warnings
+             * @description Same portfolio point-in-time gaps as the balance sheet (#1791 follow-up).
+             */
+            portfolio_warnings?: {
+                [key: string]: string;
+            }[];
             /**
              * Rows
              * @description Signed allocation rows that sum to net worth.
@@ -5839,10 +5946,14 @@ export interface components {
          * @description Axis 1 — the wire protocol a provider speaks.
          *
          *     Concrete vendors map onto exactly one family; e.g. Z.AI/GLM and DeepSeek are
-         *     ``OPENAI_COMPATIBLE`` (custom ``api_base``), Claude is ``ANTHROPIC_COMPATIBLE``.
+         *     ``OPENAI_COMPATIBLE`` (custom ``api_base``), Claude is ``ANTHROPIC_COMPATIBLE``,
+         *     and Google Gemini (AI Studio / Vertex) is ``GOOGLE_GEMINI`` — its native API
+         *     accepts a whole PDF as one ``file`` part (no per-page image rendering) and has
+         *     a high output ceiling, which is why it is the provider of choice for extracting
+         *     large or scanned statements.
          * @enum {string}
          */
-        ProtocolFamily: "openai-compatible" | "anthropic-compatible" | "openrouter-compatible";
+        ProtocolFamily: "openai-compatible" | "anthropic-compatible" | "openrouter-compatible" | "google-gemini";
         /**
          * ProviderDisagreementResponse
          * @description Provider disagreement payload.
@@ -6593,6 +6704,13 @@ export interface components {
             total_assets: string;
             /** Total Liabilities */
             total_liabilities: string;
+            /**
+             * Warnings
+             * @description Components excluded because their only snapshot postdates as_of_date — disclosed so a historical total never silently reads as complete (#1796).
+             */
+            warnings?: {
+                [key: string]: string;
+            }[];
         };
         /**
          * VoidJournalEntryRequest
@@ -9803,6 +9921,89 @@ export interface operations {
             };
         };
     };
+    backfill_transaction_classifications_classifications_backfill_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackfillClassificationsResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     create_correction_corrections_post: {
         parameters: {
             query?: never;
@@ -10082,7 +10283,9 @@ export interface operations {
     };
     health_check_health_get: {
         parameters: {
-            query?: never;
+            query?: {
+                full?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -10096,6 +10299,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -12394,7 +12606,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HoldingResponse"][];
+                    "application/json": components["schemas"]["HoldingsListResponse"];
                 };
             };
             /** @description Bad request */

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -627,6 +627,15 @@ export interface PortfolioHolding {
   provenance?: DataProvenance | null;
 }
 
+/**
+ * #1796: /portfolio/holdings responds in the repo-standard items+total wrapper;
+ * `warnings` discloses snapshots excluded from the page (e.g. no reconciled
+ * position as of the requested date) instead of omitting them silently.
+ */
+export interface HoldingsListResponse extends ListResponse<PortfolioHolding> {
+  warnings: Record<string, string>[];
+}
+
 export interface PortfolioSummaryResponse {
   total_market_value: string;
   total_cost_basis: string;

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -671,6 +671,22 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-portfolio.holdings.6",
+            statement=(
+                "GET /portfolio/holdings responds in the repo-standard "
+                "items+total wrapper with a warnings list: a point-in-time "
+                "snapshot excluded from the page (no reconciled managed "
+                "position as of the requested date) is disclosed to the "
+                "caller instead of only being logged (#1796)."
+            ),
+            test=(
+                "apps/backend/tests/portfolio/test_portfolio_router.py"
+                "::test_AC_portfolio_holdings_6_unreconciled_snapshot_disclosed_in_warnings"
+            ),
+            priority="P1",
+            status="done",
+        ),
         # ── group performance: XIRR/TWR/MWR + realized/unrealized P&L math
         # (was EPIC-017 AC17.2.1-5 and AC17.2.7-9; AC17.2.6 deduped into
         # AC-portfolio.holdings.2 — same test, same fact; migration closeout

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -600,6 +600,24 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-pricing.manualvaluation.4",
+            statement=(
+                "A (component_type, source) combination whose only snapshot "
+                "postdates the requested as_of_date is absent from the "
+                "valuation components and lines, and is disclosed through the "
+                "result/accumulator warnings instead of vanishing silently "
+                "(#1796) — 'not owned yet' vs 'not recorded yet' is "
+                "inherently ambiguous for a manual component, so the gap is "
+                "warned about, never guessed at."
+            ),
+            test=(
+                "apps/backend/tests/pricing/test_valuation_lines.py"
+                "::test_AC_pricing_manualvaluation_4_component_recorded_after_as_of_is_warned"
+            ),
+            priority="P1",
+            status="done",
+        ),
         # ── group fx: the FX lookup + conversion surface absorbed from
         # services/fx.py (#1610 P2 — ONE implementation, pricing's; the
         # in-process TTL cache was deliberately NOT carried over, see

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -109,8 +109,16 @@ CONTRACT = PackageContract(
             kind=Kind.DOMAIN_SERVICE,
             module="extension/net_worth.py",
         ),
-        Unit(name="get_account_trend", kind=Kind.DOMAIN_SERVICE, module="extension/net_worth.py"),
-        Unit(name="get_account_lineage", kind=Kind.DOMAIN_SERVICE, module="extension/lineage.py"),
+        Unit(
+            name="get_account_trend",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/net_worth.py",
+        ),
+        Unit(
+            name="get_account_lineage",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/lineage.py",
+        ),
         Unit(
             name="ReportingReadRepository",
             kind=Kind.REPOSITORY,
@@ -625,6 +633,22 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
             proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-reporting.balance-sheet.6",
+            statement=(
+                "A manual valuation component recorded only after the "
+                "report's as_of_date stays out of the balance-sheet totals "
+                "AND is disclosed in the response's portfolio_warnings, so a "
+                "historical balance sheet never silently reads as complete "
+                "(#1796)."
+            ),
+            test=(
+                "apps/backend/tests/reporting/test_reporting_net_worth_components.py"
+                "::test_AC_reporting_balance_sheet_6_valuation_gap_disclosed_in_portfolio_warnings"
+            ),
+            priority="P1",
+            status="done",
         ),
         # ── group income-statement (was EPIC-005 AC5.2.1-3, migration
         # closeout continuation, #1663 / #1716) ──

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -6,7 +6,7 @@
 - API title: `Finance Report API`
 - API version: `0.1.0`
 - Endpoint count: `138`
-- Schema count: `246`
+- Schema count: `247`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 
@@ -181,7 +181,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/portfolio/allocation/geography` | yes | `as_of_date` (query), `limit` (query), `offset` (query) | - | `200` array[`AllocationBreakdownResponse`] | Get Geography Allocation |
 | `GET` | `/portfolio/allocation/sector` | yes | `as_of_date` (query), `limit` (query), `offset` (query) | - | `200` array[`AllocationBreakdownResponse`] | Get Sector Allocation |
 | `POST` | `/portfolio/brokerage/import` | yes | - | `BrokerageImportRequest` | `200` `BrokerageImportResponse` | Import Brokerage Positions |
-| `GET` | `/portfolio/holdings` | yes | `as_of_date` (query), `include_disposed` (query), `limit` (query), `offset` (query) | - | `200` array[`HoldingResponse`] | Get Holdings |
+| `GET` | `/portfolio/holdings` | yes | `as_of_date` (query), `include_disposed` (query), `limit` (query), `offset` (query) | - | `200` `HoldingsListResponse` | Get Holdings |
 | `GET` | `/portfolio/performance` | yes | `period_start` (query), `period_end` (query), `as_of_date` (query) | - | `200` `PerformanceMetricsResponse` | Get Performance |
 | `GET` | `/portfolio/performance/report-schedule` | yes | `period_start` (query), `period_end` (query), `as_of_date` (query), `currency` (query) | - | `200` `InvestmentPerformanceReportScheduleResponse` | Get Investment Performance Report Schedule |
 | `POST` | `/portfolio/prices/update` | yes | - | `PriceUpdateBatchRequest` | `200` `PriceUpdateBatchResponse` | Update Prices |

--- a/tests/e2e/test_brokerage_upload_to_portfolio_value.py
+++ b/tests/e2e/test_brokerage_upload_to_portfolio_value.py
@@ -390,7 +390,7 @@ async def test_multi_brokerage_pdf_upload_imports_positions_and_updates_latest_p
         assert holdings_response.status_code == 200, (
             f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
         )
-        holdings = holdings_response.json()
+        holdings = holdings_response.json()["items"]
         assert len(holdings) >= int(imported_positions), (
             f"missing imported holdings: {holdings}"
         )

--- a/tests/e2e/test_four_asset_net_worth_golden_path.py
+++ b/tests/e2e/test_four_asset_net_worth_golden_path.py
@@ -376,7 +376,7 @@ async def test_four_asset_as_of_net_worth_golden_path(
         assert holdings_response.status_code == 200, (
             f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
         )
-        holdings = holdings_response.json()
+        holdings = holdings_response.json()["items"]
         assert len(holdings) >= import_payload["parsed_positions"], (
             f"missing imported holdings: {holdings}"
         )

--- a/tests/e2e/test_market_data_price_paths.py
+++ b/tests/e2e/test_market_data_price_paths.py
@@ -166,7 +166,7 @@ async def test_market_data_provider_sync_feeds_fx_and_stock_price_paths(
         assert holdings_response.status_code == 200, (
             f"holdings failed: {holdings_response.status_code} {holdings_response.text}"
         )
-        holdings = holdings_response.json()
+        holdings = holdings_response.json()["items"]
         selected_holding = next(
             (item for item in holdings if item["asset_identifier"] == symbol), None
         )

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -475,7 +475,7 @@ async def test_personal_financial_report_package_post_merge_journey(
         assert holdings_response.status_code == 200, (
             f"holdings check failed: {holdings_response.status_code} {holdings_response.text}"
         )
-        holdings = holdings_response.json()
+        holdings = holdings_response.json()["items"]
         assert len(holdings) >= import_payload["parsed_positions"], (
             f"missing imported holdings: {holdings}"
         )


### PR DESCRIPTION
## Summary

Historical reports could silently omit value: a manual valuation component whose only snapshot postdates `as_of_date` vanished from totals with no signal (Finding A), and a point-in-time holdings snapshot without a reconciled managed position was skipped with only a log line (Finding B). Both gaps are now disclosed to the API caller, following the established `fx_warnings`/`opening_balance_warnings`/`portfolio_warnings` pattern.

Closes #1796

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | Package-owned ACs (post-#1719); parent bug #1796, sibling of #1791/#1797 |
| **AC IDs** | AC-pricing.manualvaluation.4, AC-reporting.balance-sheet.6, AC-portfolio.holdings.6 |
| **AC source updated** | `common/pricing/contract.py`, `common/reporting/contract.py`, `common/portfolio/contract.py` roadmaps |

---

## SSOT Changes

- [x] None — existing SSOT already covers this change (warning-disclosure pattern established by #1797's `portfolio_warnings`; `docs/reference/api.md` + `openapi.json` + `api-types.ts` regenerated)

---

## TDD Evidence

- New AC-anchored tests:
  - `test_AC_pricing_manualvaluation_4_component_recorded_after_as_of_is_warned` — valuation gap → warning; eligible combo → no warning
  - `test_AC_reporting_balance_sheet_6_valuation_gap_disclosed_in_portfolio_warnings` — balance sheet surfaces the gap in `portfolio_warnings`
  - `test_AC_portfolio_holdings_6_unreconciled_snapshot_disclosed_in_warnings` — holdings page discloses the skipped snapshot
- `pytest tests/portfolio/ tests/pricing/ tests/reporting/ tests/extraction/test_statement_brokerage_import_bridge.py` — **575 passed**
- Frontend gate (lint + vitest coverage + build) — passed via `tools/preflight.py`
- `check_ac_index.py` / `check_package_contract.py` / `analyze_test_ac_coverage.py` — green

## Notes for reviewers

- `GET /portfolio/holdings` changes shape from a bare array to the repo-standard `ListResponse` wrapper (`{items, total, warnings}`) — the bare array was the special case among collection endpoints (`AccountListResponse`, `JournalEntryListResponse`, … already wrap), and an array has no room for disclosure. FE + BE ship in one image; all call sites and mocks (4 pages, 5 FE test files, 5 backend test files, 4 e2e journeys) are updated here.
- Deliberately NOT done (per #1791's option analysis): no fallback to "nearest later snapshot" for historical valuations — that would present estimated numbers as authoritative. Disclosure only.
- Local-only hook debt observed while committing (pre-existing on main, not from this diff): pre-commit `mypy` reports 12 arg-type errors in `holdings.py` (str vs `Currency`/`Unit`), and the `validate-schemas` hook venv lacks pydantic. CI runs neither; flagged here for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)