### PR TITLE
[finance_report_vision] feat(#1810): pre-push gate parity — preflight static tier + agent adoption contract

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,8 @@
 red lines, work order, branch/PR rules, and the navigation map to everything
 else.
 
+Before every commit/push, run the pre-push parity check — see AGENTS.md § Pre-Push Gate Parity.
+
 This file deliberately holds **no project facts** (stack versions, paths,
 model names, thresholds). A duplicated-facts file drifts silently and feeds
 auto-review wrong context — this one previously claimed Next.js 14, a retired

--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -16,12 +16,28 @@ maps your **changed files** to the relevant gates and runs only those.
 
 ```bash
 # Run inside an interpreter that has project deps (the backend venv):
-apps/backend/.venv/bin/python tools/preflight.py          # run relevant gates
-apps/backend/.venv/bin/python tools/preflight.py --list   # show what would run
+apps/backend/.venv/bin/python tools/preflight.py                # run relevant gates
+apps/backend/.venv/bin/python tools/preflight.py --tier=static  # seconds-level pre-push parity set
+apps/backend/.venv/bin/python tools/preflight.py --list         # show what would run (with each check's tier)
 apps/backend/.venv/bin/python tools/preflight.py --base origin/main
 ```
 
 Exit code is non-zero if any gate fails; the summary names which one.
+
+## Tiers (#1810)
+
+Every check carries a cost tier; `--tier` composes with the diff-glob
+selection (it narrows the selected set, never widens it):
+
+- `--tier=static` — only the seconds-level file-parser gates: the mandatory
+  pre-push parity set (AGENTS.md § Pre-Push Gate Parity).
+- `--tier=heavy` — only the expensive suite/build gates (the `tests/tooling/`
+  pytest suite, ~3 min; the frontend lint+coverage+build chain).
+- `--tier=full` (default) — both tiers, exactly the pre-tier behavior.
+
+Interactive operators run `--tier=static` before every push at minimum;
+cloud/sandbox agents run the default full tier before pushing (their CPU does
+not contend with the operator's machine).
 
 ## What it maps (changed path → gate)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,27 @@ Details: [docs/agents/orchestration.md](docs/agents/orchestration.md) · [docs/s
 
 ---
 
+## 🛡️ Pre-Push Gate Parity
+
+- ✅ **Iron rule** — before *any* push, run
+  `apps/backend/.venv/bin/python tools/preflight.py --tier=static`
+  (seconds-level, diff-aware). Non-zero exit = do **not** push.
+- A preflight red is a deterministic preview of a CI red. The check list is
+  deliberately not enumerated here — the single source of truth is
+  `tools/preflight.py --list` (no fact duplication, #1435 discipline).
+- ✅ **Escape hatch**: if preflight itself is broken, pushing is allowed, but
+  the PR body MUST declare `preflight skipped: <reason>` — never skip silently.
+- ✅ **Cloud/sandbox agents** (Copilot etc.): additionally run FULL preflight
+  (`--tier=full`, includes the tooling suite, ~3 min) before pushing — sandbox
+  CPU does not contend with the operator's machine, and a CI retry loop costs
+  far more. If the sandbox cannot install deps, declare it in the PR body per
+  the escape-hatch rule.
+- ✅ **Coverage**: during TDD, run your tests with `--cov` scoped to the files
+  you changed to confirm your new lines are covered; do **not** run
+  full-component coverage locally (~4 min — that is CI's job).
+
+---
+
 ## 🌿 Branch & PR Rules
 
 Full policy: **[docs/contributing/branch-policy.md](docs/contributing/branch-policy.md)**

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -3327,6 +3327,25 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group preflight: diff-aware pre-push dispatcher tiering
+        # (#1810 G-static-parity) ──
+        ACRecord(
+            id="AC-testing.preflight.1",
+            statement=(
+                "Preflight check tiering composes with the diff-glob selection: "
+                "--tier=static keeps exactly the seconds-level static gates "
+                "matching the diff and drops the heavy suite gates, while the "
+                "default full tier preserves the exact pre-tier selection, so "
+                "every static blocking PR gate is runnable locally in seconds "
+                "via one command (#1810 G-static-parity)."
+            ),
+            test=(
+                "tests/tooling/test_preflight.py"
+                "::test_AC_testing_preflight_1_static_tier_composes_with_glob_selection"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -35,6 +35,12 @@ Runner = Callable[[Sequence[str], str], int]
 Git = Callable[[Sequence[str]], str]
 
 
+# Check tiers (#1810 G-static-parity): "static" gates are seconds-level file
+# parsers — the mandatory pre-push parity set; "heavy" gates run whole test or
+# build suites (minutes-level) and are opted into via --tier=heavy/full.
+TIERS: tuple[str, ...] = ("static", "heavy")
+
+
 @dataclass(frozen=True)
 class Check:
     """A named gate: run ``commands`` when a changed path matches a ``glob``.
@@ -42,6 +48,9 @@ class Check:
     ``cwd`` is the working directory (relative to the repo root) the commands run
     in. Backend gates use ``apps/backend`` so ``ruff`` discovers the backend Ruff
     config and ``pytest`` can import ``src.*`` — matching how CI invokes them.
+
+    ``tier`` classifies the gate's cost (see :data:`TIERS`): ``static`` for the
+    seconds-level checks, ``heavy`` for the expensive suite/build gates.
     """
 
     name: str
@@ -49,6 +58,7 @@ class Check:
     commands: tuple[tuple[str, ...], ...]
     why: str
     cwd: str = "."
+    tier: str = "static"
 
 
 # Ordered cheapest/most-localizing first. ``fnmatch`` treats ``*`` as matching
@@ -182,6 +192,7 @@ CHECKS: tuple[Check, ...] = (
         globs=("tools/*", "common/*"),
         commands=((PY, "-m", "pytest", "tests/tooling/", "-q", "--no-cov"),),
         why="tooling/common changed: run tests/tooling (tool-wrapper sys.path contract + dispatchers)",
+        tier="heavy",
     ),
     Check(
         name="app-boundary",
@@ -200,6 +211,7 @@ CHECKS: tuple[Check, ...] = (
         ),
         why="frontend changed: eslint + vitest coverage gate + next build (layout/route type rules)",
         cwd="apps/frontend",
+        tier="heavy",
     ),
 )
 
@@ -215,14 +227,25 @@ def _matches(path: str, glob: str) -> bool:
 
 
 def select_checks(
-    changed_files: Iterable[str], *, checks: Sequence[Check] = CHECKS
+    changed_files: Iterable[str],
+    *,
+    checks: Sequence[Check] = CHECKS,
+    tier: str = "full",
 ) -> list[Check]:
-    """Return the checks whose globs match at least one changed file (in order)."""
+    """Return the checks whose globs match at least one changed file (in order).
+
+    ``tier`` composes with the glob selection: ``"full"`` (default) keeps every
+    matching check — the exact pre-tier behavior; a named tier (:data:`TIERS`)
+    keeps only the matching checks of that tier.
+    """
+    if tier != "full" and tier not in TIERS:
+        raise ValueError(f"unknown tier {tier!r}: expected one of {('full', *TIERS)}")
     files = list(changed_files)
     return [
         check
         for check in checks
-        if any(_matches(f, g) for f in files for g in check.globs)
+        if (tier == "full" or check.tier == tier)
+        and any(_matches(f, g) for f in files for g in check.globs)
     ]
 
 
@@ -301,12 +324,22 @@ def main(
         default=None,
         help="Explicit changed-file list (overrides git; for scripting/tests).",
     )
+    parser.add_argument(
+        "--tier",
+        choices=("full", *TIERS),
+        default="full",
+        help=(
+            "Which cost tier to run: 'static' = the seconds-level pre-push "
+            "parity gates, 'heavy' = the expensive suite/build gates, "
+            "'full' (default) = both."
+        ),
+    )
     args = parser.parse_args(argv)
 
     files = (
         args.changed if args.changed is not None else changed_files(args.base, git=git)
     )
-    selected = select_checks(files)
+    selected = select_checks(files, tier=args.tier)
 
     if not selected:
         print("preflight: no relevant gates for the current diff.")
@@ -314,7 +347,7 @@ def main(
 
     if args.list:
         for check in selected:
-            print(f"  {check.name}: {check.why}")
+            print(f"  [{check.tier}] {check.name}: {check.why}")
         return 0
 
     print(

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from common.testing import preflight
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -201,6 +203,117 @@ class TestRunAndMain:
 
         rc = preflight.main([], runner=lambda argv, cwd: 0, git=fake_git)
         assert rc == 0
+
+
+# ── Tier-filtered selection (#1810 G-static-parity) ──
+# The static tier is the seconds-level pre-push parity command; the heavy
+# suites (measured in minutes) stay in the full tier. Tier filtering must
+# COMPOSE with the existing glob-based diff selection, and the default must
+# preserve the exact pre-tier behavior.
+
+
+def test_AC_testing_preflight_1_static_tier_composes_with_glob_selection():
+    """AC-testing.preflight.1: a common/*.py diff matches both static gates and
+    the heavy tooling suite; --tier=static keeps the static gates for that diff
+    and drops the heavy one, while the default (full) keeps today's selection."""
+    changed = ["common/testing/preflight.py"]
+    full_names = {c.name for c in preflight.select_checks(changed)}
+    static_selected = preflight.select_checks(changed, tier="static")
+    static_names = {c.name for c in static_selected}
+
+    # Tier filtering composes with glob selection: same diff, heavy dropped.
+    assert static_names == full_names - {"tooling"}
+    # The static gates relevant to the diff still run — tier never widens
+    # or empties the glob-based selection, it only strips the heavy checks.
+    assert static_names
+    assert all(c.tier == "static" for c in static_selected)
+
+
+class TestTierSelection:
+    """Behavioral tier-selection contracts (AC-testing.preflight.1, #1810)."""
+
+    def test_every_check_has_a_valid_tier(self):
+        assert all(c.tier in ("static", "heavy") for c in preflight.CHECKS)
+
+    def test_heavy_tier_membership_is_the_two_expensive_suites(self):
+        # The two minutes-scale checks (the tests/tooling pytest suite and the
+        # frontend lint+coverage+build chain) are the only heavy-tier members.
+        heavy = {c.name for c in preflight.CHECKS if c.tier == "heavy"}
+        assert heavy == {"tooling", "frontend"}
+
+    def test_full_tier_is_the_default_and_preserves_selection(self):
+        changed = [
+            "common/testing/preflight.py",
+            "apps/frontend/src/app/layout.tsx",
+            "docs/ssot/reporting.md",
+        ]
+        assert preflight.select_checks(changed) == preflight.select_checks(
+            changed, tier="full"
+        )
+
+    def test_frontend_diff_has_no_static_gates(self):
+        # The frontend gate is heavy-only, so a frontend-only diff selects
+        # nothing under --tier=static (nothing static maps to that path).
+        selected = preflight.select_checks(
+            ["apps/frontend/src/app/layout.tsx"], tier="static"
+        )
+        assert selected == []
+
+    def test_heavy_tier_selects_only_matching_heavy_checks(self):
+        selected = preflight.select_checks(
+            ["common/testing/preflight.py", "apps/frontend/src/app/layout.tsx"],
+            tier="heavy",
+        )
+        assert [c.name for c in selected] == ["tooling", "frontend"]
+
+    def test_unknown_tier_is_rejected(self):
+        with pytest.raises(ValueError):
+            preflight.select_checks(["common/x.py"], tier="bogus")
+
+
+class TestTierCli:
+    """CLI surface of the tier switch (AC-testing.preflight.1, #1810)."""
+
+    @staticmethod
+    def _run_and_collect(args: list[str]) -> list[list[str]]:
+        ran: list[list[str]] = []
+        rc = preflight.main(
+            [*args, "--changed", "common/testing/preflight.py"],
+            runner=lambda argv, cwd: ran.append(list(argv)) or 0,
+        )
+        assert rc == 0
+        return ran
+
+    def test_main_default_equals_tier_full(self):
+        assert self._run_and_collect([]) == self._run_and_collect(["--tier=full"])
+
+    def test_main_tier_static_runs_strictly_fewer_commands_than_full(self):
+        full_ran = self._run_and_collect([])
+        static_ran = self._run_and_collect(["--tier=static"])
+        # Static ran something (the diff-matched static gates) but skipped the
+        # heavy suite's command(s) that full runs for the same diff.
+        assert 0 < len(static_ran) < len(full_ran)
+        assert all(argv in full_ran for argv in static_ran)
+
+    def test_main_list_shows_each_selected_checks_tier(self, capsys):
+        rc = preflight.main(
+            ["--list", "--changed", "common/testing/preflight.py"],
+            runner=lambda argv, cwd: 0,
+        )
+        assert rc == 0
+        lines = capsys.readouterr().out.splitlines()
+        for check in preflight.select_checks(["common/testing/preflight.py"]):
+            assert any(check.name in line and check.tier in line for line in lines)
+
+    def test_main_list_respects_tier(self, capsys):
+        rc = preflight.main(
+            ["--list", "--tier=static", "--changed", "common/testing/preflight.py"],
+            runner=lambda argv, cwd: 0,
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        heavy = {c.name for c in preflight.CHECKS if c.tier == "heavy"}
+        assert heavy and all(name not in out for name in heavy)
 
 
 def test_changed_files_unions_committed_staged_unstaged_and_untracked():

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -3,8 +3,9 @@
 
 Run the gate checks relevant to your current diff before pushing:
 
-    python tools/preflight.py            # run the relevant gates
-    python tools/preflight.py --list     # show what would run, don't run it
+    python tools/preflight.py                # run the relevant gates
+    python tools/preflight.py --tier=static  # seconds-level pre-push parity set
+    python tools/preflight.py --list         # show what would run, don't run it
     python tools/preflight.py --base origin/main
 
 Run it with an interpreter that has the project deps (e.g. the backend venv) so


### PR DESCRIPTION
Contract layer of #1810 (PR-2 of the wave). The metric layer (diff-coverage gate, ratchet demotion) is a separate PR and deliberately not touched here — no changes to `tools/calculate_unified_coverage.py`, `ci.yml`, or `docs/ssot/coverage.md`.

## G-static-parity — every static blocking gate runnable locally in seconds via one command

- `common/testing/preflight.py`: every `Check` now carries a `tier` — `static` for the seconds-level file-parser gates (measured 0.02–0.16s each), `heavy` for the two minutes-scale suites (the `tests/tooling/` pytest run, measured ~171s locally, and the frontend lint+coverage+build chain).
- New CLI switch `--tier {static,heavy,full}` (`tools/preflight.py`): tier filtering **composes** with the existing diff-glob selection — it only narrows the selected set, never widens it. Default `full` preserves today's exact behavior (backward compatible; proven by test). `--list` now shows each check's tier.
- Enforced by behavioral selection tests extending `tests/tooling/test_preflight.py` (11 new tests; they exercise `select_checks`/`main` with injected runners — no new text mirrors, the mirror-assertion ratchet stays exactly at baseline, per #1435 discipline).
- AC registered in the `testing` package roadmap (`common/testing/contract.py`): **AC-testing.preflight.1**, red-then-green.

## G-adoption-contract — the instruction layer finally adopts the tooling

- `AGENTS.md` gains **§ Pre-Push Gate Parity** between the Mandatory Work Order and Branch & PR Rules: static-tier preflight mandatory before any push; a preflight red is a deterministic preview of a CI red; the check list is deliberately NOT enumerated there (single source of truth stays `tools/preflight.py --list` — no fact duplication); declared-never-silent escape hatch (`preflight skipped: <reason>` in the PR body); full-preflight clause for cloud/sandbox agents; TDD-scoped `--cov` guidance.
  - **Operator authorization**: AGENTS.md carries an "AI may NOT modify without explicit authorization" header — this edit was explicitly authorized by the operator on 2026-07-13 (design session, recorded in #1810). `CLAUDE.md` is a symlink to `AGENTS.md` and was not touched.
- `.github/copilot-instructions.md`: one fact-free pointer line to the new section (the file stays fact-free by design).
- `.opencode/skills/domain/preflight/SKILL.md` (canonical copy; `.claude/skills/` entries are symlinks): documents `--tier` and the tier semantics.

## Verification

- `pytest tests/tooling/test_preflight.py -q --no-cov`: 37 passed (26 pre-existing + 11 new; new ones were red before the implementation).
- Diff-scoped coverage: `common/testing/preflight.py` at 98% under the preflight tests alone; the only missing lines are the two pre-existing default subprocess bodies.
- `tools/preflight.py --tier=static --base origin/main`: green (the new iron-rule command, run on this very diff).
- `--tier=static --list` / `--tier=full --list` smoke-checked by hand: a `common/*` diff lists the static gate(s) only under `static`, and adds `[heavy] tooling` under `full`.
- AC gates: `generate_ac_registry.py`, `check_ac_index.py`, `check_epic_package_dual.py` all green; mirror-assertion ratchet unchanged (2917 = baseline).
- Full-tier local run note: the heavy `tooling` gate reports 23 failures in this worktree, byte-identical to the pristine `origin/main` baseline (uninitialized `repo` submodule in the isolated worktree — environmental, none caused by this diff; CI initializes submodules and is the authoritative run).

Part of #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
