### PR TITLE
[finance_report_ui] fix(#1781): correct equity assertion in report-package e2e journey

### DIFF
--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -829,8 +829,16 @@ async def test_personal_financial_report_package_post_merge_journey(
         balance = balance_payload.json()
         assert money_amount(balance["total_assets"]) == expected_assets
         assert money_amount(balance["total_liabilities"]) == expected_liabilities
+        # total_equity is the LEDGER equity accounts only (this journey books
+        # no equity entries, so it is 0.00). Manual valuations and portfolio
+        # adjustments live in net_worth_adjustment_gain_loss, and bank cash is
+        # mirrored by cumulative net_income — the accounting equation holds
+        # across ALL components, never as equity == assets - liabilities.
         assert (
             money_amount(balance["total_equity"])
+            + money_amount(balance["net_income"])
+            + money_amount(balance["unrealized_fx_gain_loss"])
+            + money_amount(balance["net_worth_adjustment_gain_loss"])
             == expected_assets - expected_liabilities
         )
         assert (

--- a/tests/e2e/test_personal_financial_report_package.py
+++ b/tests/e2e/test_personal_financial_report_package.py
@@ -832,8 +832,10 @@ async def test_personal_financial_report_package_post_merge_journey(
         # total_equity is the LEDGER equity accounts only (this journey books
         # no equity entries, so it is 0.00). Manual valuations and portfolio
         # adjustments live in net_worth_adjustment_gain_loss, and bank cash is
-        # mirrored by cumulative net_income — the accounting equation holds
-        # across ALL components, never as equity == assets - liabilities.
+        # mirrored by cumulative net_income — so the accounting equation must
+        # be asserted across ALL components. Bare equity == assets - liabilities
+        # only holds when net income and every adjustment are zero, which this
+        # journey (by construction) never satisfies.
         assert (
             money_amount(balance["total_equity"])
             + money_amount(balance["net_income"])

--- a/tools/_lib/fixtures/personal_report_package.py
+++ b/tools/_lib/fixtures/personal_report_package.py
@@ -57,11 +57,6 @@ class ExpectedPackageOutputs:
     def total_assets(self, brokerage_value: Decimal) -> Decimal:
         return money_amount(brokerage_value + self.manual_asset_total + self.bank_cash)
 
-    def total_equity(self, brokerage_value: Decimal) -> Decimal:
-        return money_amount(
-            self.total_assets(brokerage_value) - self.manual_liability_total
-        )
-
 
 @dataclass(frozen=True)
 class RepresentativePackageFixture:


### PR DESCRIPTION
## Summary

The staging AI/OCR audit-replay red (#1781) is fully triaged; this PR fixes the last remaining failure, which is a test-expectation bug, not a product bug.

Triage of the original red (run 29181331505, v0.1.33): 2× CNY/SGD FX-rate failures — fixed by #1779; 3× parse timeouts — transient provider health. Both classes confirmed gone on the v0.1.35 verification replay ([run 29220951346](https://github.com/wangzitian0/finance_report/actions/runs/29220951346)); the one failure left is a newly-reached assertion unblocked by #1797's fix.

Root cause: the assertion claimed `total_equity == assets − liabilities`, but `total_equity` is the **ledger equity accounts only** — this journey books none (0.00 by design; `test_vision_upload_to_dashboard_hard_gate.py` already pins exactly that). Manual valuations/portfolio adjustments live in `net_worth_adjustment_gain_loss`, bank cash in cumulative `net_income`. The assertion is restated as the full component decomposition of the accounting equation; the fixture helper `total_equity()` codifying the same wrong identity is removed (zero callers).

Same root-cause class as #1791: an assertion authored before the fast-fail journey could reach it. No product change.

Refs #1781 — after this merges, the next nightly audit-replay is expected green; #1781 closes on that evidence.

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | EPIC-008 post-merge environment gates |
| **AC IDs** | AC-reporting.balance-sheet.5 (existing — this journey is its anchor test; assertion corrected) |
| **AC source updated** | N/A (no new AC; existing anchor test corrected) |

## SSOT Changes

- [x] None

## TDD Evidence

- Test-only change; the corrected assertion is the proof. The journey is tier-3 post-merge (runs against live staging), so the next audit-replay run is the green evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)