### PR TITLE
[finance_report_vision] fix(#1804): make advisor api-key guard tests hermetic to ambient AI keys

### DIFF
--- a/apps/backend/tests/ai/conftest.py
+++ b/apps/backend/tests/ai/conftest.py
@@ -22,4 +22,6 @@ def pin_ai_key_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
     tests that need a configured provider set ``service.api_key`` or patch
     ``get_config_source`` explicitly, which overrides this default.
     """
-    monkeypatch.setattr(settings, "ai_api_key", "", raising=False)
+    # raising=True (default): if the field is ever renamed, fail loudly instead
+    # of silently reverting this package to the ambient environment.
+    monkeypatch.setattr(settings, "ai_api_key", "")

--- a/apps/backend/tests/ai/conftest.py
+++ b/apps/backend/tests/ai/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for the AI advisor test package."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config import settings
+
+
+# --- Ambient AI-key isolation (#1804) ---
+@pytest.fixture(autouse=True)
+def pin_ai_key_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the env AI-provider key to "unconfigured" for every advisor test.
+
+    ``settings.ai_api_key`` is aliased to five env vars (ZAI_API_KEY,
+    GLM_API_KEY, AI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY). A developer
+    machine that exports any of them silently flips
+    ``EnvConfigSource.is_configured()`` to True, so tests asserting
+    unconfigured-provider behaviour pass in CI (which exports none) but fail
+    locally — the class of drift behind issue #1804. Pinning the key to ""
+    makes every test in this package see the same deterministic surface as CI;
+    tests that need a configured provider set ``service.api_key`` or patch
+    ``get_config_source`` explicitly, which overrides this default.
+    """
+    monkeypatch.setattr(settings, "ai_api_key", "", raising=False)

--- a/apps/backend/tests/ai/test_ai_advisor_service.py
+++ b/apps/backend/tests/ai/test_ai_advisor_service.py
@@ -276,8 +276,13 @@ async def test_stream_openrouter_raises_when_all_fail(
 
 async def test_chat_stream_requires_api_key(db: AsyncSession, test_user, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC-advisor.stream.3: AC6.7.3: Chat stream raises error when API key not configured."""
+    # The guard is compound (EPIC-023): raise only when the instance has no key
+    # AND get_config_source(user_id).is_configured() is False. The env leg is
+    # pinned unconfigured by the tests/ai conftest fixture (#1804) and the DB leg
+    # is empty by construction (fresh test DB), so the raise is deterministic
+    # regardless of ambient ZAI/GLM/AI/OPENROUTER/GEMINI_API_KEY exports.
     service = AIAdvisorService()
-    service.api_key = None
+    assert not service.api_key  # inherited from the pinned (empty) env key
 
     async def fake_context(_db: AsyncSession, _user_id) -> dict[str, str]:
         return {"summary": "ok"}
@@ -287,6 +292,39 @@ async def test_chat_stream_requires_api_key(db: AsyncSession, test_user, monkeyp
 
     with pytest.raises(AIAdvisorError, match="AI provider API key not configured"):
         await service.chat_stream(db, test_user.id, "How much did I save this month?")
+
+
+async def test_chat_stream_configured_source_unblocks_without_env_key(
+    db: AsyncSession, test_user, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC-advisor.stream.3: the guard checks the configured surface, not just the env key.
+
+    Complement of the raise branch (EPIC-023 #1185): a user whose config source is
+    configured (BYO provider / deployment default) must NOT be blocked just because
+    the deployment has no AI_API_KEY.
+    """
+    service = AIAdvisorService()
+    assert not service.api_key  # env leg unconfigured, exactly like the raise test
+
+    async def fake_context(_db: AsyncSession, _user_id) -> dict[str, str]:
+        return {"summary": "ok"}
+
+    class _ConfiguredSource:
+        async def is_configured(self) -> bool:
+            return True
+
+        async def get_binding(self, _scene):
+            return None  # no per-user binding: fall back to env models
+
+    monkeypatch.setattr(service, "get_financial_context", fake_context)
+    monkeypatch.setattr(ai_advisor_service, "get_config_source", lambda _user_id=None: _ConfiguredSource())
+    ai_advisor_service._CACHE._store.clear()
+
+    result = await service.chat_stream(db, test_user.id, "How much did I save this month?")
+
+    assert result.cached is False
+    assert result.session_id is not None
+    await result.stream.aclose()  # never started; close to avoid a dangling async generator
 
 
 async def test_get_financial_context_handles_report_errors(

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -29,6 +29,7 @@ These files are test infrastructure, not behavior proof.
 | `apps/backend/tests/ledger/_ledger_helpers.py` | Published ledger test factory (shared posted/void entry builders) |
 | `tests/tooling/_infra2_source.py` | Shared helper (not a test): resilient resolver for infra2 deploy-primitive source; see #1519 |
 | `apps/backend/tests/ai/__init__.py` | Package marker |
+| `apps/backend/tests/ai/conftest.py` | Shared advisor fixtures: pins the env AI-key surface so tests are hermetic to ambient provider keys (#1804) |
 | `apps/backend/tests/assets/__init__.py` | Package marker |
 | `apps/backend/tests/identity/__init__.py` | Package marker |
 | `apps/backend/tests/conftest.py` | Shared backend pytest fixtures |


### PR DESCRIPTION
## Root cause

`test_chat_stream_requires_api_key` asserts the "no provider configured" raise (AC-advisor.stream.3) but never constructed that state — it only nulled the instance attribute (`service.api_key = None`):

- **`1ff7683d` (EPIC-023 PR6, #1185, 2026-06-17)** changed the guard in `chat_stream` from `if not self.api_key:` to the compound `if not self.api_key and not await get_config_source(user_id).is_configured():` (`apps/backend/src/advisor/extension/service.py:179`) **without updating this test**. From that commit on, the test's outcome also depends on `EnvConfigSource.is_configured()`, i.e. on `settings.ai_api_key`.
- **`8bc3ef4a` (#1472, 2026-06-27)** added `GEMINI_API_KEY` to the `ai_api_key` alias set (`ZAI_API_KEY`, `GLM_API_KEY`, `AI_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY` — `apps/backend/src/config.py:199`). A developer machine exporting any of these (this one exports `GEMINI_API_KEY` for the Gemini extraction provider) makes `settings.ai_api_key` non-empty, `EnvConfigSource.is_configured()` returns `True`, and the guard **correctly** does not raise → `DID NOT RAISE`.

**The failure is environment-dependent, not order-dependent**: on this machine the test failed identically in isolation *and* in the full module (`1 failed, 41 passed`), and stripping the key env vars (`env -u GEMINI_API_KEY …`) made the unmodified test pass in isolation. The issue's cache suspicion is ruled out: the test clears the correct `_CACHE` instance (`service.py` imports the same object from `advisor/extension/cache.py`), and cache keys are scoped by `user_id` + context hash, so a per-test fresh user can never hit a stale entry. The product guard itself is correct per EPIC-023 (a BYO-provider/deployment-default user must not be blocked by a missing env `AI_API_KEY`) — the bug is test hermeticity.

## Why no existing gate caught it

CI backend shards export none of the five key aliases, so `settings.ai_api_key == ""` matches the test's premise **by coincidence** and the test passes there — green for the wrong reason. There was no mechanism pinning the env-config surface the test's assertion actually depends on, so the suite's verdict on the unconfigured path silently varied with the ambient shell environment (CI: raise proven; any dev machine with a key: false alarm). The complementary EPIC-023 branch ("configured source unblocks chat with no env key", shipped in `1ff7683d`) had no guard-level test at all, so nothing forced the distinction to be made explicit.

## Backfilled proof

- **`apps/backend/tests/ai/conftest.py` (new)**: autouse fixture pins `settings.ai_api_key = ""` for every test in `tests/ai/`, so the whole advisor package sees the same deterministic surface CI does, regardless of ambient `ZAI/GLM/AI/OPENROUTER/GEMINI_API_KEY` exports. Tests that need a configured provider already set `service.api_key` or patch `get_config_source` explicitly, which overrides the pin. (Cassette-recording tests that need real keys live outside `tests/ai/` and are unaffected.)
- **`test_chat_stream_requires_api_key`**: now derives its unconfigured premise from the pinned surface (asserts the fresh service inherits the empty key; env leg pinned, DB leg empty by construction) instead of overriding one attribute and inheriting the rest from the environment.
- **`test_chat_stream_configured_source_unblocks_without_env_key` (new)**: behavioral proof of the guard's other branch — `service.api_key` empty but `get_config_source(user_id).is_configured()` true → `chat_stream` returns a live `ChatStream` instead of raising. This is the EPIC-023 behavior `1ff7683d` introduced without a test; together the pair proves the guard checks the *configured surface*, not just the env key, in an order- and environment-independent way.

## Verification

- Target test passes in isolation and the full `tests/ai/` package passes (123 passed) **with** the ambient `GEMINI_API_KEY` still exported (the exact condition that reproduced the bug), `--no-cov`.
- Changed module also passes with all key aliases stripped (CI-like): 43 passed.
- `tools/preflight.py --base origin/main` green (backend-format run with the uv.lock-pinned ruff 0.14.11, as CI does; PATH ruff 0.15 skew is a known preflight-only mismatch).

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)