### PR TITLE
[finance_report_audit] feat(#1820): AC gate resolves frontend test refs — cross-end roadmap anchoring

### DIFF
--- a/.opencode/skills/domain/ac-workflow/SKILL.md
+++ b/.opencode/skills/domain/ac-workflow/SKILL.md
@@ -41,7 +41,11 @@ horizontal goal — the anchor is a goal reference, not the AC's home.
    - Package: append an `ACRecord(id=..., statement=...,
      test="apps/backend/tests/<pkg>/test_x.py::test_name", priority=...,
      status=...)` to the `roadmap` (schema:
-     `common/meta/base/package_contract.py`).
+     `common/meta/base/package_contract.py`). `test=` can anchor directly to a
+     frontend suite too (#1820) — `apps/frontend/**/*.test.ts::<it/test title>`
+     (also `.test.tsx`/`.spec.ts`/`.spec.tsx`) — resolved as file-exists + a
+     real vitest/Playwright `it(...)`/`test(...)` title match, no Python proxy
+     test required.
    - Legacy: add a row under the right `### ACx.y:` section of the EPIC with a
      unique `ACx.y.z` id, a one-line test case, the **exact test function
      name(s)**, the **test file path**, and a priority.

--- a/apps/frontend/src/lib/audit/money/money.conformance.test.ts
+++ b/apps/frontend/src/lib/audit/money/money.conformance.test.ts
@@ -60,6 +60,20 @@ describe("money conformance (cross-language standard #1167)", () => {
     }
   });
 
+  // Frontend AC-gate anchor (#1820): audit's roadmap resolves this AC's
+  // `test=` directly against this vitest title (no Python proxy test) —
+  // proves the rounding and convert vector tables share one rounding
+  // vocabulary, so quantize() and convert() can never silently diverge on
+  // which RoundingName values the standard supports.
+  it("AC-audit.20.2 quantize() and convert() share the same rounding vocabulary", () => {
+    const roundingNames = new Set(VECTORS.rounding.map((c) => c.rounding));
+    const convertRoundingNames = new Set(VECTORS.convert.map((c) => c.rounding));
+    expect(convertRoundingNames.size).toBeGreaterThan(0);
+    for (const name of convertRoundingNames) {
+      expect(roundingNames.has(name)).toBe(true);
+    }
+  });
+
   it("AC-audit.30.3 matches every convert vector through ExchangeRate", () => {
     for (const c of VECTORS.convert) {
       const result = convert(

--- a/common/audit/contract.py
+++ b/common/audit/contract.py
@@ -350,6 +350,28 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # Cross-runtime resolution proof (#1820): the FIRST roadmap AC whose
+        # `test=` anchors directly to a frontend vitest title — no Python
+        # proxy test — proving `check_package_contract`'s TS-ref resolution
+        # (file exists + a real `it(...)`/`test(...)` title matches) end to
+        # end against the live gate, not just its unit tests.
+        ACRecord(
+            id="AC-audit.20.2",
+            statement=(
+                "The frontend money conformance suite's rounding and convert "
+                "vector tables share one rounding vocabulary (every "
+                "RoundingName the convert vectors exercise is also a rounding "
+                "vector), so quantize() and convert() can never silently "
+                "diverge on which rounding modes the standard supports."
+            ),
+            test=(
+                "apps/frontend/src/lib/audit/money/money.conformance.test.ts"
+                "::AC-audit.20.2 quantize() and convert() share the same "
+                "rounding vocabulary"
+            ),
+            priority="P2",
+            status="done",
+        ),
         # ── group 9: Ratio / percent value type (was EPIC-012 AC12.9.*) ──
         ACRecord(
             id="AC-audit.9.1",

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -11,7 +11,11 @@ asserts:
   (a) ``contract.interface`` equals the BE implementation's ``__init__.__all__``
       (the published language and the contract agree);
   (b) every ``invariants[].test`` and ``roadmap[].test`` (``"path::func"``)
-      resolves to a real test function in the repo;
+      resolves to a real test function in the repo — a Python ``def``/``async
+      def`` for a pytest path, or (#1820) a vitest/Playwright ``it(...)``/
+      ``test(...)`` title for a ``*.test.ts``/``*.test.tsx``/``*.spec.ts``/
+      ``*.spec.tsx`` path, letting a package's ``roadmap`` anchor a
+      cross-runtime AC to its frontend half without a Python proxy test;
   (c) ``depends_on`` introduces no forbidden edge — a package's implementation
       modules must not import a higher layer of the five-layer topology
       (``meta < infra < middleware < domain < app``; mirrors the spirit of
@@ -69,6 +73,7 @@ from __future__ import annotations
 import argparse
 import ast
 import importlib.util
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -275,6 +280,32 @@ def _package_all(src_dir: Path) -> list[str]:
     return []
 
 
+# Frontend test-file suffixes a ``"path::func"`` ref may also resolve against
+# (#1820): a package's roadmap can anchor a cross-runtime AC to its vitest/
+# Playwright half instead of routing every FE behavior through a Python proxy
+# test. Matches the suffix vocabulary the AC-traceability scanner already uses
+# (``common.testing.ac_graph.TEST_FILE_SUFFIXES`` /
+# ``common.testing.check_ac_traceability.TEST_FILE_SUFFIXES``) so "what counts
+# as a frontend test file" cannot drift between the two gates.
+_FRONTEND_TEST_SUFFIXES = (".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
+
+# One vitest/Playwright test declaration: `it("name", ...)` / `test("name",
+# ...)`, optionally `.only`/`.skip`-modified (both suites share this call
+# shape). The name is captured verbatim between the matching quote characters
+# — no escape processing — mirroring the deliberately narrow "does a real
+# declaration with this title exist" proof the Python branch below performs
+# (an AST match on a real `def`/`async def`), not a full TS parse/compile.
+_JS_TEST_DECL = re.compile(
+    r"""\b(?:it|test)(?:\.(?:only|skip))?\s*\(\s*(['"`])(?P<name>.*?)\1""",
+    re.DOTALL,
+)
+
+
+def _frontend_test_names(text: str) -> set[str]:
+    """Every `it(...)`/`test(...)` title declared in a vitest/Playwright file."""
+    return {m.group("name") for m in _JS_TEST_DECL.finditer(text)}
+
+
 def _resolve_test(ref: str, repo_root: Path) -> str | None:
     """Return an error string if ``"path::func"`` does not resolve, else None."""
     if "::" not in ref:
@@ -283,6 +314,11 @@ def _resolve_test(ref: str, repo_root: Path) -> str | None:
     test_path = repo_root / rel_path
     if not test_path.exists():
         return f"test file does not exist: {rel_path}"
+    if rel_path.endswith(_FRONTEND_TEST_SUFFIXES):
+        names = _frontend_test_names(test_path.read_text(encoding="utf-8"))
+        if func not in names:
+            return f"test {func!r} not found in {rel_path}"
+        return None
     tree = ast.parse(test_path.read_text(encoding="utf-8"))
     names = {
         node.name

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -285,8 +285,13 @@ def _package_all(src_dir: Path) -> list[str]:
 # Playwright half instead of routing every FE behavior through a Python proxy
 # test. Matches the suffix vocabulary the AC-traceability scanner already uses
 # (``common.testing.ac_graph.TEST_FILE_SUFFIXES`` /
-# ``common.testing.check_ac_traceability.TEST_FILE_SUFFIXES``) so "what counts
-# as a frontend test file" cannot drift between the two gates.
+# ``common.testing.check_ac_traceability.TEST_FILE_SUFFIXES``) — duplicated
+# here, not imported: ``meta`` (this package) declares ``depends_on=[]``, and
+# importing ``common.testing`` (``infra``, a higher layer) would be exactly the
+# upward/undeclared edge ``_check_no_forbidden_edge`` below rejects (the one
+# prior "meta imports common.testing" exception was resolved by RELOCATING the
+# code into meta, per #1679, not by keeping the edge). Keep the two lists in
+# sync by hand if either vocabulary changes.
 _FRONTEND_TEST_SUFFIXES = (".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
 
 # One vitest/Playwright test declaration: `it("name", ...)` / `test("name",
@@ -317,7 +322,7 @@ def _resolve_test(ref: str, repo_root: Path) -> str | None:
     if rel_path.endswith(_FRONTEND_TEST_SUFFIXES):
         names = _frontend_test_names(test_path.read_text(encoding="utf-8"))
         if func not in names:
-            return f"test {func!r} not found in {rel_path}"
+            return f"test title {func!r} not found in {rel_path}"
         return None
     tree = ast.parse(test_path.read_text(encoding="utf-8"))
     names = {

--- a/tests/tooling/test_check_package_contract.py
+++ b/tests/tooling/test_check_package_contract.py
@@ -239,6 +239,164 @@ def test_resolve_test_branches(synthetic_repo: Path) -> None:
     assert _resolve_test("t/test_ok.py::test_async_real", synthetic_repo) is None
 
 
+# --- (b2) frontend (vitest/Playwright) test refs (#1820) ---------------------
+#
+# A roadmap/invariant `test=` ref may also point at a `*.test.ts`/`*.test.tsx`/
+# `*.spec.ts`/`*.spec.tsx` file. TS has no Python AST, so this resolves by file
+# existence + the test name matching a real `it(...)`/`test(...)` declaration —
+# the same "does a real declaration with this title exist" proof strength as
+# the Python branch, no stronger claim (no TS parse/compile check). The fixture
+# content below is deliberately NOT valid Python (curly-brace imports, arrow
+# functions, template literals) so a regression that still routes `.test.ts`
+# through `ast.parse` fails LOUDLY (a crash), not silently.
+
+
+def _write_ts_test_file(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            """
+            import { describe, expect, it, test } from "vitest";
+
+            describe("money conformance", () => {
+              it("AC-audit.20.2 real vitest test", () => {
+                expect(1 + 1).toBe(2);
+              });
+
+              test("a real test() declaration", () => {
+                expect(true).toBe(true);
+              });
+
+              test.only(`a template-literal title with ${1 + 1} inlined`, () => {
+                expect(true).toBe(true);
+              });
+            });
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_resolve_test_frontend_branches(synthetic_repo: Path) -> None:
+    test_dir = synthetic_repo / "apps" / "frontend" / "src"
+    test_dir.mkdir(parents=True)
+    ts_file = test_dir / "money.test.ts"
+    _write_ts_test_file(ts_file)
+    rel = "apps/frontend/src/money.test.ts"
+
+    # missing file
+    assert (
+        _resolve_test("apps/frontend/src/missing.test.ts::x", synthetic_repo)
+        is not None
+    )
+    # file exists, name absent -> reported, not a crash
+    err = _resolve_test(f"{rel}::no such test", synthetic_repo)
+    assert err is not None and "not found" in err
+    # resolves: `it(...)`, `test(...)`, and `test.only(...)` all count
+    assert (
+        _resolve_test(f"{rel}::AC-audit.20.2 real vitest test", synthetic_repo) is None
+    )
+    assert _resolve_test(f"{rel}::a real test() declaration", synthetic_repo) is None
+    assert (
+        _resolve_test(
+            f"{rel}::a template-literal title with ${{1 + 1}} inlined", synthetic_repo
+        )
+        is None
+    )
+
+
+def test_resolve_test_frontend_suffix_variants_all_resolve(
+    synthetic_repo: Path,
+) -> None:
+    """``.test.tsx`` / ``.spec.ts`` / ``.spec.tsx`` all take the frontend branch."""
+    test_dir = synthetic_repo / "apps" / "frontend" / "src"
+    test_dir.mkdir(parents=True)
+    for suffix in (".test.tsx", ".spec.ts", ".spec.tsx"):
+        ts_file = test_dir / f"money{suffix}"
+        _write_ts_test_file(ts_file)
+        rel = f"apps/frontend/src/money{suffix}"
+        assert (
+            _resolve_test(f"{rel}::AC-audit.20.2 real vitest test", synthetic_repo)
+            is None
+        ), suffix
+        assert _resolve_test(f"{rel}::not a real title", synthetic_repo) is not None, (
+            suffix
+        )
+
+
+def test_unresolved_frontend_roadmap_ref_is_reported(synthetic_repo: Path) -> None:
+    """A TS ref to a nonexistent file, and one to a real file with an absent test
+    name, are both reported by ``check_package`` — not a crash, not a silent
+    pass."""
+    pkg = _write_package(
+        _src(synthetic_repo),
+        "fefrefs",
+        klass="infra",
+        all_names=["X"],
+        interface=["X"],
+        roadmap=[
+            ACRecord(
+                id="AC1",
+                statement="s",
+                test="apps/frontend/src/no/such/file.test.ts::whatever",
+                priority="P0",
+                status="open",
+            )
+        ],
+    )
+    errors = check_package(pkg, {"fefrefs": "infra"}, synthetic_repo)
+    assert any(
+        "roadmap 'AC1'" in e and "test file does not exist" in e for e in errors
+    ), errors
+
+    # Real file, absent test name.
+    test_dir = synthetic_repo / "apps" / "frontend" / "src"
+    test_dir.mkdir(parents=True, exist_ok=True)
+    _write_ts_test_file(test_dir / "money2.test.ts")
+    pkg2 = _write_package(
+        _src(synthetic_repo),
+        "fefrefs2",
+        klass="infra",
+        all_names=["Y"],
+        interface=["Y"],
+        roadmap=[
+            ACRecord(
+                id="AC2",
+                statement="s",
+                test="apps/frontend/src/money2.test.ts::not a real title",
+                priority="P0",
+                status="open",
+            )
+        ],
+    )
+    errors2 = check_package(pkg2, {"fefrefs2": "infra"}, synthetic_repo)
+    assert any("roadmap 'AC2'" in e and "not found" in e for e in errors2), errors2
+
+
+def test_resolved_frontend_roadmap_ref_passes(synthetic_repo: Path) -> None:
+    """A TS ref to a real ``it(...)`` title resolves — no roadmap error."""
+    test_dir = synthetic_repo / "apps" / "frontend" / "src"
+    test_dir.mkdir(parents=True)
+    _write_ts_test_file(test_dir / "money.test.ts")
+    pkg = _write_package(
+        _src(synthetic_repo),
+        "fefok",
+        klass="infra",
+        all_names=["X"],
+        interface=["X"],
+        roadmap=[
+            ACRecord(
+                id="AC1",
+                statement="s",
+                test="apps/frontend/src/money.test.ts::AC-audit.20.2 real vitest test",
+                priority="P0",
+                status="open",
+            )
+        ],
+    )
+    errors = check_package(pkg, {"fefok": "infra"}, synthetic_repo)
+    assert not any("roadmap 'AC1'" in e for e in errors), errors
+
+
 # --- (c) forbidden dependency edges ------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Teaches `check_package_contract`'s `test="path::func"` resolver (the gate behind every package roadmap/invariant AC ref) to resolve frontend (vitest/Playwright) test refs, not just backend pytest paths — unblocking issue #1821 Wave B's 388 fe-owned EPIC AC rows from moving into package contract roadmaps.

Closes #1820 (parent #1819, Package-ization 1/4)

---

## The gap, precisely

`tools/generate_ac_registry.py`'s package-roadmap reader (`_roadmap_acs_from_contract`) and the mandatory-AC traceability scan (folded into `tools/check_ac_index.py`'s Gate A) never touch the `test=` field's target — they only need the AC id **string** to appear in a real test file, and that scanner already covers `apps/frontend/src` / `.test.ts(x)` / `.spec.ts(x)` (`common/testing/ac_graph.py::TEST_FILE_SUFFIXES`, `common/testing/check_ac_traceability.py::TEST_FILE_SUFFIXES`).

The actual `"path::func"` **resolver** — "does this ref point at a real test?" — lives in `common/meta/extension/check_package_contract.py::_resolve_test`, invoked by `tools/check_package_contract.py` (exercised end-to-end against the live repo by `tests/tooling/test_counter_package.py`/`test_extraction_package.py`'s `run(REPO)` calls). It called `ast.parse()` unconditionally — a `.test.ts` file is not valid Python, so any TS-anchored roadmap AC **crashed** the gate (`SyntaxError`, uncaught) rather than failing it cleanly. That's the "zero support" this issue measured.

---

## Ref grammar implemented

`test="<path>::<name>"` where `<path>` ends in `.test.ts` / `.test.tsx` / `.spec.ts` / `.spec.tsx` resolves as:

1. the file exists, **and**
2. `<name>` matches, verbatim, the quoted title of a real `it(...)` / `test(...)` declaration in that file (`.only`/`.skip` modifiers included).

Same proof strength as the backend branch (file exists + a real declaration with that name), no stronger claim — not a TS parse/compile check. Backend (`.py`) resolution is byte-identical (same `ast.parse` branch, same error wording); the frontend check is a new `if` branch that returns *before* `ast.parse` is ever reached for a `.test.ts*`/`.spec.ts*` path.

---

## End-to-end proof

`common/audit/contract.py` gets one new roadmap AC, `AC-audit.20.2`, anchored directly to a real frontend test — no Python proxy:

```
test=(
    "apps/frontend/src/lib/audit/money/money.conformance.test.ts"
    "::AC-audit.20.2 quantize() and convert() share the same "
    "rounding vocabulary"
)
```

The anchored test (`apps/frontend/src/lib/audit/money/money.conformance.test.ts`) asserts every `RoundingName` the convert vectors exercise is also declared in the rounding vectors — a real, non-placeholder assertion against the existing cross-language conformance fixture.

Verified against the live repo tree:
- `tools/generate_ac_registry.py` — regenerated, no diff (registry files are generated pointer indexes, unaffected)
- `tools/check_ac_index.py` — PASSED (2034 AC nodes managed, traceability + critical-proof contract intact)
- `tools/check_epic_package_dual.py` — PASSED
- `tools/check_package_contract.py` — PASSED (`audit`: 66 roadmap AC(s), up from 65)

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | N/A — package-model tooling/governance gate (issue #1820, parent #1819) |
| **AC IDs** | `AC-audit.20.2` (new, package roadmap — `common/audit/contract.py`, not EPIC-owned) |
| **AC source updated** | `common/audit/contract.py` roadmap (package-owned; never mirrored to an EPIC table) |

---

## SSOT Changes

- [x] None — existing SSOT (`common/meta/readme.md` §"Governance is computed, not authored") already documents `check_package_contract` as the `test=` resolver; this PR only extends its `common/meta/extension/check_package_contract.py` implementation and updates the `ac-workflow` skill (`.opencode/skills/domain/ac-workflow/SKILL.md`, symlinked from `.claude/skills/ac-workflow`) to document the new TS ref grammar.

---

## TDD Evidence

Red and green land in the same commit (fixture-driven unit tests written and run locally before commit); the pre-fix crash was verified interactively (`ast.parse` on TS content raises `SyntaxError`) before writing the fix.

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| 🔴 Red (verified pre-fix) | n/a (interactive) | `ast.parse()` on `.test.ts` content raises `SyntaxError`, confirming zero TS support |
| 🟢 Green | `9065906` | `_resolve_test` frontend branch + `tests/tooling/test_check_package_contract.py`: `test_resolve_test_frontend_branches`, `test_resolve_test_frontend_suffix_variants_all_resolve`, `test_unresolved_frontend_roadmap_ref_is_reported`, `test_resolved_frontend_roadmap_ref_passes` — 4 new tests, 36/36 pass in the file |

---

## Engineering Audit

- [ ] `sa.Enum` instances all have explicit `name="..._enum"` parameter — N/A, no schema changes
- [ ] `NEXT_PUBLIC_` variables added to `apps/frontend/Dockerfile` `ARG`/`ENV` (if applicable) — N/A
- [ ] `repo/` submodule updated for production config changes (if applicable) — N/A
- [ ] `tools/check_env_keys.py` passes (if env vars changed) — N/A, no env changes
- [ ] `tools/check_manifest.py` passes (if SSOT files changed) — N/A, no SSOT files changed
- [x] `tools/lint_doc_consistency.py` passes — N/A to this diff (only `.opencode/skills/` touched, outside its glob); not run (scoped verification per task)
- [x] No real financial data — the anchored test data is the existing generated conformance vectors fixture (`common/audit/money/conformance/vectors.json`), no real amounts/accounts/holder names.

---

## Verification (scoped; CI is the authority)

- `tools/generate_ac_registry.py`, `tools/check_ac_index.py`, `tools/check_epic_package_dual.py`, `tools/check_package_contract.py` — all PASSED against the live repo tree.
- `tools/check_taxonomy_drift.py`, `tools/preflight.py --tier=static` — PASSED.
- Targeted pytest: `tests/tooling/test_check_package_contract.py` (36 passed), plus `test_counter_package.py` + `test_extraction_package.py` + `test_ac_index_consistency.py` + `test_generate_ac_registry.py` (114 passed total) — the tests that exercise `check_package_contract.run()`/`check_ac_index.main()` against the real repo tree, most relevant to this change.
- `ruff check` / `ruff format --check` on the touched Python files — clean (one pre-existing formatting nit in my new test code auto-fixed).
- `vitest run` on the touched frontend spec (`money.conformance.test.ts`) — 10/10 pass (9 existing + 1 new). `eslint` on the same file — clean.
- Diff-scoped coverage: `--cov-report=term-missing` on `check_package_contract.py` confirms every new line is covered by the new tests (none of the new line numbers appear in the coverage tool's "Missing" list).
- Did **not** run the full `pytest tests/tooling/` suite (2000+ tests) or the full frontend build/coverage gate (`npm run build`/`test:coverage`) — per this task's explicit scoped-verification instruction; CI's heavy tier covers those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>