### PR TITLE
[finance_report_vision] chore(deploy): bump staging primary-model override to glm-5.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
-  STAGING_E2E_PRIMARY_MODEL: glm-5.1
+  STAGING_E2E_PRIMARY_MODEL: glm-5.2
   STAGING_E2E_OCR_MODEL: glm-4.6v
   STAGING_E2E_VISION_MODEL: glm-4.6v
   PYTHON_VERSION: "3.12.12"

--- a/.github/workflows/staging-ai-ocr-gate.yml
+++ b/.github/workflows/staging-ai-ocr-gate.yml
@@ -45,7 +45,7 @@ env:
   LLM_LIVE: "1"
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ${{ github.repository_owner }}/finance_report
-  STAGING_E2E_PRIMARY_MODEL: glm-5.1
+  STAGING_E2E_PRIMARY_MODEL: glm-5.2
   STAGING_E2E_OCR_MODEL: glm-4.6v
   STAGING_E2E_VISION_MODEL: glm-4.6v
   APP_URL: https://report-staging.zitian.party

--- a/tests/tooling/test_post_merge_e2e_gates.py
+++ b/tests/tooling/test_post_merge_e2e_gates.py
@@ -2353,7 +2353,7 @@ def test_AC8_13_7_staging_runs_llm_e2e_serially_with_glm_5_1() -> None:
     assert "post-merge-train-turn:" not in workflow
     assert "wait_post_merge_train_turn.py" not in workflow
     assert "workflow_dispatch:" in workflow
-    assert "STAGING_E2E_PRIMARY_MODEL: glm-5.1" in workflow
+    assert "STAGING_E2E_PRIMARY_MODEL: glm-5.2" in workflow
     assert "STAGING_E2E_OCR_MODEL: glm-4.6v" in workflow
     assert "STAGING_E2E_VISION_MODEL: glm-4.6v" in workflow
     assert (


### PR DESCRIPTION
## What

Bump the hardcoded `STAGING_E2E_PRIMARY_MODEL` override from `glm-5.1` to `glm-5.2` in
`deploy.yml` and `staging-ai-ocr-gate.yml`.

## Why

Operator directive (2026-07-14): the online primary lane must run glm-5.2 (longer context).
Vault `PRIMARY_MODEL` is already set to `glm-5.2` for staging and production, but staging deploys
pass `DEPLOY_PRIMARY_MODEL_OVERRIDE` from these workflow env values, which would keep pinning
staging back to glm-5.1 on every deploy — a silent staging/prod divergence.

Production (release.yml) passes no model override and follows Vault directly; no change needed.

## Notes

- Cassette banding is family-level by design (`llm/extension/cassette.py`), so 5.1→5.2 does not
  invalidate recorded suites (AC-llm.6.5 covers this).
- `config.py`'s local default deliberately NOT bumped here: touching `config.py` trips the
  (preflight-only) `env-keys` gate on a pre-existing drift — `AI_DAILY_LIMIT_USD` and
  `AI_MODEL_CATALOG_SOURCE` exist in the infra2 `secrets.ctmpl` (v1.1.20) with no `config.py`
  field. That drift needs its own decision (add fields vs prune ctmpl) and is out of scope.
- preflight --tier=static: green (workflow-only diff → "no relevant gates").

🤖 Generated with [Claude Code](https://claude.com/claude-code)