### PR TITLE
[finance_report_vision] fix(#1832): paginated full-document vision extraction — no silent page truncation

### DIFF
--- a/apps/backend/src/extraction/base/paged_extraction.py
+++ b/apps/backend/src/extraction/base/paged_extraction.py
@@ -1,0 +1,115 @@
+"""Pure paged-extraction helpers: part prompts and multi-part payload merge (#1832).
+
+Vision extraction renders PDF pages to images. Provider request limits bound how
+many page images fit in one call, so documents longer than one batch are
+extracted through several calls — one per page batch — and merged here. Silent
+truncation (the pre-#1832 behavior: drop every page past the cap) is never
+acceptable: it guarantees a running-balance-chain failure for any statement
+longer than the cap and quarantines a perfectly good document.
+
+This module is pure (no I/O, no model calls) so the merge semantics are
+unit-testable in isolation:
+
+- scalar metadata (institution, period, currency, ...): first non-empty part wins;
+- ``opening_balance``: first non-empty part wins (statement header lives on page 1);
+- ``closing_balance``: LAST non-empty part wins (the statement-level closing
+  balance lives on the final transaction page; earlier parts are instructed to
+  emit null rather than page carried-forward balances, this is the second line
+  of defense);
+- ``transactions`` / ``positions``: concatenated in part (= page) order.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_LIST_FIELDS = ("transactions", "positions")
+_LAST_WINS_FIELDS = ("closing_balance",)
+
+
+def _is_empty(value: Any) -> bool:
+    return value is None or value == "" or value == []
+
+
+def build_paged_prompt(
+    base_prompt: str,
+    *,
+    part_index: int,
+    part_count: int,
+    page_start: int,
+    page_end: int,
+    total_pages: int,
+    has_context_page: bool = False,
+) -> str:
+    """Append the multi-part extraction rules to the base parsing prompt.
+
+    ``part_index`` is 1-based. The rules keep each part honest about what it can
+    see: transactions only from its own pages, statement-level balances only when
+    explicitly stated as such (page carried-forward subtotals must not be
+    reported as the statement closing balance).
+
+    ``has_context_page``: non-first parts carry the document's FIRST page as a
+    leading context image — scanned statements and some brokers do not repeat
+    table headers on continuation pages, so without it a part cannot tell which
+    column is withdrawal vs deposit or which currency applies. The context page
+    is for reading headers/metadata only; its transactions belong to part 1 and
+    re-extracting them here would double-count (the dedup-conservation and
+    balance-chain gates fail closed on that, but the instruction keeps the happy
+    path happy).
+    """
+    if part_count <= 1:
+        return base_prompt
+    context_rule = (
+        "- The FIRST image is page 1 of the document, included ONLY as context for "
+        "table headers, column meanings, account metadata, and currency. Do NOT "
+        "extract transactions from this context page — extract transactions "
+        f"exclusively from the pages {page_start}-{page_end} images that follow it.\n"
+        if has_context_page
+        else ""
+    )
+    return (
+        f"{base_prompt}\n\n"
+        f"IMPORTANT — PARTIAL DOCUMENT ({part_index}/{part_count}): this request contains "
+        f"only pages {page_start}-{page_end} of a {total_pages}-page statement.\n"
+        f"{context_rule}"
+        "- Extract EVERY transaction visible on these pages, in order.\n"
+        "- opening_balance: report it only if the statement-level opening balance is "
+        "explicitly stated on these pages; otherwise use null.\n"
+        "- closing_balance: report it only if the statement-level closing/ending balance "
+        "is explicitly stated on these pages; page subtotals or balance-carried-forward "
+        "lines are NOT the closing balance — use null for those.\n"
+        "- Other metadata (institution, account digits, period, currency): report what is "
+        "visible on these pages, otherwise use null.\n"
+        "- Do not invent transactions from pages you cannot see."
+    )
+
+
+def merge_paged_extractions(parts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge per-batch extraction payloads into one whole-document payload."""
+    dict_parts = [part for part in parts if isinstance(part, dict)]
+    if not dict_parts:
+        raise ValueError("merge_paged_extractions needs at least one dict payload")
+    if len(dict_parts) == 1:
+        return dict_parts[0]
+
+    merged: dict[str, Any] = dict(dict_parts[0])
+
+    # Scalar metadata: first non-empty part wins.
+    for part in dict_parts[1:]:
+        for key, value in part.items():
+            if key in _LIST_FIELDS or key in _LAST_WINS_FIELDS:
+                continue
+            if _is_empty(merged.get(key)) and not _is_empty(value):
+                merged[key] = value
+
+    # closing_balance: the last part that saw a statement-level closing balance wins.
+    for part in dict_parts:
+        if not _is_empty(part.get("closing_balance")):
+            merged["closing_balance"] = part["closing_balance"]
+
+    # Ordered concatenation for row lists (pages arrive in document order).
+    for key in _LIST_FIELDS:
+        if any(key in part for part in dict_parts):
+            merged[key] = [row for part in dict_parts for row in (part.get(key) or [])]
+
+    return merged

--- a/apps/backend/src/extraction/base/paged_extraction.py
+++ b/apps/backend/src/extraction/base/paged_extraction.py
@@ -59,18 +59,27 @@ def build_paged_prompt(
     """
     if part_count <= 1:
         return base_prompt
-    context_rule = (
-        "- The FIRST image is page 1 of the document, included ONLY as context for "
-        "table headers, column meanings, account metadata, and currency. Do NOT "
-        "extract transactions from this context page — extract transactions "
-        f"exclusively from the pages {page_start}-{page_end} images that follow it.\n"
-        if has_context_page
-        else ""
-    )
+    if has_context_page:
+        header = (
+            f"IMPORTANT — PARTIAL DOCUMENT ({part_index}/{part_count}): the FIRST image below is "
+            f"page 1 of the document, included only as context; the remaining images are pages "
+            f"{page_start}-{page_end} of a {total_pages}-page statement.\n"
+        )
+        context_rule = (
+            "- The FIRST image is page 1 of the document, included ONLY as context for "
+            "table headers, column meanings, account metadata, and currency. Do NOT "
+            "extract transactions from this context page — extract transactions "
+            f"exclusively from the pages {page_start}-{page_end} images that follow it.\n"
+        )
+    else:
+        header = (
+            f"IMPORTANT — PARTIAL DOCUMENT ({part_index}/{part_count}): this request contains "
+            f"only pages {page_start}-{page_end} of a {total_pages}-page statement.\n"
+        )
+        context_rule = ""
     return (
         f"{base_prompt}\n\n"
-        f"IMPORTANT — PARTIAL DOCUMENT ({part_index}/{part_count}): this request contains "
-        f"only pages {page_start}-{page_end} of a {total_pages}-page statement.\n"
+        f"{header}"
         f"{context_rule}"
         "- Extract EVERY transaction visible on these pages, in order.\n"
         "- opening_balance: report it only if the statement-level opening balance is "

--- a/apps/backend/src/extraction/extension/_llm_led_gate.py
+++ b/apps/backend/src/extraction/extension/_llm_led_gate.py
@@ -59,12 +59,14 @@ QUARANTINE_MESSAGE: dict[LlmLedQuarantineReason, str] = {
     LlmLedQuarantineReason.BALANCE_CHAIN_UNRECONCILED: (
         "Extraction blocked: the running-balance chain does not reconcile "
         "(opening + inflows - outflows != closing). The parsed figures are internally "
-        "inconsistent and cannot be trusted; re-upload a clearer source."
+        "inconsistent, so the statement was not imported. Retry parsing; if it "
+        "still fails, this document layout is not fully supported yet."
     ),
     LlmLedQuarantineReason.DEDUP_CONSERVATION_VIOLATION: (
         "Extraction blocked: within-document dedup conservation failed (two distinct rows "
-        "collapsed into one). The transaction set is incomplete and cannot be trusted; "
-        "re-upload a clearer source."
+        "collapsed into one). The transaction set is incomplete, so the statement was "
+        "not imported. Retry parsing; if it still fails, this document layout is "
+        "not fully supported yet."
     ),
     LlmLedQuarantineReason.BALANCE_INVARIANT_UNEVALUABLE: (
         "Extraction blocked: the balance invariant could not be evaluated because an "

--- a/apps/backend/src/extraction/extension/_media.py
+++ b/apps/backend/src/extraction/extension/_media.py
@@ -57,8 +57,16 @@ class _MediaMixin:
             "image_url": {"url": data},
         }
 
-    def _render_pdf_pages_as_image_payloads(self, file_content: bytes) -> list[dict[str, Any]]:
-        """Render a bounded number of PDF pages to in-memory image_url payloads."""
+    def _render_pdf_pages_as_image_payload_batches(self, file_content: bytes) -> list[list[dict[str, Any]]]:
+        """Render EVERY PDF page to image_url payloads, grouped into per-call batches (#1832).
+
+        Pre-#1832 this rendered only the first ``PDF_VISION_MAX_PAGES`` pages and
+        silently dropped the rest — which made the running-balance chain
+        mathematically guaranteed to fail for any statement longer than the cap
+        and quarantined perfectly good documents. Now the cap is the per-request
+        batch size; documents above ``PDF_VISION_MAX_TOTAL_PAGES`` fail with an
+        explicit, honest error instead of truncating.
+        """
         try:
             import fitz  # type: ignore[import-untyped]
         except ImportError as e:  # pragma: no cover - dependency is installed in packaged runtime
@@ -73,9 +81,15 @@ class _MediaMixin:
             raise ExtractionError("PDF vision fallback could not open PDF content") from e
 
         try:
-            page_count = min(len(document), self.PDF_VISION_MAX_PAGES)
+            page_count = len(document)
             if page_count <= 0:
                 raise ExtractionError("PDF vision fallback could not render an empty PDF")
+            if page_count > self.PDF_VISION_MAX_TOTAL_PAGES:
+                raise ExtractionError(
+                    f"PDF has {page_count} pages, above the "
+                    f"{self.PDF_VISION_MAX_TOTAL_PAGES}-page vision-extraction limit. "
+                    "Split the document into smaller parts and upload them separately."
+                )
 
             matrix = fitz.Matrix(self.PDF_VISION_RENDER_SCALE, self.PDF_VISION_RENDER_SCALE)
             payloads: list[dict[str, Any]] = []
@@ -94,27 +108,34 @@ class _MediaMixin:
                     }
                 )
 
+            batch_size = self.PDF_VISION_MAX_PAGES
+            batches = [payloads[i : i + batch_size] for i in range(0, len(payloads), batch_size)]
             logger.info(
                 "Rendered PDF pages for vision fallback",
                 rendered_pages=page_count,
-                max_pages=self.PDF_VISION_MAX_PAGES,
+                pages_per_call=batch_size,
+                batch_count=len(batches),
                 total_image_bytes=total_bytes,
             )
-            return payloads
+            return batches
         finally:
             document.close()
 
-    def _build_vision_media_payloads(
+    def _build_vision_media_payload_batches(
         self,
         file_content: bytes | None,
         file_url: str | None,
         file_type: str,
         mime_type: str,
-    ) -> list[dict[str, Any]]:
-        """Build vision-model media payloads, rendering Z.AI PDFs to images when possible."""
+    ) -> list[list[dict[str, Any]]]:
+        """Build per-call vision media payload batches, rendering Z.AI PDFs to images when possible.
+
+        Returns one batch per model call: multi-page PDFs produce several batches
+        (all pages covered); every other input shape stays a single batch.
+        """
         if file_type == "pdf" and self._is_zai_provider() and file_content:
             try:
-                return self._render_pdf_pages_as_image_payloads(file_content)
+                return self._render_pdf_pages_as_image_payload_batches(file_content)
             except ExtractionError as render_error:
                 if file_url and self._validate_external_url(file_url):
                     logger.warning(
@@ -135,7 +156,7 @@ class _MediaMixin:
         )
         if prefer_url and not file_input.startswith(("http://", "https://")):
             raise ExtractionError("Z.AI PDF vision fallback requires file content or an external PDF URL")
-        return [self._build_media_payload(file_type=file_type, mime_type=mime_type, data=file_input)]
+        return [[self._build_media_payload(file_type=file_type, mime_type=mime_type, data=file_input)]]
 
     def _validate_external_url(self, url: str) -> bool:
         """Validate if a URL is accessible by external AI services.

--- a/apps/backend/src/extraction/extension/service.py
+++ b/apps/backend/src/extraction/extension/service.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 
 import src.config
 from src.audit.money.currency import normalize_currency_code
+from src.extraction.base.paged_extraction import build_paged_prompt, merge_paged_extractions
 from src.extraction.base.validation import (
     bank_currency_balances,
     compute_confidence_score,
@@ -78,7 +79,11 @@ def _institution_class(*, is_brokerage: bool) -> str:
 class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _CsvMixin):
     """Service for extracting structured data from financial documents."""
 
+    # Pages per vision request (provider payload bound), NOT a document cap: longer
+    # PDFs are extracted in several calls and merged (#1832). The total cap is the
+    # honest ceiling — exceeding it errors explicitly instead of truncating.
     PDF_VISION_MAX_PAGES = 5
+    PDF_VISION_MAX_TOTAL_PAGES = 30
     PDF_VISION_RENDER_SCALE = 1.6
 
     def __init__(self) -> None:
@@ -1113,24 +1118,15 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             )
         prompt = get_parsing_prompt(institution, document_kind=document_kind)
         if force_model:
-            media_payloads = await asyncio.to_thread(
-                self._build_vision_media_payloads,
+            media_batches = await asyncio.to_thread(
+                self._build_vision_media_payload_batches,
                 file_content,
                 file_url,
                 file_type,
                 mime_type,
             )
-            messages = [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": prompt},
-                        *media_payloads,
-                    ],
-                }
-            ]
-            return await self._extract_json_with_models(
-                messages=messages,
+            return await self._extract_json_from_media_batches(
+                media_batches=media_batches,
                 models=[force_model],
                 prompt=prompt,
                 institution=institution,
@@ -1181,24 +1177,15 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         if not vision_models:
             raise ExtractionError("Extraction failed after all retries")
 
-        media_payloads = await asyncio.to_thread(
-            self._build_vision_media_payloads,
+        media_batches = await asyncio.to_thread(
+            self._build_vision_media_payload_batches,
             file_content,
             file_url,
             file_type,
             mime_type,
         )
-        vision_messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prompt},
-                    *media_payloads,
-                ],
-            }
-        ]
-        return await self._extract_json_with_models(
-            messages=vision_messages,
+        return await self._extract_json_from_media_batches(
+            media_batches=media_batches,
             models=vision_models,
             prompt=prompt,
             institution=institution,
@@ -1209,3 +1196,100 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
             seed_override=seed_override,
             user_id=user_id,
         )
+
+    async def _extract_json_from_media_batches(
+        self,
+        *,
+        media_batches: list[list[dict[str, Any]]],
+        models: list[str],
+        prompt: str,
+        institution: str | None,
+        file_type: str,
+        return_raw: bool,
+        has_content: bool,
+        has_url: bool,
+        seed_override: int | None,
+        user_id: UUID | None,
+    ) -> dict[str, Any]:
+        """Run one model call per media batch and merge the payloads (#1832).
+
+        Single-batch documents keep the exact pre-#1832 call shape (including
+        ``return_raw`` passthrough). Multi-batch documents get a per-part prompt
+        (transactions from own pages only; statement-level balances only when
+        explicitly stated), concurrent part calls, and a pure merge; ``return_raw``
+        is not meaningful across parts and is ignored there.
+        """
+
+        def _messages(part_prompt: str, media: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            return [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": part_prompt},
+                        *media,
+                    ],
+                }
+            ]
+
+        if len(media_batches) == 1:
+            return await self._extract_json_with_models(
+                messages=_messages(prompt, media_batches[0]),
+                models=models,
+                prompt=prompt,
+                institution=institution,
+                file_type=file_type,
+                return_raw=return_raw,
+                has_content=has_content,
+                has_url=has_url,
+                seed_override=seed_override,
+                user_id=user_id,
+            )
+
+        part_count = len(media_batches)
+        pages_per_call = self.PDF_VISION_MAX_PAGES
+        total_pages = sum(len(media) for media in media_batches)
+
+        # Non-first parts carry page 1 as a leading context image: scanned
+        # statements and some brokers do not repeat table headers on
+        # continuation pages, so a bare batch cannot tell which column is
+        # withdrawal vs deposit or which currency applies (#1832).
+        context_page = media_batches[0][0]
+
+        async def _extract_part(part_index: int, media: list[dict[str, Any]]) -> dict[str, Any]:
+            page_start = (part_index - 1) * pages_per_call + 1
+            page_end = page_start + len(media) - 1
+            has_context_page = part_index > 1
+            part_prompt = build_paged_prompt(
+                prompt,
+                part_index=part_index,
+                part_count=part_count,
+                page_start=page_start,
+                page_end=page_end,
+                total_pages=total_pages,
+                has_context_page=has_context_page,
+            )
+            part_media = [context_page, *media] if has_context_page else media
+            return await self._extract_json_with_models(
+                messages=_messages(part_prompt, part_media),
+                models=models,
+                prompt=part_prompt,
+                institution=institution,
+                file_type=file_type,
+                return_raw=False,
+                has_content=has_content,
+                has_url=has_url,
+                seed_override=seed_override,
+                user_id=user_id,
+            )
+
+        parts = await asyncio.gather(
+            *(_extract_part(index, media) for index, media in enumerate(media_batches, start=1))
+        )
+        merged = merge_paged_extractions(list(parts))
+        logger.info(
+            "Merged paged vision extraction",
+            part_count=part_count,
+            transactions=len(merged.get("transactions") or []),
+            positions=len(merged.get("positions") or []),
+        )
+        return merged

--- a/apps/backend/tests/extraction/test_extraction.py
+++ b/apps/backend/tests/extraction/test_extraction.py
@@ -343,11 +343,12 @@ class TestMediaPayloadBuilder:
         pdf.drawString(72, 720, "DBS statement fixture")
         pdf.save()
 
-        payloads = self.service._render_pdf_pages_as_image_payloads(buffer.getvalue())
+        batches = self.service._render_pdf_pages_as_image_payload_batches(buffer.getvalue())
 
-        assert len(payloads) == 1
-        assert payloads[0]["type"] == "image_url"
-        assert payloads[0]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+        assert batches[0][0]["type"] == "image_url"
+        assert batches[0][0]["image_url"]["url"].startswith("data:image/png;base64,")
 
     def test_prefer_url_rejects_private_urls_without_falling_back(self):
         """AC-extraction.105.1: Z.AI PDF URL fallback must not accept private object URLs."""

--- a/apps/backend/tests/extraction/test_extraction_cassette_replay.py
+++ b/apps/backend/tests/extraction/test_extraction_cassette_replay.py
@@ -218,8 +218,8 @@ def _stub_env_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     role/messages/decode_params, never on which provider was resolved, so this does
     not affect what gets replayed.
 
-    A non-"zai" ``ai_provider`` also steers ``_build_vision_media_payloads`` away
-    from ``_render_pdf_pages_as_image_payloads`` (PyMuPDF rasterizes the PDF to a
+    A non-"zai" ``ai_provider`` also steers ``_build_vision_media_payload_batches`` away
+    from ``_render_pdf_pages_as_image_payload_batches`` (PyMuPDF rasterizes the PDF to a
     PNG — the exact pixels are not guaranteed byte-identical across host platforms,
     which produced a CI-only cassette MISS despite a passing local run) and onto the
     raw-base64-PDF-bytes ``file`` payload branch instead, which is a pure function of

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -241,7 +241,7 @@ async def test_extract_financial_data_shared_ocr_vision_skips_layout_parser():
         "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
     }
 
-    with patch.object(service, "_build_vision_media_payloads", return_value=[image_payload]):
+    with patch.object(service, "_build_vision_media_payload_batches", return_value=[[image_payload]]):
         result = await service.extract_financial_data(b"content", "DBS", "pdf")
 
     assert result == {"transactions": []}
@@ -284,7 +284,7 @@ async def test_vision_path_falls_back_to_secondary_model_on_non_retryable_error(
     }
 
     with (
-        patch.object(service, "_build_vision_media_payloads", return_value=[image_payload]),
+        patch.object(service, "_build_vision_media_payload_batches", return_value=[[image_payload]]),
         patch("src.extraction.extension.service.stream_ai_json", side_effect=fake_stream_ai_json),
         patch("src.extraction.extension.service.accumulate_stream", side_effect=fake_accumulate_stream),
     ):
@@ -348,10 +348,10 @@ def test_render_pdf_pages_rejects_empty_content():
     service = ExtractionService()
 
     with pytest.raises(ExtractionError, match="requires file content"):
-        service._render_pdf_pages_as_image_payloads(b"")
+        service._render_pdf_pages_as_image_payload_batches(b"")
 
 
-def test_build_vision_media_payloads_rejects_non_url_pdf_input(monkeypatch):
+def test_build_vision_media_payload_batches_rejects_non_url_pdf_input(monkeypatch):
     """AC-extraction.812.6: Z.AI PDF vision payloads require rendered content or an external URL."""
     from src.config import settings
 
@@ -360,7 +360,7 @@ def test_build_vision_media_payloads_rejects_non_url_pdf_input(monkeypatch):
 
     with patch.object(service, "_build_ai_file_input", return_value="data:application/pdf;base64,abc"):
         with pytest.raises(ExtractionError, match="requires file content or an external PDF URL"):
-            service._build_vision_media_payloads(
+            service._build_vision_media_payload_batches(
                 file_content=None,
                 file_url="https://example.com/statement.pdf",
                 file_type="pdf",
@@ -368,7 +368,7 @@ def test_build_vision_media_payloads_rejects_non_url_pdf_input(monkeypatch):
             )
 
 
-def test_build_vision_media_payloads_gemini_sends_native_pdf_not_rendered_images(monkeypatch):
+def test_build_vision_media_payload_batches_gemini_sends_native_pdf_not_rendered_images(monkeypatch):
     """Gemini extracts the whole PDF natively: a PDF with file content yields a single
     `file` payload (base64 PDF), NOT per-page rendered `image_url` images. This is what
     lets Gemini handle large/scanned statements the z.ai image-render path truncates."""
@@ -380,22 +380,23 @@ def test_build_vision_media_payloads_gemini_sends_native_pdf_not_rendered_images
     # If this path ever tried to render images for Gemini, the test would catch it.
     with patch.object(
         service,
-        "_render_pdf_pages_as_image_payloads",
+        "_render_pdf_pages_as_image_payload_batches",
         side_effect=AssertionError("Gemini must not render PDF pages to images"),
     ):
-        payloads = service._build_vision_media_payloads(
+        batches = service._build_vision_media_payload_batches(
             file_content=b"%PDF-1.4 fake pdf bytes",
             file_url=None,
             file_type="pdf",
             mime_type="application/pdf",
         )
 
-    assert len(payloads) == 1
-    assert payloads[0]["type"] == "file"
-    assert payloads[0]["file"]["file_data"].startswith("data:application/pdf;base64,")
+    assert len(batches) == 1
+    assert len(batches[0]) == 1
+    assert batches[0][0]["type"] == "file"
+    assert batches[0][0]["file"]["file_data"].startswith("data:application/pdf;base64,")
 
 
-def test_build_vision_media_payloads_reraises_render_error_without_external_url(monkeypatch):
+def test_build_vision_media_payload_batches_reraises_render_error_without_external_url(monkeypatch):
     """AC-extraction.812.6: Render failures without a safe external URL do not silently continue."""
     from src.config import settings
 
@@ -404,11 +405,11 @@ def test_build_vision_media_payloads_reraises_render_error_without_external_url(
 
     with patch.object(
         service,
-        "_render_pdf_pages_as_image_payloads",
+        "_render_pdf_pages_as_image_payload_batches",
         side_effect=ExtractionError("render failed"),
     ):
         with pytest.raises(ExtractionError, match="render failed"):
-            service._build_vision_media_payloads(
+            service._build_vision_media_payload_batches(
                 file_content=b"pdf bytes",
                 file_url=None,
                 file_type="pdf",
@@ -506,7 +507,7 @@ async def test_extract_financial_data_dedicated_ocr_failure_falls_back_to_vision
         "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
     }
 
-    with patch.object(service, "_build_vision_media_payloads", return_value=[image_payload]):
+    with patch.object(service, "_build_vision_media_payload_batches", return_value=[[image_payload]]):
         result = await service.extract_financial_data(b"content", "DBS", "pdf")
 
     assert result == {"transactions": []}

--- a/apps/backend/tests/extraction/test_extraction_flow.py
+++ b/apps/backend/tests/extraction/test_extraction_flow.py
@@ -275,7 +275,9 @@ class TestExtractionServiceFlow:
         json_content = json.dumps({"success": True})
 
         with (
-            patch.object(service, "_render_pdf_pages_as_image_payloads", return_value=[image_payload]) as mock_render,
+            patch.object(
+                service, "_render_pdf_pages_as_image_payload_batches", return_value=[[image_payload]]
+            ) as mock_render,
             patch("src.extraction.extension.service.stream_ai_json") as mock_stream,
         ):
             mock_stream.return_value = mock_stream_generator(json_content)
@@ -298,7 +300,9 @@ class TestExtractionServiceFlow:
         json_content = json.dumps({"success": True})
 
         with (
-            patch.object(service, "_render_pdf_pages_as_image_payloads", return_value=[image_payload]) as mock_render,
+            patch.object(
+                service, "_render_pdf_pages_as_image_payload_batches", return_value=[[image_payload]]
+            ) as mock_render,
             patch("src.extraction.extension.service.stream_ai_json") as mock_stream,
         ):
             mock_stream.return_value = mock_stream_generator(json_content)
@@ -328,7 +332,9 @@ class TestExtractionServiceFlow:
         json_content = json.dumps({"success": True})
 
         with (
-            patch.object(service, "_render_pdf_pages_as_image_payloads", return_value=[image_payload]) as mock_render,
+            patch.object(
+                service, "_render_pdf_pages_as_image_payload_batches", return_value=[[image_payload]]
+            ) as mock_render,
             patch("src.extraction.extension.service.stream_ai_json") as mock_stream,
         ):
             mock_stream.return_value = mock_stream_generator(json_content)

--- a/apps/backend/tests/extraction/test_paged_vision_extraction.py
+++ b/apps/backend/tests/extraction/test_paged_vision_extraction.py
@@ -136,6 +136,11 @@ class TestPagedPrompt:
         )
         assert "ONLY as context" in with_context
         assert "Do NOT extract transactions from this context page" in with_context
+        # PR #1843 review: the header must not claim "only pages X-Y" when a
+        # leading context image is also included — that mismatch could confuse
+        # the model about the extra image it's seeing.
+        assert "only pages 6-10" not in with_context
+        assert "the FIRST image below is" in with_context
         without_context = build_paged_prompt(
             "BASE", part_index=1, part_count=3, page_start=1, page_end=5, total_pages=12
         )

--- a/apps/backend/tests/extraction/test_paged_vision_extraction.py
+++ b/apps/backend/tests/extraction/test_paged_vision_extraction.py
@@ -1,0 +1,211 @@
+"""AC-extraction.1832.1/.2/.3: paginated full-document vision extraction (#1832).
+
+Staging real-statement QA (2026-07-14): the vision path rendered only the first
+``PDF_VISION_MAX_PAGES`` pages and silently dropped the rest, which made the
+running-balance chain mathematically guaranteed to fail for any statement longer
+than the cap — a mainstream 7-page bank statement could never import. These
+tests pin the replacement behavior: every page is rendered, documents longer
+than one batch are extracted through one model call per batch and merged, and
+documents above the total-page ceiling fail with an explicit error instead of
+silent truncation.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.extraction.base.paged_extraction import build_paged_prompt, merge_paged_extractions
+from src.extraction.extension._base import ExtractionError
+from src.extraction.extension.service import ExtractionService
+
+
+def _pdf_with_pages(page_count: int) -> bytes:
+    from reportlab.pdfgen import canvas
+
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer)
+    for index in range(page_count):
+        pdf.drawString(72, 720, f"statement fixture page {index + 1}")
+        pdf.showPage()
+    pdf.save()
+    return buffer.getvalue()
+
+
+class TestRenderAllPagesInBatches:
+    def test_AC_extraction_1832_1_renders_every_page_batched_by_call_cap(self):
+        """AC-extraction.1832.1: a PDF longer than one batch renders ALL pages,
+        grouped into per-call batches of PDF_VISION_MAX_PAGES."""
+        service = ExtractionService()
+        page_count = service.PDF_VISION_MAX_PAGES * 2 + 2  # 12 pages for cap 5
+
+        batches = service._render_pdf_pages_as_image_payload_batches(_pdf_with_pages(page_count))
+
+        assert [len(batch) for batch in batches] == [5, 5, 2]
+        rendered = [payload for batch in batches for payload in batch]
+        assert len(rendered) == page_count
+        assert all(p["image_url"]["url"].startswith("data:image/png;base64,") for p in rendered)
+
+    def test_AC_extraction_1832_3_total_page_ceiling_is_an_explicit_error(self):
+        """AC-extraction.1832.3: exceeding PDF_VISION_MAX_TOTAL_PAGES raises an
+        honest, page-count-naming error — never silent truncation."""
+        service = ExtractionService()
+        oversize = service.PDF_VISION_MAX_TOTAL_PAGES + 1
+
+        with pytest.raises(ExtractionError, match=rf"{oversize} pages.*{service.PDF_VISION_MAX_TOTAL_PAGES}-page"):
+            service._render_pdf_pages_as_image_payload_batches(_pdf_with_pages(oversize))
+
+
+class TestMergePagedExtractions:
+    def test_AC_extraction_1832_2_merge_semantics(self):
+        """AC-extraction.1832.2: transactions concatenate in page order; scalar
+        metadata takes the first non-empty value; opening balance comes from the
+        first part that saw it, closing balance from the last."""
+        parts = [
+            {
+                "institution": "DBS",
+                "account_last4": "0355",
+                "currency": "SGD",
+                "period_start": "2025-06-01",
+                "period_end": "2025-06-30",
+                "opening_balance": "100.00",
+                "closing_balance": None,
+                "transactions": [{"description": "t1"}, {"description": "t2"}],
+            },
+            {
+                "institution": None,
+                "currency": "",
+                "opening_balance": None,
+                "closing_balance": None,
+                "transactions": [{"description": "t3"}],
+            },
+            {
+                "institution": "DBS Bank",
+                "opening_balance": "999.99",
+                "closing_balance": "175.00",
+                "transactions": [{"description": "t4"}],
+            },
+        ]
+
+        merged = merge_paged_extractions(parts)
+
+        assert merged["institution"] == "DBS"  # first non-empty, not overwritten
+        assert merged["account_last4"] == "0355"
+        assert merged["currency"] == "SGD"
+        assert merged["opening_balance"] == "100.00"  # first part wins
+        assert merged["closing_balance"] == "175.00"  # last non-empty wins
+        assert [t["description"] for t in merged["transactions"]] == ["t1", "t2", "t3", "t4"]
+
+    def test_merge_concatenates_brokerage_positions(self):
+        parts = [
+            {"positions": [{"symbol": "A"}], "transactions": []},
+            {"positions": [{"symbol": "B"}, {"symbol": "C"}], "transactions": []},
+        ]
+        merged = merge_paged_extractions(parts)
+        assert [p["symbol"] for p in merged["positions"]] == ["A", "B", "C"]
+
+    def test_merge_single_part_is_identity(self):
+        part = {"institution": "GXS", "transactions": [{"description": "t1"}]}
+        assert merge_paged_extractions([part]) is part
+
+    def test_merge_rejects_empty_input(self):
+        with pytest.raises(ValueError):
+            merge_paged_extractions([])
+
+
+class TestPagedPrompt:
+    def test_single_part_prompt_is_unchanged(self):
+        assert build_paged_prompt("BASE", part_index=1, part_count=1, page_start=1, page_end=5, total_pages=5) == "BASE"
+
+    def test_multi_part_prompt_names_pages_and_forbids_page_subtotals(self):
+        prompt = build_paged_prompt("BASE", part_index=2, part_count=3, page_start=6, page_end=10, total_pages=12)
+        assert prompt.startswith("BASE")
+        assert "pages 6-10" in prompt
+        assert "12-page" in prompt
+        assert "(2/3)" in prompt
+        assert "balance-carried-forward" in prompt
+
+    def test_context_page_rule_appears_only_when_carried(self):
+        """Scanned statements may not repeat table headers on continuation pages,
+        so non-first parts carry page 1 as context — and the prompt must scope it
+        to headers/metadata, never transaction extraction."""
+        with_context = build_paged_prompt(
+            "BASE", part_index=2, part_count=3, page_start=6, page_end=10, total_pages=12, has_context_page=True
+        )
+        assert "ONLY as context" in with_context
+        assert "Do NOT extract transactions from this context page" in with_context
+        without_context = build_paged_prompt(
+            "BASE", part_index=1, part_count=3, page_start=1, page_end=5, total_pages=12
+        )
+        assert "context page" not in without_context
+
+
+class TestBatchedExtractFlow:
+    async def test_AC_extraction_1832_1_multi_batch_pdf_extracts_once_per_batch_and_merges(self, monkeypatch):
+        """AC-extraction.1832.1: a document spanning 3 batches produces 3 model
+        calls (each with its own part prompt + only its batch's images) whose
+        payloads merge into one full-document extraction."""
+        from src.config import settings
+
+        monkeypatch.setattr(settings, "ai_provider", "zai")
+        service = ExtractionService()
+        service.api_key = "test-key"
+
+        page_count = service.PDF_VISION_MAX_PAGES * 2 + 2
+        pdf_bytes = _pdf_with_pages(page_count)
+
+        part_payloads = [
+            {
+                "institution": "DBS",
+                "currency": "SGD",
+                "opening_balance": "100.00",
+                "closing_balance": None,
+                "transactions": [{"description": "t1"}],
+            },
+            {"transactions": [{"description": "t2"}]},
+            {"closing_balance": "175.00", "transactions": [{"description": "t3"}]},
+        ]
+        mock_extract = AsyncMock(side_effect=part_payloads)
+
+        with patch.object(service, "_extract_json_with_models", mock_extract):
+            merged = await service.extract_financial_data(pdf_bytes, "DBS", "pdf")
+
+        assert mock_extract.await_count == 3
+        first_page_payload = None
+        for index, call in enumerate(mock_extract.await_args_list, start=1):
+            content = call.kwargs["messages"][0]["content"]
+            text = content[0]["text"]
+            assert f"({index}/3)" in text
+            image_payloads = content[1:]
+            if index == 1:
+                assert len(image_payloads) == 5
+                assert "context page" not in text
+                first_page_payload = image_payloads[0]
+            else:
+                # continuation parts carry page 1 as a leading context image
+                # (scanned docs may not repeat table headers per page)
+                own_pages = 5 if index < 3 else 2
+                assert len(image_payloads) == own_pages + 1
+                assert image_payloads[0] == first_page_payload
+                assert "Do NOT extract transactions from this context page" in text
+        assert merged["institution"] == "DBS"
+        assert merged["opening_balance"] == "100.00"
+        assert merged["closing_balance"] == "175.00"
+        assert [t["description"] for t in merged["transactions"]] == ["t1", "t2", "t3"]
+
+    async def test_single_batch_pdf_keeps_single_call_shape(self, monkeypatch):
+        from src.config import settings
+
+        monkeypatch.setattr(settings, "ai_provider", "zai")
+        service = ExtractionService()
+        service.api_key = "test-key"
+
+        mock_extract = AsyncMock(return_value={"transactions": []})
+        with patch.object(service, "_extract_json_with_models", mock_extract):
+            await service.extract_financial_data(_pdf_with_pages(2), "DBS", "pdf")
+
+        assert mock_extract.await_count == 1
+        text = mock_extract.await_args.kwargs["messages"][0]["content"][0]["text"]
+        assert "PARTIAL DOCUMENT" not in text

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3712,5 +3712,61 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        # ── group 1832: paginated full-document vision extraction — the
+        # per-request page cap must never silently truncate a document (#1832) ──
+        ACRecord(
+            id="AC-extraction.1832.1",
+            statement=(
+                "Vision extraction covers EVERY page of a PDF: documents "
+                "longer than the per-request page cap are rendered in full, "
+                "extracted through one model call per page batch (each call "
+                "sees only its own pages plus part-scoped prompt rules), and "
+                "the per-part payloads are merged into one whole-document "
+                "extraction — the pre-#1832 silent truncation, which made "
+                "the running-balance chain mathematically guaranteed to fail "
+                "for any statement longer than the cap, is gone."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_paged_vision_extraction.py"
+                "::TestBatchedExtractFlow"
+                "::test_AC_extraction_1832_1_multi_batch_pdf_extracts_once_per_batch_and_merges"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.1832.2",
+            statement=(
+                "Paged-extraction merge is pure and deterministic: "
+                "transactions/positions concatenate in page order, scalar "
+                "metadata takes the first non-empty part value, opening "
+                "balance comes from the first part that saw one, closing "
+                "balance from the last."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_paged_vision_extraction.py"
+                "::TestMergePagedExtractions::test_AC_extraction_1832_2_merge_semantics"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.1832.3",
+            statement=(
+                "Documents above the total-page ceiling fail with an "
+                "explicit, page-count-naming error before any model call — "
+                "an honest bound, never silent truncation."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_paged_vision_extraction.py"
+                "::TestRenderAllPagesInBatches"
+                "::test_AC_extraction_1832_3_total_page_ceiling_is_an_explicit_error"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
     ],
 )

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3728,7 +3728,6 @@ CONTRACT = PackageContract(
             ),
             test=(
                 "apps/backend/tests/extraction/test_paged_vision_extraction.py"
-                "::TestBatchedExtractFlow"
                 "::test_AC_extraction_1832_1_multi_batch_pdf_extracts_once_per_batch_and_merges"
             ),
             priority="P0",
@@ -3746,7 +3745,7 @@ CONTRACT = PackageContract(
             ),
             test=(
                 "apps/backend/tests/extraction/test_paged_vision_extraction.py"
-                "::TestMergePagedExtractions::test_AC_extraction_1832_2_merge_semantics"
+                "::test_AC_extraction_1832_2_merge_semantics"
             ),
             priority="P1",
             status="done",
@@ -3761,7 +3760,6 @@ CONTRACT = PackageContract(
             ),
             test=(
                 "apps/backend/tests/extraction/test_paged_vision_extraction.py"
-                "::TestRenderAllPagesInBatches"
                 "::test_AC_extraction_1832_3_total_page_ceiling_is_an_explicit_error"
             ),
             priority="P1",

--- a/tests/tooling/test_secure_glm_file_url.py
+++ b/tests/tooling/test_secure_glm_file_url.py
@@ -30,7 +30,7 @@ def test_zai_pdf_fallback_uses_image_url_and_redacts_presigned_urls() -> None:
     extraction = read("apps/backend/src/extraction/extension")
     storage = read("apps/backend/src/runtime/extension/storage.py")
 
-    assert "def _render_pdf_pages_as_image_payloads" in extraction
+    assert "def _render_pdf_pages_as_image_payload_batches" in extraction
     assert "PDF_VISION_MAX_PAGES = 5" in extraction
     assert '"type": "image_url"' in extraction
     assert '"image_url": {"url": data}' in extraction


### PR DESCRIPTION
## What

Vision extraction now covers EVERY page of a PDF. Documents longer than the
per-request page cap (`PDF_VISION_MAX_PAGES = 5`) are extracted through one model
call per page batch and merged, instead of the pre-#1832 behavior of silently
rendering only the first 5 pages and dropping the rest.

## Why

Staging real-statement QA (2026-07-14) against operator statements: a mainstream
7-page, digital-native SGD bank statement (perfectly legible) parsed to
`status=rejected`. Logs showed `rendered_pages: 5, max_pages: 5` — pages 6-7 never
reached the model, so the missing transactions made the running-balance chain
*mathematically guaranteed* to fail. The remedy text told the user to "re-upload a
clearer source" — blaming a legible document for a truncation the extraction caused.
**Any statement longer than 5 pages could never import.** An 11-page and a 6-page
brokerage statement were also silently truncated in the same round.

## Fix

- `_render_pdf_pages_as_image_payload_batches` renders **all** pages, grouped into
  per-call batches of `PDF_VISION_MAX_PAGES`. A new `PDF_VISION_MAX_TOTAL_PAGES = 30`
  ceiling fails with an explicit, page-count-naming error instead of truncating —
  an honest bound, not silent data loss.
- `_extract_json_from_media_batches` runs one model call per batch concurrently and
  merges the results via a new pure module, `src/extraction/base/paged_extraction.py`
  (`merge_paged_extractions`): transactions/positions concatenate in page order,
  scalar metadata takes the first non-empty part, opening balance from the first
  part that saw one, closing balance from the last (the statement-level closing
  balance lives on the final transaction page — earlier parts are instructed to
  emit null rather than report page-carried-forward subtotals as the closing figure).
- Each part gets a scoped prompt (`build_paged_prompt`): extract transactions only
  from its own pages, statement-level balances only when explicitly stated.
- **Context-page hardening** (raised in review): scanned statements and some
  brokers don't repeat table headers on continuation pages, so a bare continuation
  batch can't reliably tell which column is withdrawal vs deposit or which currency
  applies. Non-first parts now carry page 1 as a leading **context-only** image,
  with an explicit instruction not to re-extract transactions from it. If a model
  ignores that and double-extracts anyway, the pre-existing dedup-conservation and
  balance-chain gates fail closed on the mismatch — the worst outcome is the same
  "quarantined, human review" behavior as today, never a silent double-post.
- Quarantine remedy copy ("re-upload a clearer source") no longer blames the
  document; it now names the actual internal-inconsistency reason.

## ACs

- `AC-extraction.1832.1` — every page is covered; multi-batch extraction merges correctly.
- `AC-extraction.1832.2` — merge semantics (concat order, first/last-wins fields) are
  pure and deterministic.
- `AC-extraction.1832.3` — documents above the total-page ceiling fail explicitly.

All added to `common/extraction/contract.py`'s roadmap.

## Why no gate caught it

The real-corpus eval (#1764 G-growth) had no document longer than 5 pages —
synthetic cassettes all fit the render cap, so the truncation path was never
exercised. (Adding a >5-page real-document corpus case is tracked as a follow-up,
not blocking this PR.)

## Scope note

This does **not** relax the balance-chain / dedup-conservation invariant gates
(#930's deterministic trust boundary) — a genuinely bad extraction (OCR misread, a
missed row) still gets quarantined exactly as before. This PR only removes the
*guaranteed* failure mode where a good document's later pages were never seen.

## Test plan

- [x] `tests/extraction/test_paged_vision_extraction.py` — 11 new tests (rendering,
      merge, prompt, context-page hardening, end-to-end batched flow), red→green
- [x] Existing render/media tests updated for the batched return shape
      (`test_extraction.py`, `test_extraction_error_paths.py`, `test_extraction_flow.py`,
      `test_extraction_cassette_replay.py` docstring)
- [x] Full `tests/extraction` suite: 559 passed
- [x] `tools/generate_ac_registry.py` — registries regenerated, no drift

**preflight skipped: backend-format false-red** — same as #1833/PR #1842: this
machine's `PATH` `ruff` is 0.15.17; CI/preflight pin `apps/backend/.venv/bin/ruff`
at 0.14.11. Verified clean with the pinned binary directly.

## Related

Found alongside #1833 (opening-balance auto-post, PR #1842) and #1834 (Prefect
config drift) in the same 2026-07-14 staging QA round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)