### PR TITLE
[finance_report_vision] chore(docs): sync stale pre-migration paths; drop dead coverage omits + orphan package

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -123,9 +123,7 @@ parallel = true
 sigterm = true
 omit = [
     "__init__.py",
-    "models/__init__.py",
     "schemas/__init__.py",
-    "services/__init__.py",
     "routers/__init__.py",
     "main.py",
     "tests/**",

--- a/docs/agents/red-lines.md
+++ b/docs/agents/red-lines.md
@@ -34,9 +34,9 @@ Assets = Liabilities + Equity + (Income - Expenses)
 ```
 
 - Every `JournalEntry` must have **balanced debits and credits**.  
-  Test: `apps/backend/tests/accounting/test_accounting.py::test_balanced_entry_passes`
+  Test: `apps/backend/tests/ledger/test_accounting.py::test_balanced_entry_passes`
 - Accounting equation must be satisfied at every point.  
-  Test: `apps/backend/tests/accounting/test_accounting_equation.py::test_accounting_equation_violation_detected`
+  Test: `apps/backend/tests/ledger/test_accounting_equation.py::test_accounting_equation_violation_detected`
 - Reconciliation thresholds (≥85 auto-accept; 60–84 review; <60 unmatched) must not be overridden.  
   See: [reconciliation.md](../ssot/reconciliation.md)
 

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -321,8 +321,8 @@ class TestVoidRequest:         # 2 tests
 src/ledger/extension/accounting.py      91%
 src/schemas/account.py         100%
 src/schemas/journal.py         100%
-src/models/account.py           97%
-src/models/journal.py           96%
+src/ledger/orm/account.py       97%
+src/ledger/orm/journal.py       96%
 ```
 
 ### Running Tests
@@ -334,7 +334,7 @@ cd apps/backend
 podman compose -f docker-compose.yml up -d postgres
 
 # Create test database
-podman exec finance_report_db psql -U postgres -c "CREATE DATABASE finance_report_test;"
+podman exec finance-report-db psql -U postgres -c "CREATE DATABASE finance_report_test;"
 
 # Run tests
 uv run pytest -v
@@ -384,8 +384,8 @@ retained in [#548](https://github.com/wangzitian0/finance_report/issues/548):
 
 ## 🔗 Deliverables
 
-- [x] `apps/backend/src/models/account.py` - Account model
-- [x] `apps/backend/src/models/journal.py` - JournalEntry & JournalLine models
+- [x] `apps/backend/src/ledger/orm/account.py` - Account model (moved from `src/models/` in #1675)
+- [x] `apps/backend/src/ledger/orm/journal.py` - JournalEntry & JournalLine models (moved from `src/models/` in #1675)
 - [x] `apps/backend/src/ledger/extension/accounting.py` - Accounting service
 - [x] `apps/backend/src/routers/accounts.py` - Account API endpoints
 - [x] `apps/backend/src/routers/journal.py` - Journal API endpoints

--- a/docs/project/EPIC-003.statement-parsing.md
+++ b/docs/project/EPIC-003.statement-parsing.md
@@ -155,14 +155,14 @@ roadmap) stays registered in
 
 ## 🔗 Deliverables
 
-- [x] `apps/backend/src/models/statement.py`
+- [x] `apps/backend/src/extraction/orm/` - statement models (`layer1.py`–`layer4.py`, `statement_enums.py`, `statement_summary.py`; moved from `src/models/statement.py` in #1675)
 - [x] `apps/backend/src/extraction/extension/service.py`
 - [x] `apps/backend/src/extraction/base/validation.py`
 - [x] `apps/backend/src/routers/statements.py`
 - [x] `apps/frontend/src/app/(main)/statements/page.tsx`
 - [x] `apps/frontend/src/app/(main)/statements/[id]/page.tsx`
 - [x] `apps/backend/tests/extraction/` - Test suite
-- [x] `apps/backend/tests/test_csv_parsing.py` - CSV test suite
+- [x] `apps/backend/tests/extraction/test_csv_parsing.py` - CSV test suite
 
 ---
 

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -204,7 +204,7 @@ See: common/ledger/readme.md#decimal-rule
 
 ## 🔗 Deliverables
 
-- [x] `apps/backend/src/models/reconciliation.py`
+- [x] `apps/backend/src/reconciliation/orm/reconciliation.py` (moved from `src/models/` in #1675)
 - [x] `apps/backend/src/reconciliation/extension/matching.py`
 - [x] `apps/backend/src/reconciliation/extension/review_queue.py`
 - [x] `apps/backend/src/reconciliation/extension/anomaly.py`

--- a/docs/project/EPIC-005.reporting-visualization.md
+++ b/docs/project/EPIC-005.reporting-visualization.md
@@ -435,8 +435,8 @@ fetching and normalizing it inline. Monetary values stay decimal strings.
 
 ## 🔗 Deliverables
 
-- [x] `apps/backend/src/services/reporting.py`
-- [x] `apps/backend/src/services/fx.py`
+- [x] `apps/backend/src/reporting/extension/` - reporting engine (moved from `src/services/reporting.py` in the reporting package cutover, #1648)
+- [x] `apps/backend/src/pricing/extension/fx.py` (moved from `src/services/fx.py` in #1610)
 - [x] `apps/backend/src/routers/reports.py`
 - [x] `apps/frontend/src/app/dashboard/page.tsx`
 - [x] `apps/frontend/src/app/reports/`

--- a/docs/project/EPIC-006.ai-advisor.md
+++ b/docs/project/EPIC-006.ai-advisor.md
@@ -279,7 +279,7 @@ The above analysis is for reference only.
 
 ## 🔗 Deliverables
 
-- [x] `apps/backend/src/services/ai_advisor.py`
+- [x] `apps/backend/src/advisor/extension/service.py` - AI advisor service (moved from `src/services/ai_advisor.py` in #1671)
 - [x] `apps/backend/src/routers/chat.py`
 - [x] `apps/frontend/src/app/chat/page.tsx`
 - [x] `apps/frontend/src/components/ChatWidget.tsx`

--- a/docs/project/EPIC-015.processing-account.md
+++ b/docs/project/EPIC-015.processing-account.md
@@ -170,13 +170,13 @@ Balance ≠ 0  → Pending Review ⚠️
 
 - [x] `docs/ssot/processing_account.md (retired -> common/ledger/readme.md)` (485 lines) - SSOT specification
 - [x] `apps/backend/migrations/versions/c955c65dcc1f_add_is_system_to_accounts.py` - Migration
-- [x] `apps/backend/src/models/account.py` - is_system flag added
+- [x] `apps/backend/src/ledger/orm/account.py` - is_system flag added (moved from `src/models/` in #1675)
 - [x] `apps/backend/src/schemas/account.py` - is_system schema field
 - [x] `apps/backend/src/ledger/extension/account_service.py` - System account handling (31 lines)
-- [x] `apps/backend/src/services/processing_account.py` (487 lines) - Core service
+- [x] `apps/backend/src/ledger/base/processing.py` + `apps/backend/src/ledger/extension/processing.py` - Core service (moved from `src/services/processing_account.py`)
 - [x] `apps/backend/src/reconciliation/extension/matching.py` - 3-phase flow integration (128 lines added)
 - [x] `apps/backend/src/ledger/extension/accounting.py` - Import/export updates (9 lines)
-- [x] `apps/backend/tests/accounting/test_processing_account.py` (811 lines) - Unit tests (33 tests)
+- [x] `apps/backend/tests/ledger/test_processing_account.py` (811 lines) - Unit tests (33 tests)
 - [x] `apps/backend/tests/reconciliation/test_transfer_integration.py` (569 lines) - Integration tests (7 tests)
 
 **Git Commit**: SHA `16ee6e9` - "feat: integrate Processing account with reconciliation engine (Task 1.4)"

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -73,7 +73,7 @@ now better managed by code, SSOT files, and generated proof.
 
 | Scope area | Owner |
 |---|---|
-| Holdings, cost basis, P&L, allocation, dividends | `apps/backend/src/services/portfolio.py`, `apps/backend/src/services/performance.py`, portfolio tests |
+| Holdings, cost basis, P&L, allocation, dividends | `apps/backend/src/portfolio/extension/` (`holdings.py`, `performance.py`, `allocation.py`, …), portfolio tests |
 | Brokerage statement parsing and import bridge | [common/extraction/readme.md](https://github.com/wangzitian0/finance_report/blob/main/common/extraction/readme.md), extraction/portfolio tests |
 | Asset and atomic-position model rationale | [assets.md](../ssot/assets.md), [schema.md](../ssot/schema.md) |
 | Portfolio API surface | `apps/backend/src/routers/portfolio.py`, API contract tests |

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -95,7 +95,7 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
   - Categories: Food & Dining, Transport, Shopping, Utilities, Salary, Transfer, Investment, Insurance, Rent, Healthcare, Entertainment, Education, Subscriptions, Other
   - Confidence: 0.0-1.0 float returned by AI
 - [x] Add `suggested_category` VARCHAR(100) and `category_confidence` DECIMAL(3,2) columns to `BankStatementTransaction`
-  - File: `apps/backend/src/models/statement.py`
+  - File: `apps/backend/src/extraction/orm/layer2.py` (`BankStatementTransaction` superseded by `AtomicTransaction` in #827; ORM moved from `src/models/` in #1675)
   - Migration: Alembic migration with nullable columns (backward compatible)
 - [x] Update extraction service to parse and persist AI-returned category fields
   - File: `apps/backend/src/extraction/extension/service.py`
@@ -210,7 +210,7 @@ Upload → [AI Vision + Category] → BankStatement → [AI + Rules Hybrid] → 
 
 #### 4.1 Reports Read Layer 3 Classification
 - [x] Modify `reporting.py` to read `TransactionClassification` (Layer 3) instead of raw `JournalLine`
-  - File: `apps/backend/src/services/reporting.py`
+  - File: `apps/backend/src/reporting/extension/` (moved from `src/services/reporting.py` in the reporting package cutover, #1648)
   - Current: Reports read `JournalEntry` → `JournalLine` directly, ignoring Layer 3
   - Target: Reports query `TransactionClassification` for category breakdowns
   - Fallback: If transaction has no classification, use account name as category (backward compatible)

--- a/docs/ssot/coverage.md
+++ b/docs/ssot/coverage.md
@@ -128,7 +128,7 @@ or registers it in that list via a reviewable diff. You cannot skip coverage by
 "just not registering" a folder. Exempting genuinely one-off tooling is allowed,
 but it must be an explicit, justified entry — never a silent omission.
 
-`tools/build_unified_lcov.py` rewrites component-relative LCOV paths into repository-root-relative paths before uploading the main-branch unified report to Coveralls. For example, backend `SF:src/services/example.py` becomes `SF:apps/backend/src/services/example.py`, and frontend `SF:src/app/page.tsx` becomes `SF:apps/frontend/src/app/page.tsx`.
+`tools/build_unified_lcov.py` rewrites component-relative LCOV paths into repository-root-relative paths before uploading the main-branch unified report to Coveralls. For example, backend `SF:src/ledger/example.py` becomes `SF:apps/backend/src/ledger/example.py`, and frontend `SF:src/app/page.tsx` becomes `SF:apps/frontend/src/app/page.tsx`.
 
 Coveralls upload LCOV files are line-only. CI strips `BRDA:`, `BRF:`, and
 `BRH:` records before main-branch upload so Coveralls percentages track the same

--- a/docs/ssot/development.md
+++ b/docs/ssot/development.md
@@ -124,8 +124,8 @@ moon run :test -- --fast          # TDD mode (no coverage, fastest)
 moon run :test -- --smart         # Coverage on changed files only
 moon run :test -- --e2e           # Root deployment E2E tests under tests/e2e/
 moon run :test -- --backend-e2e   # Backend Tier-1 API E2E under apps/backend/tests/e2e/
-moon run :test -- tests/accounting/  # Run specific module
-moon run :test -- tests/accounting/test_journal_service.py  # Run specific file
+moon run :test -- tests/ledger/  # Run specific module
+moon run :test -- tests/ledger/test_journal_service.py  # Run specific file
 
 # Environment Verification (See common/runtime/readme.md for full details)
 uv run python -m src.boot --mode full  # Full Stack Check (Gate 3)


### PR DESCRIPTION
## Summary

Repo-wide drift audit (docs vs. code) after the models/services decentralization (#1675 D6, #1815) and earlier package cutovers. Five parallel audit sweeps covered: dissolved-module residue, SSOT-vs-CI drift, orphan/dead files, test-suite residue, and README/EPIC accuracy. Test hygiene, tooling scripts, generated artifacts, workflows, and MANIFEST ownership all came back clean — the confirmed drift is entirely doc/config residue, fixed here. No behavior change.

## Changes

**Stale paths presented as current (docs):**
- EPIC-002/003/004/005/006/015/017/018 — deliverable and scope rows still pointed at dissolved `src/models/*` / `src/services/*` files; repointed to current package locations with moved-in annotations (#1675, #1671, #1648, #1610, #827)
- `docs/agents/red-lines.md`, `docs/ssot/development.md` — accounting-integrity test paths moved from `tests/accounting/` to `tests/ledger/` (note: `tests/accounting/` itself still exists; only these files moved)
- EPIC-002 — `podman exec finance_report_db` predates the hyphenated compose naming (`finance-report-db`); coverage-snapshot paths modernized to match the already-updated ledger row
- `docs/ssot/coverage.md` — LCOV rewrite example used the deleted `src/services/` layout

**Config/garbage:**
- `apps/backend/pyproject.toml` — dropped coverage `omit` entries for `models/__init__.py` / `services/__init__.py` (directories deleted in #1812/#1815)
- `tools/_lib/migrations/__init__.py` — removed zero-byte package with zero importers

## Verification

- `tools/preflight.py --tier=static`: all 4 relevant gates passed (ac-traceability, ssot-ownership, doc-consistency, taxonomy-drift); AC registries unchanged
- Every repointed path verified to exist on disk; every "moved" claim verified against git history
- No mirror-assertion tests reference the edited literals (checked `tests/tooling/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)