### PR TITLE
[finance_report_vision] feat(#1810): diff-scoped PR coverage gate — ratchet demoted to main-only water-line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1247,6 +1247,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+          # #1810: the diff coverage gate needs history to resolve the
+          # merge-base against the PR base branch.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -1302,6 +1305,19 @@ jobs:
           else
             echo "No tools coverage found"
           fi
+
+      # #1810 (G-diff-coverage): on PRs, the BLOCKING coverage verdict is
+      # diff-scoped — changed/added lines in governed source trees must be
+      # covered at or above the threshold (default 85%), and a red verdict
+      # names the uncovered file:line ranges. Deterministic per PR, no
+      # baseline, no epsilon, locally reproducible from the tests the author
+      # is already running (tools/check_diff_coverage.py).
+      - name: Diff coverage gate (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin "$GITHUB_BASE_REF"
+          python tools/check_diff_coverage.py --base "origin/$GITHUB_BASE_REF"
+
       - name: Audit coverage policy
         run: |
           python tools/check_coverage_policy.py
@@ -1313,15 +1329,22 @@ jobs:
         # artifact preflight (#414) is therefore opt-in here — we do NOT pass
         # --require-artifacts / COVERAGE_REQUIRED_COMPONENTS, so a legitimately
         # absent artifact is reported (as 0% for the missing component) rather
-        # than hard-aborting this always-run gate. The no-regression check still
-        # applies to whatever LCOV is present.
+        # than hard-aborting this always-run gate.
         #
-        # #1689: on a PR, only the components the PR actually touched BLOCK the
-        # run on regression; an unrelated component's regression is still
-        # reported (visible in this step's output) but does not fail the job —
-        # main-branch push always gates the full unscoped set (env unset here).
+        # #1810: on a PR the component-% ratchet is REPORT-ONLY — a detected
+        # baseline regression is printed in this step's output but does not
+        # fail the job; the blocking PR coverage verdict is the diff coverage
+        # gate step above. Main pushes run in "block" mode: the ratchet stays
+        # the main-only no-regression water-line, and the raise-only baseline
+        # floor (unified-coverage-baseline-pr) is unchanged.
+        #
+        # #1689 (still active for the report): the scoped gate-components list
+        # names which components' regressions are attributed to THIS PR in the
+        # report; main-branch push always evaluates the full unscoped set (env
+        # unset here).
         env:
           COVERAGE_GATE_COMPONENTS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.coverage_gate_components || '' }}
+          COVERAGE_RATCHET_MODE: ${{ github.event_name == 'pull_request' && 'report' || 'block' }}
         run: |
           python tools/calculate_unified_coverage.py
 
@@ -1785,9 +1808,9 @@ jobs:
           {
             echo "## Coverage Gate"
             echo ""
-            echo "- Authoritative coverage gate: \`Calculate Unified Coverage\` plus \`finish\`."
+            echo "- Authoritative coverage gate: \`Calculate Unified Coverage\` plus \`finish\` — PRs block on diff coverage of changed lines (#1810); main pushes block on the component ratchet."
             echo "- Pull requests do not publish Coveralls status contexts; main pushes upload unified line coverage for badge/trend reporting only."
-            echo "- Merge readiness follows \`finish\` and the committed \`unified-coverage.json\` baseline."
+            echo "- Merge readiness follows \`finish\`; PRs gate on \`tools/check_diff_coverage.py\`, main pushes on the committed \`unified-coverage.json\` baseline."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check job status

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -3346,6 +3346,79 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group diff-coverage: diff-scoped PR coverage gate + ratchet
+        # demotion (#1810, metric layer: G-diff-coverage /
+        # G-ratchet-backstop). The unit of the blocking PR coverage
+        # verdict is the PR's own diff, not a component percentage. ──
+        ACRecord(
+            id="AC-testing.diff-coverage.1",
+            statement=(
+                "On a PR, the blocking coverage verdict is diff-scoped: it is "
+                "computed from the PR's own diff plus per-component test-run LCOV "
+                "(no full-pipeline dependency, no baseline epsilon) and passes "
+                "iff coverage of the measurable changed lines is at or above the "
+                "threshold (default 85%, overridable via --threshold / "
+                "DIFF_COVERAGE_THRESHOLD) (#1810 G-diff-coverage)."
+            ),
+            test=(
+                "tests/tooling/test_diff_coverage.py"
+                "::test_cli_blocks_below_threshold_and_passes_at_or_above"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.diff-coverage.2",
+            statement=(
+                "A red diff-coverage verdict names each offending file with its "
+                "uncovered changed lines as file:line ranges, and a changed "
+                "in-scope file entirely absent from its component's LCOV is "
+                "counted conservatively (added non-blank, non-comment lines are "
+                "uncovered), so a new file with zero tests cannot pass silently "
+                "(#1810 G-diff-coverage)."
+            ),
+            test=(
+                "tests/tooling/test_diff_coverage.py"
+                "::test_red_verdict_lists_uncovered_line_ranges_and_new_file_hole"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.diff-coverage.3",
+            statement=(
+                "Out-of-scope changes (docs, tests, configs, workflows, "
+                "policy-excluded files) never enter the diff-coverage "
+                "denominator; a diff with no measurable changed lines passes "
+                "explicitly; and an entirely absent component LCOV artifact "
+                "skips that component's files with a loud warning (parity with "
+                "the lenient CI merge step) (#1810 G-diff-coverage)."
+            ),
+            test=(
+                "tests/tooling/test_diff_coverage.py"
+                "::test_out_of_scope_files_and_absent_artifacts_are_lenient"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.diff-coverage.4",
+            statement=(
+                "The component-% ratchet is a main-only water-line: in report "
+                "mode (PR CI) a detected regression is printed as report-only "
+                "and does not fail the run, while block mode (main pushes; the "
+                "default when --ratchet-mode/COVERAGE_RATCHET_MODE is unset) "
+                "keeps the exact blocking behavior, with unified-coverage.json "
+                "still written and the COVERAGE_THRESHOLD safety net unchanged "
+                "in both modes (#1810 G-ratchet-backstop)."
+            ),
+            test=(
+                "tests/tooling/test_calculate_unified_coverage.py"
+                "::test_ratchet_report_mode_reports_regression_without_blocking"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
 )
 
@@ -3355,4 +3428,5 @@ TEST_ROOTS: tuple[str, ...] = (
     "tests/tooling/test_coverage_analyzer.py",
     "tests/tooling/test_calculate_unified_coverage.py",
     "tests/tooling/test_coverage_artifact_preflight.py",
+    "tests/tooling/test_diff_coverage.py",
 )

--- a/common/testing/coverage/calculate_unified_coverage.py
+++ b/common/testing/coverage/calculate_unified_coverage.py
@@ -61,6 +61,18 @@ REQUIRED_COMPONENTS_ENV = "COVERAGE_REQUIRED_COMPONENTS"
 # Overridden by the ``--gate-components`` CLI flag when that is supplied.
 GATE_COMPONENTS_ENV = "COVERAGE_GATE_COMPONENTS"
 
+# #1810 (G-ratchet-backstop): how a detected baseline regression is enforced.
+# "block" (the default when flag and env are both unset) keeps the exact
+# historical behavior — a regression exits 1. "report" prints the same
+# regression message prefixed as report-only and does NOT fail the run: on
+# PRs the blocking coverage verdict is the diff-coverage gate
+# (tools/check_diff_coverage.py), while the component ratchet remains the
+# blocking water-line on main pushes only. unified-coverage.json is still
+# written and the COVERAGE_THRESHOLD safety net applies in both modes.
+# Overridden by the ``--ratchet-mode`` CLI flag when that is supplied.
+RATCHET_MODE_ENV = "COVERAGE_RATCHET_MODE"
+RATCHET_MODES = ("block", "report")
+
 BACKEND_DIR = ROOT_DIR / "apps" / "backend"
 FRONTEND_DIR = ROOT_DIR / "apps" / "frontend"
 TOOLS_DIR = ROOT_DIR / "tools"
@@ -542,6 +554,19 @@ def parse_args(argv: list[str] | tuple[str, ...]) -> argparse.Namespace:
             f"to the {GATE_COMPONENTS_ENV} env var."
         ),
     )
+    parser.add_argument(
+        "--ratchet-mode",
+        choices=RATCHET_MODES,
+        default=None,
+        help=(
+            "#1810: 'block' (default) fails the run when a baseline regression "
+            "is detected; 'report' prints the regression as report-only and "
+            "does not fail (PR lane — the blocking PR coverage verdict is the "
+            "diff-coverage gate). unified-coverage.json is written and the "
+            "COVERAGE_THRESHOLD safety net applies in both modes. Falls back "
+            f"to the {RATCHET_MODE_ENV} env var."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -596,6 +621,18 @@ def main(argv: list[str] | tuple[str, ...] = ()) -> None:
             sys.exit(2)
     else:
         gate_component_names = None
+
+    # #1810: resolve the ratchet enforcement mode (flag > env > "block").
+    ratchet_mode = args.ratchet_mode
+    if ratchet_mode is None:
+        ratchet_mode = os.environ.get(RATCHET_MODE_ENV, "").strip() or "block"
+    if ratchet_mode not in RATCHET_MODES:
+        print(
+            f"\n❌ Invalid --ratchet-mode/{RATCHET_MODE_ENV}: {ratchet_mode!r}; "
+            f"valid modes: {', '.join(RATCHET_MODES)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     preflight_errors = required_artifacts_preflight(preflight_components, ROOT_DIR)
     if preflight_errors:
@@ -753,8 +790,23 @@ def main(argv: list[str] | tuple[str, ...] = ()) -> None:
     write_unified_coverage(unified, output_path)
 
     if regression_error:
-        print(regression_error, file=sys.stderr)
-        sys.exit(1)
+        if ratchet_mode == "report":
+            # #1810 (G-ratchet-backstop): report-only lane (PRs). The full
+            # regression message stays visible, but the blocking PR coverage
+            # verdict is the diff-coverage gate; main pushes run in "block"
+            # mode and still fail here.
+            print(
+                "📣 REPORT-ONLY (#1810): the component ratchet does not block "
+                "this run (ratchet-mode=report; PR lane). The blocking PR "
+                "coverage verdict is the diff-coverage gate "
+                "(tools/check_diff_coverage.py); main pushes still block on "
+                "this ratchet.",
+                file=sys.stderr,
+            )
+            print(regression_error, file=sys.stderr)
+        else:
+            print(regression_error, file=sys.stderr)
+            sys.exit(1)
 
     # Exit with appropriate code (safety net after baseline check)
     threshold = int(os.environ.get("COVERAGE_THRESHOLD", "0"))

--- a/common/testing/coverage/diff_coverage.py
+++ b/common/testing/coverage/diff_coverage.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Diff-scoped PR coverage gate (#1810, G-diff-coverage).
+
+On pull requests the BLOCKING coverage verdict is computed from the PR's own
+diff plus per-component LCOV: every changed/added line that falls inside a
+governed source tree (``common/meta/extension/coverage/policy.py``) must be
+covered by tests at or above the threshold (default 85%). A red verdict names
+the uncovered lines as ``file: uncovered lines a-b, c`` ranges, so the fix is
+never a guess. The component-percentage ratchet
+(``calculate_unified_coverage.py``) stays the blocking water-line on main
+pushes only.
+
+Scope rules:
+
+- Changed files that resolve to no coverage component (docs, tests, configs,
+  workflows, policy-excluded files) are out of scope — ignored.
+- A changed line absent from a PRESENT file record is non-executable
+  (blank/comment) — skipped.
+- A changed in-scope file entirely absent from its component's loaded LCOV is
+  counted conservatively: its added non-blank, non-comment lines are
+  uncovered. This is exactly the "new file with zero tests" hole.
+- A component whose LCOV artifact is entirely absent is skipped with a loud
+  warning — lenient parity with the CI merge step, which tolerates
+  legitimately-absent artifacts.
+
+Local parity: run your test suite with ``--cov`` (producing an LCOV for the
+touched component), then ``python tools/check_diff_coverage.py --base
+origin/main``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from common.meta.extension.coverage.policy import (
+    COMPONENTS,
+    CoverageComponent,
+    get_component,
+)
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+
+DEFAULT_THRESHOLD = 85.0
+DEFAULT_BASE = "origin/main"
+
+#: Env fallbacks for the CLI flags (flag wins when both are given).
+THRESHOLD_ENV = "DIFF_COVERAGE_THRESHOLD"
+BASE_ENV = "DIFF_COVERAGE_BASE"
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+#: Line prefixes treated as non-executable for the conservative
+#: missing-from-LCOV rule (Python and TS/TSX comment markers).
+_COMMENT_PREFIXES = ("#", "//")
+
+
+def parse_unified_diff(diff_text: str) -> dict[str, set[int]]:
+    """Map ``git diff -U0`` output to {repo-relative path: added line numbers}.
+
+    Tracks ``+++ b/<path>`` targets and ``@@ -a[,b] +c[,d] @@`` hunk headers:
+    the new-side lines are ``c..c+d-1`` (``d`` defaults to 1; ``d=0`` is a pure
+    deletion and contributes no lines). Deleted files (``+++ /dev/null``) and
+    pure renames (no hunks) contribute nothing.
+    """
+    changed: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            target = line[4:].strip()
+            if target.startswith('"') and target.endswith('"'):
+                target = target[1:-1]
+            if target == "/dev/null":
+                current = None
+            elif target.startswith("b/"):
+                current = target[2:]
+            else:
+                current = target
+            continue
+        match = _HUNK_RE.match(line)
+        if match and current is not None:
+            start = int(match.group(1))
+            count = 1 if match.group(2) is None else int(match.group(2))
+            if count > 0:
+                changed.setdefault(current, set()).update(range(start, start + count))
+    return changed
+
+
+def resolve_component(
+    repo_relative_path: str,
+    components: tuple[CoverageComponent, ...] = COMPONENTS,
+) -> tuple[CoverageComponent, str] | None:
+    """Resolve a changed repo-relative path to (component, LCOV source path).
+
+    A path is in scope iff it lives under a component's governed source root,
+    carries one of the component's extensions, and is not policy-excluded.
+    Returns ``None`` for out-of-scope paths (docs, tests, configs, workflows).
+    """
+    path = repo_relative_path.replace("\\", "/")
+    for component in components:
+        prefix_parts = [
+            part for part in (component.component_root, component.source_subdir) if part
+        ]
+        source_prefix = "/".join(prefix_parts) + "/"
+        if not path.startswith(source_prefix):
+            continue
+        if not path.endswith(component.extensions):
+            continue
+        if component.component_root:
+            component_relative = path[len(component.component_root) + 1 :]
+        else:
+            component_relative = path
+        if component.is_excluded(component_relative):
+            continue
+        return component, component_relative
+    return None
+
+
+def parse_lcov_line_hits(
+    lcov_path: Path,
+    component: CoverageComponent,
+    repo_root: Path = ROOT_DIR,
+) -> dict[str, dict[int, int]]:
+    """Parse LCOV ``DA:<line>,<hits>`` records per normalized source path.
+
+    Sources are normalized via ``component.normalize_lcov_source`` and hits
+    are summed across duplicate ``SF:`` records for the same source (merged
+    shards), mirroring the flush/accumulate semantics of
+    ``calculate_unified_coverage.parse_lcov_records``.
+    """
+    if not lcov_path.exists():
+        return {}
+
+    hits: dict[str, dict[int, int]] = {}
+    current_source = ""
+    with open(lcov_path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if line.startswith("SF:"):
+                current_source = component.normalize_lcov_source(line[3:], repo_root)
+                hits.setdefault(current_source, {})
+            elif line.startswith("DA:") and current_source:
+                fields = line[3:].split(",")
+                try:
+                    line_no = int(fields[0])
+                    hit_count = int(fields[1])
+                except (IndexError, ValueError):
+                    continue
+                file_hits = hits[current_source]
+                file_hits[line_no] = file_hits.get(line_no, 0) + hit_count
+            elif line == "end_of_record":
+                current_source = ""
+    return hits
+
+
+def _significant_lines(file_path: Path, line_numbers: set[int]) -> tuple[int, ...]:
+    """Filter added line numbers down to non-blank, non-comment lines.
+
+    Used by the conservative missing-from-LCOV rule. When the file cannot be
+    read, every added line counts (stay conservative).
+    """
+    try:
+        lines = file_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return tuple(sorted(line_numbers))
+    significant: list[int] = []
+    for line_no in sorted(line_numbers):
+        if not 1 <= line_no <= len(lines):
+            continue
+        stripped = lines[line_no - 1].strip()
+        if not stripped or stripped.startswith(_COMMENT_PREFIXES):
+            continue
+        significant.append(line_no)
+    return tuple(significant)
+
+
+@dataclass(frozen=True)
+class FileVerdict:
+    """Per-file diff-coverage verdict (line numbers are repo-file 1-based)."""
+
+    path: str
+    component: str
+    covered_lines: tuple[int, ...]
+    uncovered_lines: tuple[int, ...]
+    #: True when the file has no record in its component's (present) LCOV —
+    #: the conservative "new file with zero tests" case.
+    missing_from_lcov: bool = False
+
+
+@dataclass(frozen=True)
+class DiffCoverageReport:
+    """Aggregated diff-coverage verdict over every in-scope changed file."""
+
+    files: tuple[FileVerdict, ...]
+    #: Components with in-scope changed files but an entirely absent LCOV
+    #: artifact — skipped leniently (CI merge-step parity), warned loudly.
+    skipped_components: tuple[str, ...]
+
+    @property
+    def measurable_lines(self) -> int:
+        return sum(
+            len(verdict.covered_lines) + len(verdict.uncovered_lines)
+            for verdict in self.files
+        )
+
+    @property
+    def covered_count(self) -> int:
+        return sum(len(verdict.covered_lines) for verdict in self.files)
+
+    @property
+    def percent(self) -> float | None:
+        measurable = self.measurable_lines
+        if measurable == 0:
+            return None
+        return self.covered_count / measurable * 100
+
+
+def evaluate_diff_coverage(
+    changed_lines: dict[str, set[int]],
+    repo_root: Path = ROOT_DIR,
+    components: tuple[CoverageComponent, ...] = COMPONENTS,
+) -> DiffCoverageReport:
+    """Compute the diff-coverage verdict for parsed changed lines."""
+    lcov_cache: dict[str, dict[str, dict[int, int]] | None] = {}
+    verdicts: list[FileVerdict] = []
+    skipped_components: list[str] = []
+
+    for path in sorted(changed_lines):
+        lines = changed_lines[path]
+        if not lines:
+            continue
+        resolved = resolve_component(path, components)
+        if resolved is None:
+            continue
+        component, component_relative = resolved
+
+        if component.name not in lcov_cache:
+            lcov_path = component.lcov_path(repo_root)
+            lcov_cache[component.name] = (
+                parse_lcov_line_hits(lcov_path, component, repo_root)
+                if lcov_path.exists()
+                else None
+            )
+        component_hits = lcov_cache[component.name]
+        if component_hits is None:
+            if component.name not in skipped_components:
+                skipped_components.append(component.name)
+            continue
+
+        file_hits = component_hits.get(component_relative)
+        if file_hits is None:
+            verdicts.append(
+                FileVerdict(
+                    path=path,
+                    component=component.name,
+                    covered_lines=(),
+                    uncovered_lines=_significant_lines(repo_root / path, lines),
+                    missing_from_lcov=True,
+                )
+            )
+            continue
+
+        covered: list[int] = []
+        uncovered: list[int] = []
+        for line_no in sorted(lines):
+            if line_no not in file_hits:
+                continue  # non-executable (blank/comment): not in the record
+            if file_hits[line_no] > 0:
+                covered.append(line_no)
+            else:
+                uncovered.append(line_no)
+        verdicts.append(
+            FileVerdict(
+                path=path,
+                component=component.name,
+                covered_lines=tuple(covered),
+                uncovered_lines=tuple(uncovered),
+            )
+        )
+
+    return DiffCoverageReport(
+        files=tuple(verdicts),
+        skipped_components=tuple(sorted(skipped_components)),
+    )
+
+
+def format_line_ranges(lines: Iterable[int]) -> str:
+    """Render line numbers as compact ranges: [45,46,47,48,92] -> '45-48, 92'."""
+    ordered = sorted(set(lines))
+    if not ordered:
+        return ""
+    ranges: list[tuple[int, int]] = []
+    start = previous = ordered[0]
+    for line_no in ordered[1:]:
+        if line_no == previous + 1:
+            previous = line_no
+            continue
+        ranges.append((start, previous))
+        start = previous = line_no
+    ranges.append((start, previous))
+    return ", ".join(
+        str(first) if first == last else f"{first}-{last}" for first, last in ranges
+    )
+
+
+def git_diff_text(base: str, repo_root: Path = ROOT_DIR) -> str:
+    """Return ``git diff -U0`` text from the merge-base of ``base`` to HEAD."""
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "diff",
+            "-U0",
+            "--diff-filter=ACMR",
+            "--merge-base",
+            base,
+            "HEAD",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff against {base!r} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def parse_args(argv: list[str] | tuple[str, ...]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Diff-scoped PR coverage gate (#1810): changed/added lines in "
+            "governed source trees must be covered by tests at or above the "
+            "threshold."
+        )
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help=(
+            "Base ref for the merge-base diff (default: the "
+            f"{BASE_ENV} env var, else {DEFAULT_BASE!r}). Ignored when "
+            "--diff-file is given."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help=(
+            "Minimum percent of measurable changed lines that must be covered "
+            f"(default: the {THRESHOLD_ENV} env var, else {DEFAULT_THRESHOLD:g})."
+        ),
+    )
+    parser.add_argument(
+        "--diff-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Read unified diff text from PATH instead of running git "
+            "(deterministic input for tests and offline runs)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Repository root to resolve LCOV artifacts and changed files "
+            "against (default: this checkout)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | tuple[str, ...] = ()) -> None:
+    """CLI entry point: exit 0 on pass (or nothing to gate), 1 below threshold,
+    2 on usage/environment errors."""
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else ROOT_DIR
+
+    threshold = args.threshold
+    if threshold is None:
+        raw_threshold = os.environ.get(THRESHOLD_ENV, "").strip()
+        if raw_threshold:
+            try:
+                threshold = float(raw_threshold)
+            except ValueError:
+                print(
+                    f"❌ Invalid {THRESHOLD_ENV}: {raw_threshold!r} "
+                    "(expected a number)",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+        else:
+            threshold = DEFAULT_THRESHOLD
+
+    print("=" * 60)
+    print("Diff Coverage Gate (#1810)")
+    print("=" * 60)
+
+    if args.diff_file:
+        diff_path = Path(args.diff_file)
+        if not diff_path.exists():
+            print(f"❌ Diff file not found: {diff_path}", file=sys.stderr)
+            sys.exit(2)
+        diff_text = diff_path.read_text(encoding="utf-8", errors="ignore")
+        print(f"   diff source: {diff_path}")
+    else:
+        base = args.base or os.environ.get(BASE_ENV, "").strip() or DEFAULT_BASE
+        try:
+            diff_text = git_diff_text(base, repo_root)
+        except RuntimeError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            sys.exit(2)
+        print(f"   diff source: git diff --merge-base {base} HEAD")
+
+    report = evaluate_diff_coverage(parse_unified_diff(diff_text), repo_root)
+
+    for name in report.skipped_components:
+        component = get_component(name)
+        print(
+            f"⚠️  WARNING: {name}: coverage artifact absent (expected "
+            f"{component.ci_lcov_path}); skipping its changed files — lenient "
+            "parity with the CI merge step, which tolerates absent artifacts"
+        )
+
+    if report.measurable_lines == 0:
+        print(
+            "✅ diff coverage: no measurable changed lines "
+            "(out-of-scope or non-executable diff) — nothing to gate"
+        )
+        sys.exit(0)
+
+    for verdict in report.files:
+        if not verdict.uncovered_lines:
+            continue
+        ranges = format_line_ranges(verdict.uncovered_lines)
+        if verdict.missing_from_lcov:
+            print(
+                f"❌ {verdict.path}: uncovered lines {ranges} "
+                f"(file not in {verdict.component} LCOV — a new file with zero "
+                "tests? all added code lines counted uncovered)"
+            )
+        else:
+            print(f"❌ {verdict.path}: uncovered lines {ranges}")
+
+    percent = report.percent
+    assert percent is not None  # measurable_lines > 0 here
+    summary = (
+        f"diff coverage: {percent:.1f}% ({report.covered_count}/"
+        f"{report.measurable_lines} measurable changed lines covered), "
+        f"threshold {threshold:g}%"
+    )
+    if percent >= threshold:
+        print(f"✅ {summary}")
+        sys.exit(0)
+
+    print(f"❌ {summary}")
+    print(
+        "   Cover the uncovered changed lines listed above with tests, then "
+        "re-check locally: run your suite with --cov to produce the component "
+        "LCOV and re-run tools/check_diff_coverage.py.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])

--- a/docs/ssot/ci-cd.md
+++ b/docs/ssot/ci-cd.md
@@ -44,7 +44,7 @@ main-only: unified-coverage ─→ unified-coverage-baseline-pr (not required by
 | **container-images** | Fail-closed gitleaks secret scan over each component's Docker build context (`apps/<component>`) before the build, then build backend and frontend staging images without pushing on PRs; push SHA-tagged images only on `main`. Right-moved: runs only when the build context changed (`image_build_required`), see Key CI Property 20 | `needs: [changes]` |
 | **verify-sha-image-published** | Independently re-inspect the registry for the just-built `:<sha>` image on `main` push, so a build step that reports success without actually publishing is caught at commit time. Right-moved: only runs on `main` push, see Key CI Property 20a | `needs: [container-images]` |
 | **tooling-coverage** | Run root tooling tests with common/tools coverage and upload LCOV inputs | `needs: [changes]` |
-| **unified-coverage** | Merge backend, frontend Vitest, common, and tools LCOV inputs, audit source-tree/LCOV policy, calculate unified coverage, compare to baseline, upload the coverage context artifact, and update Coveralls on `main` when heavy CI is required | `needs: [changes, backend, frontend-vitest, tooling-coverage]` |
+| **unified-coverage** | Merge backend, frontend Vitest, common, and tools LCOV inputs, run the PR-blocking diff coverage gate (`tools/check_diff_coverage.py`, #1810), audit source-tree/LCOV policy, calculate unified coverage and compare to baseline (blocking on `main` pushes, report-only on PRs), upload the coverage context artifact, and update Coveralls on `main` when heavy CI is required | `needs: [changes, backend, frontend-vitest, tooling-coverage]` |
 | **unified-coverage-baseline-pr** | Main-only automation that downloads `unified-coverage-context`, commits a changed `unified-coverage.json` to `automation/unified-coverage-baseline`, and opens or updates the reviewed baseline PR. This job owns write-scoped GitHub token permissions; PR coverage calculation remains read-only. | `needs: [changes, unified-coverage]` |
 | **ac-traceability** | Verify generated AC registries, E2E EPIC ownership, the uploaded AC traceability audit, and the reconciliation audit for all PR/main changes, including docs-only changes | None |
 | **ac-behavioral-ratchet** | Aggregate JUnit AC evidence from backend and frontend Vitest stages and enforce the persisted per-AC behavioral score floor | `needs: [changes, backend, backend-integration, backend-e2e-tier1, frontend-vitest]` |
@@ -63,7 +63,7 @@ main-only: unified-coverage ─→ unified-coverage-baseline-pr (not required by
 8. **Backend and frontend stages are explicit and split**: Backend fast-path remains shard stage (`backend`) with workflow job name `Backend Tests (Shard ${{ matrix.shard }}/5)`, 5-way `pytest-split`, `--splitting-algorithm=least_duration`, and the committed backend duration seed at `apps/backend/ci/backend-test-durations.json`. The backend job fails before pytest when the seed is missing or unexpectedly small, so CI cannot silently fall back to unseeded even splitting. Frontend PR CI is split into `frontend-build`, `frontend-vitest`, `frontend-playwright`, and `frontend-telemetry-e2e`, each starting after change classification instead of waiting on one another. Standalone gates start immediately: `lint` and `ac-traceability` have no `needs` dependency and run in parallel with change classification. Deterministic test, schema migration, browser, telemetry, and image jobs start after change classification and do not wait for lint, AC traceability, or behavior-only backend gates. Behavior-only backend gates run in parallel as explicit `backend-integration` and `backend-e2e-tier1` stages, and finish remains the authoritative aggregate gate for lint, AC traceability, AC behavioral score ratchet, schema migrations, tests, image validation, coverage, and skipped heavy-job semantics.
 9. **Coverage Debug Context Is Always Uploaded**: The `tooling-coverage` job uploads `coverage-tooling` with `coverage/common.lcov` and `coverage/tools.lcov`; the read-only `unified-coverage` job downloads that artifact and uploads `unified-coverage-context` on success and failure. The unified artifact contains `coverage/backend.lcov`, `coverage/frontend.lcov`, `coverage/common.lcov`, `coverage/tools.lcov`, the current `unified-coverage.json`, and `coverage/coverage-context.txt` with raw line-count inputs, commit/event/run metadata, toolchain versions, and input hashes. Coverage regressions must be diagnosed from these artifacts before treating a percentage delta as nondeterminism. On `push` to `main`, the separate `unified-coverage-baseline-pr` job is the only CI job with `contents: write` / `pull-requests: write` for automatic baseline PR updates; PR coverage calculation does not receive write-scoped token permissions.
 10. **CI Observability Artifacts Are Failure-Path Owned**: Backend shard, backend integration, backend Tier-1 E2E, frontend Vitest, frontend Playwright, frontend telemetry E2E, schema migrations, tooling/common coverage, AC traceability, PR preview, staging, manual AI/OCR, production release, and scheduled cleanup gates publish CI observability artifacts with `if: always()`. These artifacts include JUnit XML where pytest or Vitest can produce it, raw coverage/report inputs where relevant, and a small context file with repository/event/ref/SHA/run metadata plus target environment/version fields. Step summaries remain human-readable status pages; artifacts are the replayable evidence for both success and failure.
-11. **Coveralls Is Main-Only Reporting**: Pull requests do not call Coveralls and therefore do not publish external Coveralls status contexts. CI pass/fail is decided by local gates (`tools/check_ci_metrics_contract.py`, `tools/check_coverage_policy.py`, `tools/calculate_unified_coverage.py`) aggregated by `finish`. Main pushes upload only the unified line-only LCOV report to Coveralls for badge and trend reporting after the local coverage gate passes. Backend/frontend per-flag Coveralls uploads are intentionally absent so a single commit has one reporting denominator.
+11. **Coveralls Is Main-Only Reporting**: Pull requests do not call Coveralls and therefore do not publish external Coveralls status contexts. CI pass/fail is decided by local gates (`tools/check_ci_metrics_contract.py`, `tools/check_coverage_policy.py`, `tools/check_diff_coverage.py` on PRs, `tools/calculate_unified_coverage.py`) aggregated by `finish`. Main pushes upload only the unified line-only LCOV report to Coveralls for badge and trend reporting after the local coverage gate passes. Backend/frontend per-flag Coveralls uploads are intentionally absent so a single commit has one reporting denominator.
 12. **Single CI Metrics Contract**: `tools/check_ci_metrics_contract.py` is the single CI metrics contract. It runs in `lint` and validates that source-root discovery, `common/meta/extension/coverage/policy.py`, workflow gates, and AC traceability semantics stay aligned before coverage jobs finish.
 13. **Toolchain Contract**: `tools/check_toolchain_contract.py` runs in lint and fails when Python, Node.js, uv, Docker base images, Compose service images, or frontend engine constraints drift from `toolchain.toml`.
 13a. **Workflow Contract**: `tools/check_workflow_contract.py` runs in lint and is the mechanical guard against CI/deploy prose drift (#531). It parses `.github/workflows/*.yml` and fails when the documented job ids (e.g. the classifier job id `changes`, `lint`, `unified-coverage`, `finish`) or trigger events drift from this SSOT, when `deploy.yml` gains a branch `push`/`pull_request` path for staging (release-image tag push is allowed), or when an issue template uses a label outside the live repository taxonomy (e.g. the stale `infra`/`feature` instead of `infrastructure`/`enhancement`). It checks live job ids/triggers/labels, not mutable run status (run ids, timing, conclusions), which stay in CI artifacts.
@@ -431,12 +431,19 @@ the gate.
 
 ## No-Regression Coverage Gate
 
-The CI workflow enforces a **no-regression policy** for test coverage.
+The CI workflow enforces a **no-regression policy** for test coverage as the
+**main-push water-line**. On pull requests the blocking coverage verdict is
+the **diff coverage gate** (`tools/check_diff_coverage.py`, #1810): the PR's
+changed/added lines in governed source trees must be covered at or above the
+threshold (default 85%), with uncovered `file: line-range`s named in the
+output; the no-regression comparison still runs on PRs but is **report-only**
+(`COVERAGE_RATCHET_MODE=report`). Semantics detail:
+[coverage.md](./coverage.md#coverage-gate).
 
 ### How It Works
 
 1. **Baseline Storage**: `unified-coverage.json` at repo root.
-   - PR CI reads the committed file as the no-regression floor.
+   - CI reads the committed file as the no-regression floor (blocking on `main` pushes; report-only on PRs).
    - Main CI writes the current measured file inside the read-only `unified-coverage` job artifact. A separate main-only `unified-coverage-baseline-pr` job downloads that artifact and opens or updates an automatic baseline PR when that file differs.
    - CI never pushes directly to `main`; branch protection still requires the reviewed baseline PR to merge.
 
@@ -444,7 +451,7 @@ The CI workflow enforces a **no-regression policy** for test coverage.
    - Reads `unified-coverage.json` before calculating final coverage
    - Compares current vs baseline for **all components**: unified, backend, frontend, common, tools
    - Uses `round(x, 2)` for floating-point comparison
-   - **Zero tolerance**: `current < baseline` → CI fails immediately
+   - **Zero tolerance in block mode** (main pushes): `current < baseline` (beyond the ±0.05% jitter epsilon) → CI fails immediately; in report mode (PRs) the same regression is printed but does not fail the run
    - If baseline file missing: falls through to `COVERAGE_THRESHOLD` check (safety net)
 3. **Source-tree/LCOV Logic**:
    - `common/meta/extension/coverage/policy.py` defines the single component policy used by coverage calculation and audit checks
@@ -467,7 +474,9 @@ The CI workflow enforces a **no-regression policy** for test coverage.
 
 5. **Environment Variables**:
    - `BASELINE_FILE`: Path to baseline JSON (default: `unified-coverage.json`)
-   - `COVERAGE_THRESHOLD`: Safety net threshold (default: `0`; baseline comparison is primary gate)
+   - `COVERAGE_THRESHOLD`: Safety net threshold (default: `0`; applies in both ratchet modes)
+   - `COVERAGE_RATCHET_MODE`: `block` (default; main pushes) fails on a baseline regression, `report` (PR lane) prints it report-only (#1810)
+   - `DIFF_COVERAGE_THRESHOLD` / `DIFF_COVERAGE_BASE`: diff coverage gate overrides (defaults: `85`, `origin/main`)
 
 ### Baseline Reset / Raise
 

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -1,7 +1,7 @@
 # Unified Test Coverage
 
 > **SSOT Key**: `coverage`
-> **Version**: 2.0.0
+> **Version**: 2.1.0
 > **Version scope**: Coverage policy semantics only; live baseline values are
 > owned by `unified-coverage.json` and CI artifacts.
 
@@ -33,7 +33,20 @@ unified_coverage = total_covered_lines / total_executable_lines
 - AC metrics are separate by design: AC pass rate and AC traceability are behavior/reference gates, not line-coverage arithmetic.
 - `common/meta/extension/coverage/policy.py` plus policy-aware auditors ensure these exact four scopes remain the unified denominator.
 
-**Unified CI Gate**: No-regression baseline comparison (zero tolerance for drops), plus a source tree vs LCOV policy audit. No fixed minimum unified threshold is enforced.
+**Unified CI Gate** (#1810, two lanes):
+
+- **PR lane (blocking)**: **diff coverage** — the changed/added lines of the
+  PR's own diff that fall inside governed source trees must be covered by
+  tests at or above the threshold (default **85%**, override via
+  `--threshold` / `DIFF_COVERAGE_THRESHOLD`). A red verdict names the
+  uncovered `file: line-range` list. Enforced by
+  `tools/check_diff_coverage.py` in the `unified-coverage` job. The
+  component-% ratchet still runs on PRs but is **report-only**
+  (`COVERAGE_RATCHET_MODE=report`).
+- **Main lane (blocking)**: the component-% **no-regression ratchet** against
+  the committed `unified-coverage.json` baseline (raise-only floor via the
+  main-only baseline PR), plus the source tree vs LCOV policy audit. No fixed
+  minimum unified threshold is enforced.
 
 **Baseline ownership**: Component line counts, coverage percentages, and
 committed no-regression floors are generated facts. Read
@@ -185,14 +198,39 @@ jobs:
     needs: [backend, frontend]
     # Downloads all artifacts
     # Merges backend shards → coverage/backend.lcov
-    # Runs: python tools/calculate_unified_coverage.py
+    # PR only: python tools/check_diff_coverage.py (BLOCKING diff-coverage verdict, #1810)
     # Runs: python tools/check_coverage_policy.py
-    # Fails if coverage drops below baseline (no-regression gate); no fixed minimum threshold
+    # Runs: python tools/calculate_unified_coverage.py
+    #   - PR: COVERAGE_RATCHET_MODE=report — regressions reported, not blocking
+    #   - main push: block mode — fails if coverage drops below baseline
     # Uploads unified-coverage-context with all raw line-count inputs
     # Builds repository-root-relative, line-only backend + frontend + common + tools LCOV for Coveralls
 ```
 
-### Coverage Calculation
+### Diff Coverage Calculation (PR-blocking, #1810)
+
+`tools/check_diff_coverage.py` (implementation:
+`common/testing/coverage/diff_coverage.py`):
+
+1. Derives the changed lines from `git diff -U0 --diff-filter=ACMR
+   --merge-base <base> HEAD` (CI passes `--base origin/$GITHUB_BASE_REF`), or
+   from `--diff-file PATH` for deterministic/offline input
+2. Resolves each changed file against the shared component policy
+   (`common/meta/extension/coverage/policy.py`); files outside every governed
+   source root (docs, tests, configs, workflows, policy-excluded files) are
+   out of scope
+3. Reads per-line `DA:` hits from each component's LCOV; a changed line
+   absent from a present file record is non-executable and skipped
+4. Counts a changed in-scope file that is entirely absent from its
+   component's LCOV conservatively: its added non-blank, non-comment lines
+   are uncovered (the "new file with zero tests" hole)
+5. Skips a component whose LCOV artifact is entirely absent, with a loud
+   warning (lenient parity with the CI merge step)
+6. Exits 1 below the threshold, printing the uncovered `file: line-range`
+   list; exits 0 when at/above threshold or when the diff has no measurable
+   changed lines
+
+### Unified Coverage Calculation (ratchet)
 
 `tools/calculate_unified_coverage.py`:
 
@@ -202,7 +240,11 @@ jobs:
 2. Parses LCOV files (`LF:` = total executable lines, `LH:` = covered lines)
 3. Uses LCOV `LF:` as denominator (NOT filesystem line counts)
 4. Aggregates backend + frontend + common + tools covered/executable counts
-5. Reports unified percentage and exits 1 if coverage dropped below baseline
+5. Reports unified percentage and compares against the committed baseline:
+   in `block` mode (main pushes; the default) a regression exits 1, in
+   `report` mode (`--ratchet-mode report` / `COVERAGE_RATCHET_MODE=report`,
+   the PR lane) the same regression message is printed report-only and does
+   not fail the run (#1810)
 6. Lists file-level low coverage from the same component LCOV files when run
    with `--list-low-files`
 7. Writes the current `unified-coverage.json` before failing on a regression,
@@ -217,17 +259,27 @@ python tools/strip_lcov_branches.py coverage/unified.lcov coverage/coveralls-uni
 python tools/calculate_unified_coverage.py --list-low-files --threshold 90
 ```
 
-The `--threshold` flag applies only to the printed file-level low-coverage
-report. The CI pass/fail gate remains the no-regression comparison against
-`unified-coverage.json`.
+The calculator's `--threshold` flag applies only to the printed file-level
+low-coverage report. On main pushes the CI pass/fail decision remains the
+no-regression comparison against `unified-coverage.json`; on PRs it is the
+diff-coverage verdict.
 
 ---
 
 ### Coverage Gate
 
-The CI workflow uses baseline comparison to prevent coverage regressions. There is no fixed minimum threshold.
+The CI coverage gate has two lanes (#1810):
 
-- **Rationale**: No-regression is the primary gate; coverage must not drop from the committed baseline.
+- **PR lane — diff coverage (blocking)**: the unit of measurement matches the
+  unit of work. A PR passes iff its measurable changed lines are covered at or
+  above the threshold (default 85%). Deterministic per PR: no baseline, no
+  epsilon, no full-pipeline dependency, and a red verdict names the exact
+  uncovered `file: line-range` list instead of an aggregate percentage.
+- **Main lane — component ratchet (blocking water-line)**: coverage must not
+  drop from the committed `unified-coverage.json` baseline (±0.05% jitter
+  epsilon). On PRs the same ratchet still runs and prints its comparison, but
+  it is report-only. The baseline floor stays raise-only via the reviewed
+  main-only baseline PR.
 - **External reporting**: Coveralls remains enabled for historical visibility, but local deterministic gates decide whether CI fails. Coveralls status contexts are not required checks and CI does not publish synthetic GitHub statuses for them. External Coveralls failures must not fail CI or block post-merge staging.
 - **Coverage context artifact**: CI uploads `unified-coverage-context` with
   `coverage/backend.lcov`, `coverage/frontend.lcov`, `coverage/common.lcov`,
@@ -246,27 +298,42 @@ The CI workflow uses baseline comparison to prevent coverage regressions. There 
   through deterministic local jobs.
 
 #### How It Works
-1. **Primary gate**: Baseline comparison (zero tolerance for drops)
+1. **PR blocking gate**: Diff coverage (#1810)
+   - `tools/check_diff_coverage.py --base origin/$GITHUB_BASE_REF` runs in the
+     `unified-coverage` job on pull requests only, after the LCOV merge step
+   - Threshold default 85%; override per run with `--threshold` or the
+     `DIFF_COVERAGE_THRESHOLD` env var (a policy change belongs in
+     `common/testing/coverage/diff_coverage.py::DEFAULT_THRESHOLD` plus this doc)
+   - Local parity: run the tests you are already writing with `--cov` so the
+     touched component emits LCOV (backend: `apps/backend/coverage.lcov`;
+     tooling/common: `coverage-common.lcov` / `coverage-tools.lcov`; frontend:
+     `apps/frontend/coverage/lcov.info`), then run
+     `python tools/check_diff_coverage.py --base origin/main` — the same
+     verdict CI computes, in seconds, with no full-pipeline dependency
+2. **Main blocking gate**: Baseline comparison (no-regression ratchet)
    - Compares current coverage against `unified-coverage.json` baseline
-   - Fails CI if ANY component drops below baseline
+   - Fails main CI if ANY component drops below baseline (beyond the jitter
+     epsilon); on PRs the same comparison runs in report-only mode
+     (`COVERAGE_RATCHET_MODE=report`)
    - Opens or updates a baseline PR on main when coverage rises and the measured
      `unified-coverage.json` differs from the committed baseline
    - See [No-Regression Coverage Gate](./ci-cd.md#no-regression-coverage-gate) for details
-2. **Safety net**: Threshold check (optional)
+3. **Safety net**: Threshold check (optional)
    - `COVERAGE_THRESHOLD` defaults to `0` (disabled)
    - Set explicitly in CI if a minimum floor is desired
-   - Acts as fallback when baseline file doesn't exist
-#### Adjusting the Threshold
+   - Acts as fallback when baseline file doesn't exist; applies in both
+     ratchet modes
+#### Adjusting the Thresholds
 
-The threshold may be adjusted based on project needs:
-
-- **Raise threshold**: When a minimum floor is desired (e.g., set to 80 for a hard floor)
-- **Lower threshold**: Set to 0 to disable (default)
-- **Update process**:
-  1. Update `COVERAGE_THRESHOLD` in `.github/workflows/ci.yml`
-  2. Update this documentation
-  3. Ensure current coverage exceeds new threshold
-**Note**: If no threshold is set (`COVERAGE_THRESHOLD=0` or unset), only the no-regression baseline gate applies.
+- **Diff coverage threshold** (PR lane): default 85% lives in
+  `common/testing/coverage/diff_coverage.py::DEFAULT_THRESHOLD`; per-run
+  override via `--threshold` / `DIFF_COVERAGE_THRESHOLD`. Update the default
+  and this documentation together.
+- **Unified minimum floor** (`COVERAGE_THRESHOLD`): set to 0 to disable
+  (default). To raise: update `COVERAGE_THRESHOLD` in
+  `.github/workflows/ci.yml`, update this documentation, and ensure current
+  coverage exceeds the new floor.
+**Note**: If no unified floor is set (`COVERAGE_THRESHOLD=0` or unset), PRs gate on diff coverage and main pushes gate on the no-regression baseline.
 
 ---
 
@@ -284,6 +351,10 @@ cd apps/frontend && npx vitest run --coverage
 # Calculate unified coverage locally
 cp apps/frontend/coverage/lcov.info coverage/frontend.lcov
 python tools/calculate_unified_coverage.py
+
+# Check the PR-blocking diff coverage verdict locally (#1810): produce LCOV
+# for the component you touched (tests with --cov), then:
+python tools/check_diff_coverage.py --base origin/main
 ```
 
 ### Coverage Thresholds
@@ -292,7 +363,8 @@ python tools/calculate_unified_coverage.py
 |------|-------|-------|---------------|
 | Backend local/default pytest coverage | `apps/backend/pyproject.toml` | Backend unit test runs outside CI shard overrides | Developer feedback and pre-push guard |
 | Frontend local/default vitest coverage | `apps/frontend/vitest.config.ts` | Frontend unit/component runs | Developer feedback and pre-push guard |
-| Unified PR/main no-regression coverage | `tools/calculate_unified_coverage.py` + `unified-coverage.json` | Backend + frontend + common + tools LCOV | Authoritative project-level coverage merge gate |
+| Diff coverage (PR-blocking, #1810) | `tools/check_diff_coverage.py` (`common/testing/coverage/diff_coverage.py`) | Changed/added lines of the PR diff inside governed source trees | Authoritative PR coverage merge gate (threshold 85%) |
+| Unified main no-regression coverage | `tools/calculate_unified_coverage.py` + `unified-coverage.json` | Backend + frontend + common + tools LCOV | Authoritative main-push water-line; report-only on PRs |
 | Coveralls | Coveralls upload jobs | Line-only LCOV reporting contexts | Badge and trend reporting only |
 
 > **Note**: CI backend shard jobs may set `--cov-fail-under=0` to avoid unstable
@@ -388,7 +460,6 @@ cat unified-coverage.json
 
 1. **Frontend page tests**: Add tests for Next.js page components to raise frontend coverage
 2. **Coverage trends**: Track coverage over time with historical data
-3. **Per-PR coverage delta**: Report coverage change per PR (not just absolute)
 
 ---
 
@@ -407,7 +478,8 @@ statuses are not acceptance evidence.
 | Backend Tier-1 API E2E | No | No | No | Behavior-only stage; excluded from coverage denominator |
 | Frontend tests | Yes | Yes, via frontend LCOV | Frontend context | Component/UI coverage |
 | Tools/common coverage | Yes | Yes, via unified LCOV | Unified context only | Repository tooling and shared-library coverage |
-| Calculate Unified Coverage | Uses merged LCOV | Authoritative PR/main no-regression gate | Produces unified reporting artifact | Stable project-level gate |
+| Diff coverage gate (PR) | Uses merged LCOV | Authoritative PR-blocking verdict on changed lines (#1810) | No | Diff-scoped gate; runs only on pull requests |
+| Calculate Unified Coverage | Uses merged LCOV | Authoritative main no-regression gate; report-only on PRs | Produces unified reporting artifact | Stable project-level water-line |
 | Coveralls | Consumes CI LCOV | No | Reporting, badge, trend analysis | Not a merge gate |
 
 ### Source Scope Review
@@ -430,9 +502,10 @@ policy before CI can pass.
   current CI artifact.
 - `tools/check_coverage_policy.py` must fail when eligible source files are
   missing from LCOV or when unexpected files appear in LCOV.
-- Coveralls badge is reporting-only. The authoritative coverage gate is the
-  local CI calculation against `unified-coverage.json`, aggregated by `finish`.
-- The authoritative coverage gate is the deterministic local CI calculation;
+- Coveralls badge is reporting-only. The authoritative coverage gate is local
+  and deterministic in both lanes — diff coverage
+  (`tools/check_diff_coverage.py`) blocks PRs, and the calculation against
+  `unified-coverage.json` blocks main pushes — aggregated by `finish`;
   Coveralls is a main-branch external reporting baseline only.
 - Coveralls receives line-only LCOV files so its coverage percentage should
   track the local line metric for main-branch trend reporting.
@@ -458,7 +531,8 @@ When reviewing coverage gaps:
 
 ```markdown
 ## Coverage Assessment
- [ ] Unified coverage has no baseline regression (run `python tools/calculate_unified_coverage.py`)
+ [ ] Changed lines are covered at the diff threshold (run `python tools/check_diff_coverage.py --base origin/main`)
+ [ ] Unified coverage has no baseline regression on main (run `python tools/calculate_unified_coverage.py`)
 - [ ] Branch coverage verified with `--cov-branch`
 - [ ] No `pragma: no cover` without justification
 - [ ] Missing lines are truly non-testable (not just untested)
@@ -507,8 +581,8 @@ When reviewing coverage gaps:
 ## Success Criteria
 
 **Quantitative**:
- [ ] All PRs maintain or improve unified coverage from baseline
- [ ] CI fails if unified coverage drops below baseline
+ [ ] All PRs cover their measurable changed lines at or above the diff-coverage threshold
+ [ ] Main CI fails if unified coverage drops below baseline
 - [ ] Branch coverage tracked via `--cov-branch`
 - [ ] Coveralls badge reflects actual coverage
 

--- a/docs/ssot/test-execution-matrix.yaml
+++ b/docs/ssot/test-execution-matrix.yaml
@@ -49,6 +49,8 @@ ownership:
     package: testing
   - path: tests/tooling/test_coverage_policy.py
     package: testing
+  - path: tests/tooling/test_diff_coverage.py
+    package: testing
   - path: tests/tooling/test_ledger_module.py
     package: ledger
   - path: tests/tooling/test_ledger_package.py

--- a/tests/tooling/test_calculate_unified_coverage.py
+++ b/tests/tooling/test_calculate_unified_coverage.py
@@ -1348,6 +1348,124 @@ class TestMainBaselineExceptionPaths:
 
 
 # ---------------------------------------------------------------------------
+# Ratchet mode (#1810 G-ratchet-backstop): the component-% ratchet blocks main
+# pushes (block mode, the default) and is report-only on PRs (report mode).
+# ---------------------------------------------------------------------------
+
+
+class TestRatchetMode:
+    """AC-testing.diff-coverage.4: ratchet demoted to a main-only water-line."""
+
+    def _regressing_setup(self, tmp_path, monkeypatch):
+        """Baseline 80% everywhere; current backend drops to 70%."""
+        import re as _re  # noqa: PLC0415 — local to keep module imports intact
+
+        baseline_file = tmp_path / "baseline.json"
+        baseline_file.write_text(
+            json.dumps(
+                {
+                    "coverage_percent": 80.0,
+                    "total_lines": 300,
+                    "covered_lines": 240,
+                    "breakdown": {
+                        "backend": {
+                            "total_lines": 100,
+                            "covered_lines": 80,
+                            "coverage_percent": 80.0,
+                        },
+                        "frontend": {
+                            "total_lines": 100,
+                            "covered_lines": 80,
+                            "coverage_percent": 80.0,
+                        },
+                        "tools": {
+                            "total_lines": 100,
+                            "covered_lines": 80,
+                            "coverage_percent": 80.0,
+                        },
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("BASELINE_FILE", str(baseline_file))
+        monkeypatch.setenv("COVERAGE_THRESHOLD", "0")
+        monkeypatch.delenv("COVERAGE_RATCHET_MODE", raising=False)
+        monkeypatch.setattr(cuc, "ROOT_DIR", tmp_path)
+        monkeypatch.setattr(
+            cuc,
+            "get_backend_coverage",
+            lambda: {"total_lines": 100, "covered_lines": 70, "coverage_percent": 70.0},
+        )
+        ok = {"total_lines": 100, "covered_lines": 80, "coverage_percent": 80.0}
+        monkeypatch.setattr(cuc, "get_frontend_coverage", lambda: ok)
+        monkeypatch.setattr(cuc, "get_tools_coverage", lambda: ok)
+        return _re
+
+    def test_ratchet_report_mode_reports_regression_without_blocking(
+        self, tmp_path, monkeypatch, capfd
+    ):
+        _re = self._regressing_setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("COVERAGE_RATCHET_MODE", "report")
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main()
+
+        assert exc.value.code == 0
+        err = capfd.readouterr().err
+        # The regression is still fully reported, marked report-only.
+        assert _re.search(r"(?i)report-only", err)
+        assert _re.search(r"backend: current=70\.00% baseline=80\.00%", err)
+        # unified-coverage.json is still written in report mode.
+        assert (tmp_path / "unified-coverage.json").exists()
+
+    def test_ratchet_block_mode_flag_blocks_regression(self, tmp_path, monkeypatch):
+        self._regressing_setup(tmp_path, monkeypatch)
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main(["--ratchet-mode", "block"])
+
+        assert exc.value.code == 1
+
+    def test_ratchet_default_mode_is_block(self, tmp_path, monkeypatch):
+        self._regressing_setup(tmp_path, monkeypatch)
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main()
+
+        assert exc.value.code == 1
+
+    def test_ratchet_mode_flag_overrides_env(self, tmp_path, monkeypatch):
+        self._regressing_setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("COVERAGE_RATCHET_MODE", "block")
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main(["--ratchet-mode", "report"])
+
+        assert exc.value.code == 0
+
+    def test_report_mode_keeps_threshold_safety_net(self, tmp_path, monkeypatch):
+        self._regressing_setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("COVERAGE_RATCHET_MODE", "report")
+        # Unified current is 230/300 = 76.67% < 90 -> the safety net still fails
+        # the run even though the ratchet itself is report-only.
+        monkeypatch.setenv("COVERAGE_THRESHOLD", "90")
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main()
+
+        assert exc.value.code == 1
+
+    def test_invalid_ratchet_mode_env_fails_loudly(self, tmp_path, monkeypatch):
+        self._regressing_setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("COVERAGE_RATCHET_MODE", "sometimes")
+
+        with pytest.raises(SystemExit) as exc:
+            cuc.main()
+
+        assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
 # __main__ entry point (line 327)
 # ---------------------------------------------------------------------------
 

--- a/tests/tooling/test_common_tooling_modules.py
+++ b/tests/tooling/test_common_tooling_modules.py
@@ -122,6 +122,7 @@ def test_AC8_13_56_coverage_tools_delegate_to_common_implementations():
     strip_tool = importlib.import_module("tools.strip_lcov_branches")
     policy_tool = importlib.import_module("tools.check_coverage_policy")
     metrics_tool = importlib.import_module("tools.check_ci_metrics_contract")
+    diff_tool = importlib.import_module("tools.check_diff_coverage")
 
     assert (
         build_tool.main
@@ -152,6 +153,10 @@ def test_AC8_13_56_coverage_tools_delegate_to_common_implementations():
     assert (
         metrics_tool.main
         is importlib.import_module("common.meta.extension.metrics_contract").main
+    )
+    assert (
+        diff_tool.main
+        is importlib.import_module("common.testing.coverage.diff_coverage").main
     )
 
 

--- a/tests/tooling/test_diff_coverage.py
+++ b/tests/tooling/test_diff_coverage.py
@@ -1,0 +1,630 @@
+"""Behavioral tests for the diff-scoped PR coverage gate (#1810).
+
+ACs: AC-testing.diff-coverage.1 / .2 / .3 (common/testing/contract.py roadmap).
+
+Every test here is behavioral per the #1435 mirror-assertion discipline: it
+feeds a diff (``--diff-file``) plus a temporary LCOV tree into the module's
+functions or the ``tools/check_diff_coverage.py`` CLI and asserts on returned
+structures, exit codes, and output shape — never on another artifact's text.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from common.testing.coverage import diff_coverage as dc  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "tools" / "check_diff_coverage.py"
+
+
+# ---------------------------------------------------------------------------
+# parse_unified_diff
+# ---------------------------------------------------------------------------
+
+
+def test_parse_unified_diff_multi_file_multi_hunk():
+    diff = "\n".join(
+        [
+            "diff --git a/common/pkg/mod.py b/common/pkg/mod.py",
+            "index 1111111..2222222 100644",
+            "--- a/common/pkg/mod.py",
+            "+++ b/common/pkg/mod.py",
+            "@@ -10,2 +12,3 @@ def foo():",
+            "+a = 1",
+            "+b = 2",
+            "+c = 3",
+            "@@ -40 +45,2 @@ def bar():",
+            "+d = 4",
+            "+e = 5",
+            "diff --git a/tools/new_tool.py b/tools/new_tool.py",
+            "new file mode 100644",
+            "index 0000000..3333333",
+            "--- /dev/null",
+            "+++ b/tools/new_tool.py",
+            "@@ -0,0 +1,2 @@",
+            "+import sys",
+            "+print(sys.argv)",
+            "",
+        ]
+    )
+    assert dc.parse_unified_diff(diff) == {
+        "common/pkg/mod.py": {12, 13, 14, 45, 46},
+        "tools/new_tool.py": {1, 2},
+    }
+
+
+def test_parse_unified_diff_count_defaults_to_one():
+    diff = "\n".join(
+        [
+            "--- a/common/x.py",
+            "+++ b/common/x.py",
+            "@@ -3 +7 @@",
+            "+changed = True",
+            "",
+        ]
+    )
+    assert dc.parse_unified_diff(diff) == {"common/x.py": {7}}
+
+
+def test_parse_unified_diff_handles_quoted_and_unprefixed_targets():
+    diff = "\n".join(
+        [
+            '--- "a/common/spaced name.py"',
+            '+++ "b/common/spaced name.py"',
+            "@@ -1 +1 @@",
+            "+x = 1",
+            "--- common/noprefix.py",
+            "+++ common/noprefix.py",
+            "@@ -1 +2 @@",
+            "+y = 2",
+            "",
+        ]
+    )
+    assert dc.parse_unified_diff(diff) == {
+        "common/spaced name.py": {1},
+        "common/noprefix.py": {2},
+    }
+
+
+def test_parse_unified_diff_zero_count_hunk_adds_no_lines():
+    # A pure-deletion hunk (`+4,0`) touches no new-side lines.
+    diff = "\n".join(
+        [
+            "--- a/common/x.py",
+            "+++ b/common/x.py",
+            "@@ -5,3 +4,0 @@",
+            "-gone = 1",
+            "-gone = 2",
+            "-gone = 3",
+            "",
+        ]
+    )
+    assert dc.parse_unified_diff(diff) == {}
+
+
+def test_parse_unified_diff_ignores_deletions_and_pure_renames():
+    diff = "\n".join(
+        [
+            "diff --git a/common/old.py b/common/old.py",
+            "deleted file mode 100644",
+            "--- a/common/old.py",
+            "+++ /dev/null",
+            "@@ -1,3 +0,0 @@",
+            "-x = 1",
+            "-y = 2",
+            "-z = 3",
+            "diff --git a/common/before.py b/common/after.py",
+            "similarity index 100%",
+            "rename from common/before.py",
+            "rename to common/after.py",
+            "",
+        ]
+    )
+    assert dc.parse_unified_diff(diff) == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_component — scope rules over the shared coverage policy
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_component_maps_paths_to_policy_components():
+    resolved = dc.resolve_component("apps/backend/src/services/foo.py")
+    assert resolved is not None
+    component, relative = resolved
+    assert component.name == "backend"
+    assert relative == "src/services/foo.py"
+
+    resolved = dc.resolve_component("common/testing/coverage/diff_coverage.py")
+    assert resolved is not None
+    assert resolved[0].name == "common"
+    assert resolved[1] == "common/testing/coverage/diff_coverage.py"
+
+    resolved = dc.resolve_component("tools/check_diff_coverage.py")
+    assert resolved is not None
+    assert resolved[0].name == "tools"
+
+    resolved = dc.resolve_component("apps/frontend/src/lib/api.ts")
+    assert resolved is not None
+    assert resolved[0].name == "frontend"
+    assert resolved[1] == "src/lib/api.ts"
+
+
+def test_resolve_component_rejects_out_of_scope_paths():
+    # Docs, tests, workflows, wrong extensions, and policy-excluded files are
+    # out of scope for the diff gate.
+    assert dc.resolve_component("docs/ssot/coverage.md") is None
+    assert dc.resolve_component("tests/tooling/test_diff_coverage.py") is None
+    assert dc.resolve_component(".github/workflows/ci.yml") is None
+    assert dc.resolve_component("apps/backend/src/notes.txt") is None
+    assert dc.resolve_component("apps/backend/src/__init__.py") is None
+    assert dc.resolve_component("apps/backend/README.md") is None
+    assert dc.resolve_component("common/testing/__init__.py") is None
+    assert dc.resolve_component("apps/frontend/src/__tests__/page.test.tsx") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_lcov_line_hits
+# ---------------------------------------------------------------------------
+
+
+def test_parse_lcov_line_hits_sums_duplicates_and_normalizes_paths(tmp_path):
+    lcov = tmp_path / "common.lcov"
+    lcov.write_text(
+        "\n".join(
+            [
+                "SF:common/pkg/mod.py",
+                "DA:1,1",
+                "DA:2,0",
+                "DA:5,3",
+                "end_of_record",
+                # Duplicate record for the same source (e.g. merged shards):
+                # hits must accumulate, mirroring flush_record semantics.
+                "SF:common/pkg/mod.py",
+                "DA:2,2",
+                "DA:9,0",
+                # Malformed DA records are skipped, not fatal.
+                "DA:bad,1",
+                "DA:7",
+                "end_of_record",
+            ]
+        )
+    )
+    component = dc.get_component("common")
+    hits = dc.parse_lcov_line_hits(lcov, component, tmp_path)
+    assert hits == {"common/pkg/mod.py": {1: 1, 2: 2, 5: 3, 9: 0}}
+
+
+def test_parse_lcov_line_hits_missing_file_returns_empty(tmp_path):
+    component = dc.get_component("common")
+    assert dc.parse_lcov_line_hits(tmp_path / "no.lcov", component, tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# evaluate_diff_coverage — verdict math on a temporary repo tree
+# ---------------------------------------------------------------------------
+
+
+def _write(root: Path, rel: str, content: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _common_lcov(root: Path, records: str) -> None:
+    _write(root, "coverage/common.lcov", records)
+
+
+def test_verdict_covered_uncovered_and_nonexecutable_lines(tmp_path):
+    _common_lcov(
+        tmp_path,
+        "\n".join(
+            [
+                "SF:common/pkg/mod.py",
+                "DA:10,1",
+                "DA:11,0",
+                "DA:13,2",
+                "end_of_record",
+                "",
+            ]
+        ),
+    )
+    # Changed lines: 10 (covered), 11 (uncovered), 12 (absent from the present
+    # record -> non-executable, skipped), 13 (covered).
+    report = dc.evaluate_diff_coverage(
+        {"common/pkg/mod.py": {10, 11, 12, 13}}, tmp_path
+    )
+    assert report.skipped_components == ()
+    assert len(report.files) == 1
+    verdict = report.files[0]
+    assert verdict.path == "common/pkg/mod.py"
+    assert verdict.component == "common"
+    assert verdict.covered_lines == (10, 13)
+    assert verdict.uncovered_lines == (11,)
+    assert verdict.missing_from_lcov is False
+    assert report.measurable_lines == 3
+    assert report.covered_count == 2
+
+
+def test_file_absent_from_present_lcov_is_conservatively_uncovered(tmp_path):
+    # The component artifact exists but has no record for the changed file —
+    # the "new file with zero tests" hole. Its added non-blank, non-comment
+    # lines count as uncovered.
+    _common_lcov(
+        tmp_path,
+        "SF:common/pkg/other.py\nDA:1,1\nend_of_record\n",
+    )
+    _write(
+        tmp_path,
+        "common/pkg/newmod.py",
+        "\n".join(
+            [
+                '"""Docstring."""',  # line 1: significant
+                "",  # line 2: blank
+                "# a comment",  # line 3: comment
+                "import sys",  # line 4: significant
+                "",  # line 5: blank
+                "print(sys.argv)",  # line 6: significant
+            ]
+        ),
+    )
+    # Line 99 is beyond EOF (defensive: a stale diff) and is skipped; an
+    # entry with no changed lines contributes nothing.
+    report = dc.evaluate_diff_coverage(
+        {
+            "common/pkg/newmod.py": {1, 2, 3, 4, 5, 6, 99},
+            "common/pkg/untouched.py": set(),
+        },
+        tmp_path,
+    )
+    assert len(report.files) == 1
+    verdict = report.files[0]
+    assert verdict.missing_from_lcov is True
+    assert verdict.covered_lines == ()
+    assert verdict.uncovered_lines == (1, 4, 6)
+    assert report.measurable_lines == 3
+    assert report.covered_count == 0
+
+
+def test_significant_lines_fall_back_to_all_lines_when_unreadable(tmp_path):
+    # read_text failing (e.g. the path is a directory) keeps the rule
+    # conservative: every added line counts as uncovered.
+    assert dc._significant_lines(tmp_path, {2, 1}) == (1, 2)
+
+
+def test_out_of_scope_files_and_absent_artifacts_are_lenient(tmp_path, capfd):
+    """AC-testing.diff-coverage.3: docs/tests/config changes and absent
+    component artifacts never produce a blocking verdict."""
+    # No coverage/ artifacts exist at all in this tree.
+    _write(tmp_path, "tools/some_tool.py", "x = 1\n")
+    changed = {
+        "docs/ssot/coverage.md": {1, 2},
+        "tests/tooling/test_something.py": {5},
+        ".github/workflows/ci.yml": {100},
+        "tools/some_tool.py": {1},
+    }
+    report = dc.evaluate_diff_coverage(changed, tmp_path)
+    # Docs/tests/workflow changes resolve to no component; the tools file's
+    # component artifact is absent -> the component is skipped, loudly.
+    assert report.files == ()
+    assert report.skipped_components == ("tools",)
+    assert report.measurable_lines == 0
+    assert report.percent is None
+
+    # CLI parity: the same situation exits 0 and says so explicitly.
+    diff = "\n".join(
+        [
+            "--- a/tools/some_tool.py",
+            "+++ b/tools/some_tool.py",
+            "@@ -0,0 +1 @@",
+            "+x = 1",
+            "",
+        ]
+    )
+    diff_file = _write(tmp_path, "changes.diff", diff)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(tmp_path),
+            "--diff-file",
+            str(diff_file),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0
+    assert re.search(r"(?i)warning.*tools", result.stdout + result.stderr)
+    assert re.search(r"(?i)no measurable changed lines", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# format_line_ranges
+# ---------------------------------------------------------------------------
+
+
+def test_format_line_ranges_collapses_runs():
+    assert dc.format_line_ranges([45, 46, 47, 48, 92]) == "45-48, 92"
+    assert dc.format_line_ranges([7]) == "7"
+    assert dc.format_line_ranges([3, 1, 2, 9]) == "1-3, 9"
+    assert dc.format_line_ranges([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# CLI — subprocess, the exact surface CI invokes
+# ---------------------------------------------------------------------------
+
+
+def _cli_fixture(tmp_path: Path) -> Path:
+    """A tree where common/pkg/mod.py has 4 covered + 1 uncovered changed
+    lines and common/pkg/newmod.py (2 code lines) is absent from LCOV:
+    4/7 measurable changed lines covered = 57.1%."""
+    _common_lcov(
+        tmp_path,
+        "\n".join(
+            [
+                "SF:common/pkg/mod.py",
+                "DA:45,0",
+                "DA:50,1",
+                "DA:51,1",
+                "DA:52,2",
+                "DA:60,4",
+                "end_of_record",
+                "",
+            ]
+        ),
+    )
+    _write(tmp_path, "common/pkg/newmod.py", "import sys\nprint(sys.argv)\n")
+    diff = "\n".join(
+        [
+            "--- a/common/pkg/mod.py",
+            "+++ b/common/pkg/mod.py",
+            "@@ -44,0 +45 @@",
+            "+bad = 1",
+            "@@ -49,2 +50,3 @@",
+            "+ok = 1",
+            "+ok = 2",
+            "+ok = 3",
+            "@@ -59 +60 @@",
+            "+ok = 4",
+            "--- /dev/null",
+            "+++ b/common/pkg/newmod.py",
+            "@@ -0,0 +1,2 @@",
+            "+import sys",
+            "+print(sys.argv)",
+            "",
+        ]
+    )
+    return _write(tmp_path, "changes.diff", diff)
+
+
+def _run_cli(tmp_path: Path, diff_file: Path, *args: str, env: dict | None = None):
+    import os
+
+    merged_env = dict(os.environ)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(tmp_path),
+            "--diff-file",
+            str(diff_file),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=merged_env,
+    )
+
+
+def test_cli_blocks_below_threshold_and_passes_at_or_above(tmp_path):
+    """AC-testing.diff-coverage.1: verdict is computed from the diff plus the
+    LCOV tree alone and gates on the threshold."""
+    diff_file = _cli_fixture(tmp_path)
+
+    red = _run_cli(tmp_path, diff_file, "--threshold", "85")
+    assert red.returncode == 1
+    # Summary states percent, covered/measurable counts, and the threshold.
+    assert re.search(
+        r"diff coverage: 57\.1% \(4/7 measurable changed lines covered\)",
+        red.stdout,
+    )
+    assert re.search(r"threshold 85", red.stdout)
+
+    green = _run_cli(tmp_path, diff_file, "--threshold", "50")
+    assert green.returncode == 0
+
+    # Exactly at the threshold passes.
+    at_threshold = _run_cli(tmp_path, diff_file, "--threshold", "57.1")
+    assert at_threshold.returncode == 0
+
+    # DIFF_COVERAGE_THRESHOLD env is the fallback when the flag is absent.
+    env_red = _run_cli(tmp_path, diff_file, env={"DIFF_COVERAGE_THRESHOLD": "90"})
+    assert env_red.returncode == 1
+    env_green = _run_cli(tmp_path, diff_file, env={"DIFF_COVERAGE_THRESHOLD": "50"})
+    assert env_green.returncode == 0
+
+
+def test_red_verdict_lists_uncovered_line_ranges_and_new_file_hole(tmp_path):
+    """AC-testing.diff-coverage.2: a red verdict names file:line ranges and
+    flags files absent from LCOV."""
+    diff_file = _cli_fixture(tmp_path)
+    result = _run_cli(tmp_path, diff_file, "--threshold", "85")
+    assert result.returncode == 1
+    assert re.search(r"common/pkg/mod\.py: uncovered lines 45", result.stdout)
+    assert re.search(r"common/pkg/newmod\.py: uncovered lines 1-2", result.stdout)
+    # The new-file hole is called out as such, not silently folded in.
+    assert re.search(r"(?i)not in .*lcov|zero tests", result.stdout)
+
+
+def _tiny_git_repo(tmp_path: Path) -> Path:
+    """A real two-commit repo: feature adds lines 2-3 of common/pkg/mod.py."""
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+            env={
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@example.com",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@example.com",
+                "PATH": __import__("os").environ["PATH"],
+                "HOME": str(tmp_path),
+            },
+        )
+
+    git("init", "-b", "main")
+    _write(root, "common/pkg/mod.py", "a = 1\n")
+    git("add", ".")
+    git("commit", "-m", "base")
+    git("checkout", "-b", "feature")
+    _write(root, "common/pkg/mod.py", "a = 1\nb = 2\nc = 3\n")
+    git("add", ".")
+    git("commit", "-m", "change")
+    _common_lcov(
+        root,
+        "SF:common/pkg/mod.py\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n",
+    )
+    return root
+
+
+def test_cli_git_mode_diffs_against_merge_base(tmp_path):
+    """Without --diff-file the CLI derives the diff from git itself."""
+    root = _tiny_git_repo(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(root),
+            "--base",
+            "main",
+            "--threshold",
+            "85",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0
+    assert re.search(
+        r"diff coverage: 100\.0% \(2/2 measurable changed lines covered\)",
+        result.stdout,
+    )
+
+
+def test_cli_missing_diff_file_is_a_usage_error(tmp_path):
+    result = _run_cli(tmp_path, tmp_path / "does-not-exist.diff")
+    assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# main() — in-process drives. The subprocess tests above prove the real
+# command surface; these drive the same flows in-process so the CI tooling
+# LCOV measures the module's own lines (subprocesses are not instrumented) —
+# which is exactly what this PR's diff-coverage gate demands of itself.
+# ---------------------------------------------------------------------------
+
+
+def _main_code(argv: list[str]) -> int:
+    with pytest.raises(SystemExit) as exc:
+        dc.main(argv)
+    return exc.value.code
+
+
+def test_main_red_then_green_thresholds(tmp_path, capfd):
+    diff_file = _cli_fixture(tmp_path)
+    base_args = ["--repo-root", str(tmp_path), "--diff-file", str(diff_file)]
+
+    assert _main_code([*base_args, "--threshold", "85"]) == 1
+    out = capfd.readouterr().out
+    assert re.search(
+        r"diff coverage: 57\.1% \(4/7 measurable changed lines covered\)", out
+    )
+    assert re.search(r"common/pkg/mod\.py: uncovered lines 45", out)
+    assert re.search(r"common/pkg/newmod\.py: uncovered lines 1-2", out)
+    assert re.search(r"(?i)zero tests", out)
+
+    assert _main_code([*base_args, "--threshold", "50"]) == 0
+    assert re.search(r"✅ diff coverage", capfd.readouterr().out)
+
+
+def test_main_env_threshold_fallback_and_validation(tmp_path, monkeypatch):
+    diff_file = _cli_fixture(tmp_path)
+    base_args = ["--repo-root", str(tmp_path), "--diff-file", str(diff_file)]
+
+    monkeypatch.setenv("DIFF_COVERAGE_THRESHOLD", "90")
+    assert _main_code(base_args) == 1
+    monkeypatch.setenv("DIFF_COVERAGE_THRESHOLD", "50")
+    assert _main_code(base_args) == 0
+    monkeypatch.setenv("DIFF_COVERAGE_THRESHOLD", "not-a-number")
+    assert _main_code(base_args) == 2
+
+
+def test_main_no_measurable_lines_passes_with_warning(tmp_path, capfd):
+    _write(tmp_path, "tools/some_tool.py", "x = 1\n")
+    diff_file = _write(
+        tmp_path,
+        "changes.diff",
+        "\n".join(
+            [
+                "--- a/tools/some_tool.py",
+                "+++ b/tools/some_tool.py",
+                "@@ -0,0 +1 @@",
+                "+x = 1",
+                "",
+            ]
+        ),
+    )
+    code = _main_code(["--repo-root", str(tmp_path), "--diff-file", str(diff_file)])
+    out = capfd.readouterr().out
+    assert code == 0
+    assert re.search(r"(?i)warning.*tools", out)
+    assert re.search(r"(?i)no measurable changed lines", out)
+
+
+def test_main_git_mode_and_bad_base(tmp_path, capfd, monkeypatch):
+    root = _tiny_git_repo(tmp_path)
+
+    monkeypatch.setenv("DIFF_COVERAGE_BASE", "main")
+    assert _main_code(["--repo-root", str(root), "--threshold", "85"]) == 0
+    assert re.search(
+        r"diff coverage: 100\.0% \(2/2 measurable changed lines covered\)",
+        capfd.readouterr().out,
+    )
+
+    monkeypatch.delenv("DIFF_COVERAGE_BASE")
+    code = _main_code(
+        ["--repo-root", str(root), "--base", "no-such-ref", "--threshold", "85"]
+    )
+    assert code == 2
+    assert re.search(
+        r"(?i)git diff against 'no-such-ref' failed", capfd.readouterr().err
+    )
+
+
+def test_main_missing_diff_file_is_a_usage_error(tmp_path):
+    code = _main_code(
+        ["--repo-root", str(tmp_path), "--diff-file", str(tmp_path / "nope.diff")]
+    )
+    assert code == 2

--- a/tools/check_diff_coverage.py
+++ b/tools/check_diff_coverage.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Command wrapper for the diff-scoped PR coverage gate (#1810)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.testing.coverage.diff_coverage import main  # noqa: E402
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary

Metric layer of #1810 (PR-3). On pull requests the blocking coverage verdict becomes **diff coverage**: the PR's own changed/added lines inside governed source trees must be covered by tests at or above the threshold, and a red verdict names the uncovered `file: line-range` list. The component-% ratchet stops blocking PRs and remains the blocking no-regression water-line on `main` pushes only.

## Guarantee mapping

| Guarantee (#1810) | Delivered by | Proof |
|---|---|---|
| **G-diff-coverage** — a PR's blocking coverage verdict is computable from the PR's own diff plus its own test run (no full-pipeline dependency, no epsilon), and a red verdict names uncovered file:line ranges | `common/testing/coverage/diff_coverage.py` + `tools/check_diff_coverage.py`, wired as the PR-only "Diff coverage gate (PR)" step in the `unified-coverage` job | `AC-testing.diff-coverage.1/.2/.3` → `tests/tooling/test_diff_coverage.py` (behavioral: `--diff-file` + tmp LCOV trees, subprocess CLI + in-process drives) |
| **G-ratchet-backstop** — the component-% ratchet remains a main-only water-line; floor stays raise-only; no AC net-deleted | `calculate_unified_coverage.py --ratchet-mode {block,report}` (`COVERAGE_RATCHET_MODE`); CI sets `report` on PRs, `block` (default) on main pushes; the `unified-coverage-baseline-pr` raise-only flow is untouched, `#1689` gate-components scoping kept | `AC-testing.diff-coverage.4` → `tests/tooling/test_calculate_unified_coverage.py::TestRatchetMode` |

## Threshold and overrides

- Default **85%** (`common/testing/coverage/diff_coverage.py::DEFAULT_THRESHOLD`) — issue #1810 suggested 80–90; final value is a review-time policy pick, changeable in one line.
- Per-run override: `--threshold N` or `DIFF_COVERAGE_THRESHOLD=N`; base ref via `--base` / `DIFF_COVERAGE_BASE` (default `origin/main`).
- Exit semantics: `0` pass or no measurable changed lines (says so explicitly), `1` below threshold, `2` usage/git errors.

## Scope rules (conservative where it matters)

- Out-of-scope changes (docs, tests, configs, workflows, policy-excluded files) never enter the denominator.
- A changed line absent from a present LCOV file record = non-executable → skipped.
- A changed in-scope file entirely absent from its component's LCOV → all added non-blank, non-comment lines count uncovered (the "new file with zero tests" hole is closed, and the output says so).
- An entirely absent component artifact → that component's files are skipped with a loud warning (parity with the lenient CI merge step).

## Local parity

Run the tests you are already writing with `--cov` so the touched component emits LCOV, then:

```bash
python tools/check_diff_coverage.py --base origin/main
```

Same verdict CI computes, in seconds, no full-pipeline dependency. Deterministic offline input via `--diff-file` + `--repo-root`.

## Self-test

This PR is the first to exercise its own gate: measured locally against CI-parity LCOV, its own diff scores **100.0% (248/248 measurable changed lines covered)**.

## Ripples handled

- `docs/ssot/coverage.md` (v2.1.0) + `docs/ssot/ci-cd.md`: PR lane = diff coverage, main lane = ratchet water-line.
- `ci.yml` `finish` coverage summary reflects the two lanes; `unified-coverage` checkout gets `fetch-depth: 0` for the merge-base.
- Mirror-assertion ratchet baseline unchanged (2917 → 2917); no new text mirrors — new tests are behavioral.
- `common/testing/contract.py` roadmap group `diff-coverage` (+ `TEST_ROOTS`), regenerated `docs/ssot/test-execution-matrix.yaml`.
- Expected trivial append conflict with sibling PR `feat/1810-preflight-static-tier-contract` in `contract.py`'s roadmap; both additions are self-contained.

Part of #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)