### PR TITLE
[finance_report_vision] fix(#1833): auto-post chain-validated opening balance on auto-approve

### DIFF
--- a/apps/backend/src/extraction/extension/statement_posting.py
+++ b/apps/backend/src/extraction/extension/statement_posting.py
@@ -20,7 +20,7 @@ from src.extraction.extension.statement_validation import approve_statement, res
 from src.extraction.extension.transaction_classification import classify_by_effective_policy
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
 from src.extraction.orm.statement_summary import StatementSummary
-from src.ledger import Account, AccountType, JournalEntry, JournalEntryStatus, ValidationError
+from src.ledger import Account, AccountType, JournalEntry, JournalEntryStatus, JournalLine, ValidationError
 from src.observability import get_logger
 
 logger = get_logger(__name__)
@@ -230,6 +230,35 @@ async def validate_statement_period_unique(
         )
 
 
+async def _account_has_opening_balance_entry(
+    db: AsyncSession,
+    user_id: UUID,
+    account_id: UUID,
+) -> bool:
+    """Whether ``account_id`` already has a guided opening-balance entry.
+
+    An opening balance establishes a one-time starting position for an account,
+    not a per-period fact — so the right idempotency check is "has this account
+    ever received one", not a date-ordering heuristic. (``post_opening_balance_entry``
+    itself only rejects when prior *posted activity* exists strictly before the
+    new entry_date, which does not cover two statements sharing the same
+    period_start; this check is a stronger, statement-auto-post-specific guard on
+    top of it.)
+    """
+    equity_entry_ids = (
+        select(JournalLine.journal_entry_id)
+        .join(Account, Account.id == JournalLine.account_id)
+        .where(Account.user_id == user_id, Account.is_system.is_(True), Account.code == "3199")
+    )
+    result = await db.execute(
+        select(JournalLine.id)
+        .where(JournalLine.account_id == account_id)
+        .where(JournalLine.journal_entry_id.in_(equity_entry_ids))
+        .limit(1)
+    )
+    return result.first() is not None
+
+
 async def try_auto_post_statement_opening_balance(
     db: AsyncSession,
     statement: StatementSummary,
@@ -243,10 +272,14 @@ async def try_auto_post_statement_opening_balance(
     otherwise the account's ledger balance is the period net flow, not the closing
     balance, and the balance sheet headline is wrong until a manual fix.
 
-    Fail-soft by design: ``post_opening_balance_entry`` rejects non-base currencies,
-    non-positive amounts, and accounts with prior activity (a follow-up month's
-    import). Any such rejection skips the opening entry without disturbing the
-    already-posted transactions.
+    Called unconditionally after a successful auto-approve — NOT gated on whether
+    any transactions were posted this call: a statement can be high-confidence and
+    balance-validated with zero transactions in its period (e.g. a dormant-account
+    month), and that statement's opening balance still needs posting or the account
+    balance is silently wrong (review comment on PR #1842). Idempotency is instead
+    enforced by ``_account_has_opening_balance_entry`` plus ``post_opening_balance_entry``'s
+    own guards (fail-soft: non-base currencies, non-positive amounts, and prior
+    activity all skip without disturbing already-posted transactions).
     """
     from src.ledger import post_opening_balance_entry
 
@@ -257,6 +290,9 @@ async def try_auto_post_statement_opening_balance(
         or statement.period_start is None
         or statement.account_id is None
     ):
+        return False
+
+    if await _account_has_opening_balance_entry(db, user_id, statement.account_id):
         return False
 
     try:
@@ -310,6 +346,11 @@ async def try_auto_approve_high_confidence_statement(
             await db.flush()
         return 0
 
-    if created_count:
-        await try_auto_post_statement_opening_balance(db, statement, user_id)
+    # Not gated on created_count: a statement can be high-confidence and
+    # balance-validated with zero transactions in its period (e.g. a dormant
+    # account), and its opening balance still needs posting (#1833, PR #1842
+    # review). Idempotency lives in try_auto_post_statement_opening_balance
+    # itself (_account_has_opening_balance_entry + post_opening_balance_entry's
+    # own guards), not here.
+    await try_auto_post_statement_opening_balance(db, statement, user_id)
     return created_count

--- a/apps/backend/src/extraction/extension/statement_posting.py
+++ b/apps/backend/src/extraction/extension/statement_posting.py
@@ -20,7 +20,10 @@ from src.extraction.extension.statement_validation import approve_statement, res
 from src.extraction.extension.transaction_classification import classify_by_effective_policy
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
 from src.extraction.orm.statement_summary import StatementSummary
-from src.ledger import Account, AccountType, JournalEntry, JournalEntryStatus
+from src.ledger import Account, AccountType, JournalEntry, JournalEntryStatus, ValidationError
+from src.observability import get_logger
+
+logger = get_logger(__name__)
 
 HIGH_CONFIDENCE_AUTO_APPROVE_THRESHOLD = 85
 
@@ -227,6 +230,55 @@ async def validate_statement_period_unique(
         )
 
 
+async def try_auto_post_statement_opening_balance(
+    db: AsyncSession,
+    statement: StatementSummary,
+    user_id: UUID,
+) -> bool:
+    """Post the statement's chain-validated opening balance as a guided opening entry (#1833).
+
+    Auto-approval already trusted the extracted opening balance to the same standard
+    it trusted the transactions (the running-balance chain reconciled), so the
+    starting position is posted against the system Opening Balance Equity account —
+    otherwise the account's ledger balance is the period net flow, not the closing
+    balance, and the balance sheet headline is wrong until a manual fix.
+
+    Fail-soft by design: ``post_opening_balance_entry`` rejects non-base currencies,
+    non-positive amounts, and accounts with prior activity (a follow-up month's
+    import). Any such rejection skips the opening entry without disturbing the
+    already-posted transactions.
+    """
+    from src.ledger import post_opening_balance_entry
+
+    opening_balance = statement.opening_balance
+    if (
+        opening_balance is None
+        or opening_balance <= 0
+        or statement.period_start is None
+        or statement.account_id is None
+    ):
+        return False
+
+    try:
+        async with db.begin_nested():
+            await post_opening_balance_entry(
+                db,
+                user_id,
+                entry_date=statement.period_start,
+                balances={statement.account_id: opening_balance},
+                currency=normalize_currency_code(statement.currency or ""),
+                memo="Opening balance (statement import)",
+            )
+        return True
+    except (ValidationError, ValueError) as exc:
+        logger.info(
+            "statement.opening_balance.auto_post_skipped",
+            statement_id=str(statement.id),
+            reason=str(exc)[:200],
+        )
+        return False
+
+
 async def try_auto_approve_high_confidence_statement(
     db: AsyncSession,
     statement_id: UUID,
@@ -249,7 +301,6 @@ async def try_auto_approve_high_confidence_statement(
             approved = await approve_statement(db, statement_id, user_id)
             created_count = await auto_create_posted_entries_for_statement(db, approved, user_id)
             await db.flush()
-        return created_count
     except ValueError as exc:
         refreshed = await db.get(StatementSummary, statement_id)
         if refreshed is not None:
@@ -258,3 +309,7 @@ async def try_auto_approve_high_confidence_statement(
             refreshed.validation_error = str(exc)[:500]
             await db.flush()
         return 0
+
+    if created_count:
+        await try_auto_post_statement_opening_balance(db, statement, user_id)
+    return created_count

--- a/apps/backend/tests/integration/test_statement_opening_balance_auto_post.py
+++ b/apps/backend/tests/integration/test_statement_opening_balance_auto_post.py
@@ -1,0 +1,180 @@
+"""AC-extraction.1833.1/.2: auto-approve posts the chain-validated opening balance (#1833).
+
+Staging real-statement QA (2026-07-14) showed the happy path producing a wrong
+headline: a high-confidence, balance-validated statement auto-approves and posts
+its period transactions, but the opening balance the chain validation just
+proved is never posted — so the account "balance" on the balance sheet is the
+period net flow (negative for a draw-down month), not the closing balance.
+
+These tests drive the same parse -> auto-approve -> post path as
+``test_bank_statement_auto_account_post.py`` and assert the ledger ends at the
+statement's closing balance, not its net flow.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from sqlalchemy import select
+
+from src.extraction.extension.service import ExtractionService
+from src.extraction.extension.statement_posting import try_auto_approve_high_confidence_statement
+from src.extraction.orm.statement_enums import BankStatementStatus
+from src.ledger import Account, JournalEntry, JournalEntryStatus, JournalLine
+
+
+def _drawdown_statement_payload() -> dict:
+    """A validated statement whose net flow is negative (the QA failure shape)."""
+    return {
+        "institution": "GXS",
+        "account_last4": "7174",
+        "currency": "SGD",
+        "period_start": "2026-06-01",
+        "period_end": "2026-06-30",
+        "opening_balance": "51730.82",
+        "closing_balance": "2953.14",
+        "transactions": [
+            {
+                "date": "2026-06-05",
+                "description": "Transfer out",
+                "amount": "48800.00",
+                "direction": "OUT",
+                "currency": "SGD",
+                "balance_after": "2930.82",
+            },
+            {
+                "date": "2026-06-30",
+                "description": "Interest",
+                "amount": "22.32",
+                "direction": "IN",
+                "currency": "SGD",
+                "balance_after": "2953.14",
+            },
+        ],
+    }
+
+
+def _followup_month_payload() -> dict:
+    return {
+        "institution": "GXS",
+        "account_last4": "7174",
+        "currency": "SGD",
+        "period_start": "2026-07-01",
+        "period_end": "2026-07-31",
+        "opening_balance": "2953.14",
+        "closing_balance": "3053.14",
+        "transactions": [
+            {
+                "date": "2026-07-15",
+                "description": "Deposit",
+                "amount": "100.00",
+                "direction": "IN",
+                "currency": "SGD",
+                "balance_after": "3053.14",
+            },
+        ],
+    }
+
+
+async def _parse_and_auto_post(db, test_user, payload: dict, file_hash: str):
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(return_value=payload)
+    statement, _txns = await service.parse_document(
+        file_path=Path(f"{file_hash}.pdf"),
+        institution=payload["institution"],
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash=file_hash,
+        db=db,
+    )
+    await db.flush()
+    assert statement.status == BankStatementStatus.APPROVED
+    posted = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+    assert posted >= 1
+    return statement
+
+
+async def _account_ledger_balance(db, account_id) -> Decimal:
+    lines = (
+        (
+            await db.execute(
+                select(JournalLine)
+                .join(JournalEntry, JournalLine.journal_entry_id == JournalEntry.id)
+                .where(JournalLine.account_id == account_id)
+                .where(JournalEntry.status.in_([JournalEntryStatus.POSTED, JournalEntryStatus.RECONCILED]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    balance = Decimal("0")
+    for line in lines:
+        if line.direction.value == "DEBIT":
+            balance += line.amount
+        else:
+            balance -= line.amount
+    return balance
+
+
+async def _opening_equity_line_count(db, user_id) -> int:
+    equity = (
+        await db.execute(
+            select(Account).where(
+                Account.user_id == user_id,
+                Account.is_system.is_(True),
+                Account.code == "3199",
+            )
+        )
+    ).scalar_one_or_none()
+    if equity is None:
+        return 0
+    lines = (await db.execute(select(JournalLine).where(JournalLine.account_id == equity.id))).scalars().all()
+    return len(lines)
+
+
+async def test_AC_extraction_1833_1_auto_approve_posts_validated_opening_balance(db, test_user):
+    """AC-extraction.1833.1: after auto-approve, the asset account's ledger
+    balance equals the statement's closing balance (opening balance posted
+    against the system Opening Balance Equity account), not the period net flow."""
+    statement = await _parse_and_auto_post(db, test_user, _drawdown_statement_payload(), "ac-1833-1")
+
+    assert statement.account_id is not None
+    balance = await _account_ledger_balance(db, statement.account_id)
+    assert balance == Decimal("2953.14"), (
+        f"asset ledger balance is {balance} — the period net flow — instead of the "
+        "statement closing balance; the validated opening balance was not posted"
+    )
+    assert await _opening_equity_line_count(db, test_user.id) == 1
+
+
+async def test_AC_extraction_1833_2_second_import_does_not_duplicate_opening_balance(db, test_user):
+    """AC-extraction.1833.2: a follow-up month import for the same account posts
+    its transactions but never a second opening-balance entry (the account
+    already has prior posted activity)."""
+    first = await _parse_and_auto_post(db, test_user, _drawdown_statement_payload(), "ac-1833-2a")
+    second = await _parse_and_auto_post(db, test_user, _followup_month_payload(), "ac-1833-2b")
+
+    assert second.account_id == first.account_id
+    assert await _opening_equity_line_count(db, test_user.id) == 1
+
+    balance = await _account_ledger_balance(db, first.account_id)
+    assert balance == Decimal("3053.14")
+
+
+async def test_AC_extraction_1833_1_zero_or_absent_opening_balance_posts_no_opening_entry(db, test_user):
+    """A statement with no starting position still auto-posts its transactions
+    and creates no opening-balance entry (nothing to establish)."""
+    payload = _drawdown_statement_payload()
+    payload["opening_balance"] = "0.00"
+    payload["closing_balance"] = "-48777.68"
+    # keep the chain internally consistent so validation still passes
+    payload["transactions"][0]["balance_after"] = "-48800.00"
+    payload["transactions"][1]["balance_after"] = "-48777.68"
+
+    statement = await _parse_and_auto_post(db, test_user, payload, "ac-1833-3")
+
+    assert await _opening_equity_line_count(db, test_user.id) == 0
+    balance = await _account_ledger_balance(db, statement.account_id)
+    assert balance == Decimal("-48777.68")

--- a/apps/backend/tests/integration/test_statement_opening_balance_auto_post.py
+++ b/apps/backend/tests/integration/test_statement_opening_balance_auto_post.py
@@ -20,7 +20,10 @@ from unittest.mock import AsyncMock
 from sqlalchemy import select
 
 from src.extraction.extension.service import ExtractionService
-from src.extraction.extension.statement_posting import try_auto_approve_high_confidence_statement
+from src.extraction.extension.statement_posting import (
+    try_auto_approve_high_confidence_statement,
+    try_auto_post_statement_opening_balance,
+)
 from src.extraction.orm.statement_enums import BankStatementStatus
 from src.ledger import Account, JournalEntry, JournalEntryStatus, JournalLine
 
@@ -178,3 +181,75 @@ async def test_AC_extraction_1833_1_zero_or_absent_opening_balance_posts_no_open
     assert await _opening_equity_line_count(db, test_user.id) == 0
     balance = await _account_ledger_balance(db, statement.account_id)
     assert balance == Decimal("-48777.68")
+
+
+async def test_AC_extraction_1833_3_zero_created_count_still_posts_opening_balance(db, test_user, monkeypatch):
+    """AC-extraction.1833.3 (PR #1842 review): created_count == 0 must not block
+    the opening-balance post.
+
+    created_count reaching 0 for a HIGH-CONFIDENCE, balance-validated statement is
+    realistic — e.g. every transaction in the period turns out to be an internal
+    transfer excluded via the reconciliation transfer-exclusions provider, or the
+    statement is re-processed after its transactions were already posted. (A
+    literally-empty extracted payload, by contrast, cannot reach this path: the
+    confidence-scoring formula's txn-count/balance-progression components need
+    >=1 transaction, so a genuinely empty statement scores below the 85
+    auto-approve threshold and never reaches this function — verified empirically
+    while writing this test.) This test isolates the orchestration contract
+    directly: given created_count == 0 for any reason, the opening balance must
+    still be posted.
+    """
+    from src.extraction.extension import statement_posting as statement_posting_module
+
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(return_value=_drawdown_statement_payload())
+    statement, _txns = await service.parse_document(
+        file_path=Path("ac-1833-4.pdf"),
+        institution="GXS",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="ac-1833-4",
+        db=db,
+    )
+    await db.flush()
+    assert statement.status == BankStatementStatus.APPROVED
+
+    # Force created_count == 0 as if every transaction were excluded (internal
+    # transfer match, or already posted by a prior call) — the scenario the
+    # created_count gate could not distinguish from "genuinely nothing to post".
+    monkeypatch.setattr(statement_posting_module, "auto_create_posted_entries_for_statement", AsyncMock(return_value=0))
+
+    posted = await try_auto_approve_high_confidence_statement(db, statement.id, test_user.id)
+    assert posted == 0
+
+    assert await _opening_equity_line_count(db, test_user.id) == 1
+    balance = await _account_ledger_balance(db, statement.account_id)
+    assert balance == Decimal("51730.82")  # opening balance posted; no transactions posted
+
+
+async def test_same_period_start_second_import_does_not_duplicate_opening_balance(db, test_user):
+    """Hardening beyond PR #1842's review: two statements sharing the exact same
+    period_start (so post_opening_balance_entry's date-ordering guard alone would
+    not catch a re-attempt) must still only post the opening balance once —
+    enforced by the per-account _account_has_opening_balance_entry check."""
+    first = await _parse_and_auto_post(db, test_user, _drawdown_statement_payload(), "ac-1833-5a")
+
+    # Same account (same institution/last4/currency), same period_start as `first`.
+    duplicate_period_payload = _drawdown_statement_payload()
+    duplicate_period_payload["opening_balance"] = "51730.82"
+    service = ExtractionService()
+    service.extract_financial_data = AsyncMock(return_value=duplicate_period_payload)
+    statement, _txns = await service.parse_document(
+        file_path=Path("ac-1833-5b.pdf"),
+        institution="GXS",
+        user_id=test_user.id,
+        file_content=b"%PDF-1.7",
+        file_hash="ac-1833-5b",
+        account_id=first.account_id,
+        db=db,
+    )
+    await db.flush()
+
+    await try_auto_post_statement_opening_balance(db, statement, test_user.id)
+
+    assert await _opening_equity_line_count(db, test_user.id) == 1

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3690,5 +3690,27 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        ACRecord(
+            id="AC-extraction.1833.3",
+            statement=(
+                "The opening-balance post is never gated on created_count: a "
+                "high-confidence, balance-validated statement whose "
+                "transactions are all excluded from posting (internal-transfer "
+                "matches, or already posted by a prior call) still gets its "
+                "opening balance posted. Idempotency against re-posting is "
+                "enforced per-account (does this account already have an "
+                "opening-balance-equity line), not by created_count or by "
+                "date-ordering alone — covering two statements that share the "
+                "same period_start, where date-ordering alone would not catch "
+                "a re-attempt."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_statement_opening_balance_auto_post.py"
+                "::test_AC_extraction_1833_3_zero_created_count_still_posts_opening_balance"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
     ],
 )

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3650,5 +3650,45 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group 1833: auto-approve posts the chain-validated opening
+        # balance so the balance sheet shows balances, not net flow (#1833) ──
+        ACRecord(
+            id="AC-extraction.1833.1",
+            statement=(
+                "When a high-confidence statement auto-approves (its "
+                "running-balance chain reconciled), the extracted opening "
+                "balance is posted as a guided opening-balance entry against "
+                "the system Opening Balance Equity account, so the asset "
+                "account's ledger balance equals the statement's closing "
+                "balance — never the period net flow. A zero/absent opening "
+                "balance posts no opening entry; non-base currencies and "
+                "other post_opening_balance_entry rejections skip fail-soft "
+                "without disturbing the posted transactions."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_statement_opening_balance_auto_post.py"
+                "::test_AC_extraction_1833_1_auto_approve_posts_validated_opening_balance"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.1833.2",
+            statement=(
+                "A follow-up period import for the same account posts its "
+                "transactions but never a second opening-balance entry: "
+                "prior posted activity before the new period start makes "
+                "the guided opening post reject, and that rejection is "
+                "absorbed fail-soft."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_statement_opening_balance_auto_post.py"
+                "::test_AC_extraction_1833_2_second_import_does_not_duplicate_opening_balance"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
     ],
 )


### PR DESCRIPTION
## What

`try_auto_approve_high_confidence_statement` now posts the statement's opening balance
(via the existing guided opening-balance machinery, `post_opening_balance_entry` /
system Opening Balance Equity account 3199) in the same auto-approval flow that already
posts the period transactions.

## Why

Staging real-statement QA (2026-07-14) against operator statements found a wrong
headline on the fully-automated happy path: two bank statements auto-approved exactly
as designed (confidence 100, `balance_validated: true` — the running-balance chain
verified correct against the source PDFs), yet the balance sheet showed a **negative
total assets** afterwards. Root cause: auto-approve posts only the period transactions,
so an imported account's ledger balance was the *period net flow* (e.g. -48,777.68 for
a month with a large one-off transfer out), never the *closing balance* the extraction
had already verified.

## Fix

`try_auto_post_statement_opening_balance` posts the opening balance in its own
savepoint, fail-soft:
- zero/absent opening balance → no opening entry (nothing to establish)
- non-base-currency statements → `post_opening_balance_entry`'s existing currency guard skips it
- follow-up-month imports (account already has prior posted activity) →
  the existing "must precede all activity" guard skips it, so no duplicate opening entry

None of these skips disturb the already-posted transactions.

## ACs

- `AC-extraction.1833.1` — auto-approve posts the validated opening balance; ledger balance
  ends at the statement's closing balance, not the net flow.
- `AC-extraction.1833.2` — a follow-up period import never double-posts the opening balance.

Both added to `common/extraction/contract.py`'s roadmap.

## Why no gate caught it

Staging E2E asserts dashboard/report values against a seeded fixture journey whose
accounts start at zero balance — where net-flow and closing-balance are numerically
identical, so this class of bug is invisible to it. The new tests use a nonzero opening
balance specifically to make the two diverge.

## Test plan

- [x] `tests/integration/test_statement_opening_balance_auto_post.py` (3 new tests, red→green)
- [x] `tests/extraction` full suite: 548 passed
- [x] `tests/ledger` full suite: 150 passed
- [x] `tests/integration` full suite: 10 passed
- [x] `tools/generate_ac_registry.py` — registries regenerated, no drift

**preflight skipped: backend-format false-red** — this machine's `PATH` `ruff` is 0.15.17;
CI/preflight pin `apps/backend/.venv/bin/ruff` at 0.14.11. Verified clean with the pinned
binary directly (`ruff check` + `ruff format --check` both pass on `src tests`); the 65
errors surfaced only under the unpinned PATH ruff.

## Related

Found alongside #1832 (paginated vision extraction) and #1834 (Prefect config drift) in
the same 2026-07-14 staging QA round. Zombie-account cleanup on reject (also surfaced in
that round) is tracked separately, not in this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)