### PR TITLE
[finance_report_audit] refactor(#1821): Wave B-3 — remaining 13 EPICs' fe rows into package roadmaps

### DIFF
--- a/apps/frontend/playwright/advisor-brief.spec.ts
+++ b/apps/frontend/playwright/advisor-brief.spec.ts
@@ -144,6 +144,7 @@ test.describe("AC21.3.4 Advisor Brief responsive layout", () => {
     { name: "desktop", viewport: { width: 1440, height: 1000 } },
     { name: "mobile", viewport: { width: 390, height: 844 } },
   ]) {
+    // AC-advisor.fe-remainder-chat.4
     test(`${scenario.name} advisor-brief desktop and mobile layouts avoid horizontal overflow`, async ({ page }) => {
       await page.setViewportSize(scenario.viewport);
       await installAdvisorBriefMocks(page);

--- a/apps/frontend/playwright/mobile-ux.spec.ts
+++ b/apps/frontend/playwright/mobile-ux.spec.ts
@@ -269,6 +269,7 @@ test("AC16.26.3 stage 2 run review preserves mobile approval gate and match work
   await expectNoDocumentHorizontalScroll(page);
 });
 
+// AC-ledger.fe-accounts2.1
 test("AC2.17.1 mobile accounts avoids document horizontal scroll and overlapping row controls", async ({ page }) => {
   await gotoReady(page, "/accounts");
 
@@ -301,6 +302,7 @@ test.describe("375px mobile review proof", () => {
     hasTouch: true,
   });
 
+  // AC-testing.fe-coverage.2
   test("AC8.13.76 stage 1 and stage 2 review routes remain usable at 375px", async ({ page }) => {
     await gotoReady(page, "/statements/stmt-mobile/review");
     await expect(page.getByTestId("stage1-mobile-transaction-card-txn-mobile-1")).toBeVisible({ timeout: COLD_ROUTE_TIMEOUT_MS });
@@ -327,6 +329,7 @@ test.describe("1440px desktop review proof", () => {
   });
 
   // AC-extraction.fe-stage1-review.11
+  // AC-testing.fe-coverage.3
   test("AC8.13.82/AC16.27.2 desktop stage 1 review keeps transaction table readable at 1440px", async ({ page }) => {
     await gotoReady(page, "/statements/stmt-mobile/review");
 

--- a/apps/frontend/playwright/report-readiness.spec.ts
+++ b/apps/frontend/playwright/report-readiness.spec.ts
@@ -178,6 +178,7 @@ test.describe("AC19.8.7 AC19.8.8 AC22.8.4 AC22.19 report package smoke", () => {
     { name: "mobile", viewport: { width: 390, height: 844 } },
   ]) {
     // AC-reporting.fe-ia-reports.17
+    // AC-reporting.fe-remainder-reports.13
     test(`${scenario.name} renders cover, contents, and readiness before package output`, async ({
       page,
     }) => {

--- a/apps/frontend/playwright/upload-first-dashboard.spec.ts
+++ b/apps/frontend/playwright/upload-first-dashboard.spec.ts
@@ -129,6 +129,7 @@ test.describe("AC19.4.7 upload-first dashboard smoke", () => {
     { name: "desktop", viewport: { width: 1440, height: 1000 } },
     { name: "mobile", viewport: { width: 390, height: 844 } },
   ]) {
+    // AC-reporting.fe-remainder-reports.10
     test(`${scenario.name} renders upload-to-report home before secondary analytics`, async ({ page }) => {
       await page.setViewportSize(scenario.viewport);
       await installDashboardMocks(page);

--- a/apps/frontend/playwright/workflow-notifications.spec.ts
+++ b/apps/frontend/playwright/workflow-notifications.spec.ts
@@ -157,6 +157,7 @@ test.describe("AC19.3.7 workflow notification smoke", () => {
     { name: "desktop", viewport: { width: 1440, height: 1000 }, isMobile: false },
     { name: "mobile", viewport: { width: 390, height: 844 }, isMobile: true },
   ]) {
+    // AC-platform.fe-workflow.4
     test(`${scenario.name} shows workflow badge, inbox, and dashboard status feed`, async ({ page }) => {
       await page.setViewportSize(scenario.viewport);
       await installWorkflowMocks(page);

--- a/apps/frontend/src/__tests__/StatementUploader.test.tsx
+++ b/apps/frontend/src/__tests__/StatementUploader.test.tsx
@@ -372,6 +372,7 @@ describe("AC3.5.3 StatementUploader model selection", () => {
     expect(apiUpload).not.toHaveBeenCalled();
   });
 
+  // AC-extraction.fe-remainder-extraction.4
   it("AC19.15.3 statement uploader rejects csv and csv uploader rejects non-csv, each enforcing its own kind's extensions", async () => {
     vi.mocked(fetchAiModels).mockResolvedValue({
       default_model: "google/gemini-3-flash-preview",

--- a/apps/frontend/src/__tests__/accountsPage.test.tsx
+++ b/apps/frontend/src/__tests__/accountsPage.test.tsx
@@ -310,6 +310,7 @@ describe("AccountsPage", () => {
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Account Details" })).not.toBeInTheDocument())
   })
 
+  // AC-ledger.fe-accounts2.2
   it("AC2.15.8 opens the guided opening-balance modal and refreshes on success", async () => {
     mockedApiFetch.mockResolvedValue({
       items: [{ id: "a1", name: "Cash", type: "ASSET", currency: "SGD", is_active: true, balance: "1000" }],
@@ -329,6 +330,7 @@ describe("AccountsPage", () => {
     await waitFor(() => expect(screen.queryByText("Opening Balance Modal")).not.toBeInTheDocument())
   })
 
+  // AC-ledger.fe-accounts2.3
   it("AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing", async () => {
     mockedApiFetch.mockImplementation((path: string) => {
       if (path === "/api/accounts/opening-balance-readiness") {

--- a/apps/frontend/src/__tests__/advisorBrief.test.tsx
+++ b/apps/frontend/src/__tests__/advisorBrief.test.tsx
@@ -52,6 +52,7 @@ const advisorSuggestions: AdvisorSuggestion[] = [
 ];
 
 describe("AdvisorBrief", () => {
+  // AC-advisor.fe-remainder-chat.2
   it("AC21.3.2 test_AC21_3_2_advisor_brief_renders_structured_cards_and_safe_routes", () => {
     render(<AdvisorBrief suggestions={advisorSuggestions} />);
 

--- a/apps/frontend/src/__tests__/apiErrorStructured.test.ts
+++ b/apps/frontend/src/__tests__/apiErrorStructured.test.ts
@@ -43,6 +43,7 @@ describe("structured ApiError (#1005)", () => {
     vi.stubGlobal("localStorage", localStorageMock);
   });
 
+  // AC-meta.fe-http-client.1
   it("test_AC12_27_3_api_error_carries_error_id parses error_id from the body", async () => {
     const fetchMock = makeFetchMock(409, {
       error_id: "conflict",

--- a/apps/frontend/src/__tests__/apiFunctions.test.ts
+++ b/apps/frontend/src/__tests__/apiFunctions.test.ts
@@ -121,6 +121,7 @@ describe('apiFetch', () => {
     expect(calledHeaders['Authorization']).toBe('Bearer test-jwt-token');
   });
 
+  // AC-identity.fe-auth2.1
   it('AC1.10.3 sends HttpOnly auth cookies by default', async () => {
     const fetchMock = makeFetchMock(200, {});
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/frontend/src/__tests__/apiTypedClient.test.ts
+++ b/apps/frontend/src/__tests__/apiTypedClient.test.ts
@@ -8,6 +8,7 @@ import type { Schemas } from "@/lib/api-schema";
 // against the generated `Schemas[...]` aliases, so a backend contract change that
 // isn't regenerated would fail the type-check.
 describe("generated typed client (#1004)", () => {
+    // AC-meta.fe-http-client.2
     it("test_AC12_28_3_types_stage2_batch_responses_against_generated_schema", () => {
         const approve: Schemas["BatchApproveResponse"] = {
             approved_count: 2,

--- a/apps/frontend/src/__tests__/assetsPage.test.tsx
+++ b/apps/frontend/src/__tests__/assetsPage.test.tsx
@@ -376,6 +376,7 @@ describe("AssetsPage", () => {
   })
 
   // AC-portfolio.fe-ia-portfolio.2
+  // AC-portfolio.fe-assets2.2
   it("AC11.9.4 AC22.10.2 renders manual valuation snapshots and creates a new property valuation", async () => {
     mockedApiFetch.mockImplementation((path: string, options?: RequestInit) => {
       if (path === "/api/assets/valuation-snapshots" && options?.method === "POST") {
@@ -461,6 +462,7 @@ describe("AssetsPage", () => {
     expect(showToastMock).toHaveBeenCalledWith("Manual valuation saved", "success")
   })
 
+  // AC-portfolio.fe-assets2.1
   it("AC11.20.3 test_AC11_20_3_assets_page_surfaces_retirement_and_benefit_asset_labels", async () => {
     mockedApiFetch.mockImplementation((path: string) => {
       if (path.startsWith("/api/assets/valuation-snapshots")) {

--- a/apps/frontend/src/__tests__/auditHub.test.tsx
+++ b/apps/frontend/src/__tests__/auditHub.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import AuditPage from "@/app/(main)/audit/page";
 
 describe("Audit hub (EPIC-022 AC22.21.3)", () => {
+    // AC-ledger.fe-processing.5
     it("AC15.7.6 aggregates the verify-on-demand machinery (incl. Processing) as deep-linking cards", () => {
         render(<AuditPage />);
 

--- a/apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx
+++ b/apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx
@@ -179,6 +179,7 @@ describe("Brokerage import completion route flow", () => {
     vi.unstubAllGlobals()
   })
 
+  // AC-portfolio.fe-assets2.11 / AC-portfolio.fe-assets2.12 / AC-portfolio.fe-assets2.14
   it("AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation", async () => {
     const user = userEvent.setup()
 

--- a/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
+++ b/apps/frontend/src/__tests__/chatPanelComponent.test.tsx
@@ -106,6 +106,7 @@ describe("ChatPanel", () => {
     await waitFor(() => expect(screen.getByText("Assistant answer")).toBeInTheDocument())
   })
 
+  // AC-advisor.fe-remainder-chat.3
   it("AC21.3.3 test_AC21_3_3_chat_panel_renders_contextual_advisor_brief", async () => {
     render(<ChatPanel variant="page" />)
 
@@ -215,6 +216,7 @@ describe("ChatPanel", () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  // AC-advisor.fe-remainder-chat.1
   it("AC19.8.6 shows chat sessions inside the AI page without workflow ownership", async () => {
     render(<ChatPanel variant="page" />)
 

--- a/apps/frontend/src/__tests__/contractTypes.test.ts
+++ b/apps/frontend/src/__tests__/contractTypes.test.ts
@@ -23,6 +23,7 @@ import type {
  * if a duplicate envelope or a second raw-fetch boundary is reintroduced.
  */
 describe("frontend contract consolidation (EPIC-025 / #1158)", () => {
+  // AC-meta.fe-contract-types.1
   it("AC25.3.1: every list response derives from the single ListResponse<T> envelope", () => {
     // Compile-time: each list response must be mutually assignable with
     // ListResponse<itsItem>. If any wrapper drifts from {items,total}, tsc fails.
@@ -75,6 +76,7 @@ describe("frontend contract consolidation (EPIC-025 / #1158)", () => {
     ]);
   });
 
+  // AC-meta.fe-contract-types.2
   it("AC25.3.2: lib/api.ts is the single raw-fetch boundary in the frontend", () => {
     const sourceFiles: string[] = [];
     const visit = (path: string) => {

--- a/apps/frontend/src/__tests__/coverageBaseline.test.ts
+++ b/apps/frontend/src/__tests__/coverageBaseline.test.ts
@@ -7,6 +7,7 @@ interface CoverageConfigWithThresholds {
 }
 
 describe("frontend coverage baseline", () => {
+  // AC-testing.fe-coverage.4
   it("AC8.13.92 keeps the frontend Vitest threshold baseline code-owned", () => {
     const coverage = vitestConfig.test?.coverage as CoverageConfigWithThresholds | undefined
     const thresholds = coverage?.thresholds

--- a/apps/frontend/src/__tests__/dashboardPage.test.tsx
+++ b/apps/frontend/src/__tests__/dashboardPage.test.tsx
@@ -344,6 +344,7 @@ describe("HomePage", () => {
     expect(attentionLinks.length).toBeGreaterThanOrEqual(2)
   })
 
+  // AC-reporting.fe-remainder-reports.4
   it("AC19.3.6 renders the workflow status feed on the dashboard landing surface", async () => {
     mockDashboardApi()
 
@@ -357,6 +358,7 @@ describe("HomePage", () => {
   })
 
   // AC-meta.fe-app-shell.4
+  // AC-reporting.fe-remainder-reports.5
   it("AC19.4.2 AC16.16.1 renders the upload-to-report home before secondary dashboard metrics", async () => {
     mockDashboardApi()
 
@@ -394,6 +396,7 @@ describe("HomePage", () => {
     expect(screen.getByText("Total Assets")).toBeInTheDocument()
   })
 
+  // AC-reporting.fe-remainder-reports.6
   it("AC19.4.3 follows workflow next_action for blocker and upload primary CTAs", async () => {
     mockDashboardApi()
 
@@ -430,6 +433,7 @@ describe("HomePage", () => {
     })
   })
 
+  // AC-reporting.fe-remainder-reports.7
   it("AC19.4.4 renders report readiness above analytics with blocker count and link", async () => {
     mockDashboardApi()
 
@@ -443,6 +447,7 @@ describe("HomePage", () => {
     expect(Boolean(readiness.compareDocumentPosition(totalAssets) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true)
   })
 
+  // AC-reporting.fe-remainder-reports.8
   it("AC19.4.5 shows actionable recent events and summarizes routine automation", async () => {
     mockDashboardApi()
 
@@ -455,6 +460,7 @@ describe("HomePage", () => {
     expect(screen.getAllByText("Safe entries posted").length).toBeGreaterThanOrEqual(1)
   })
 
+  // AC-reporting.fe-remainder-reports.9
   it("AC19.4.6 keeps upload-to-report home visible when secondary analytics fail", async () => {
     mockDashboardApi({ balanceError: new Error("balance failed") })
 
@@ -468,6 +474,7 @@ describe("HomePage", () => {
   })
 
   // AC-reporting.fe-viz-reports.1
+  // AC-portfolio.fe-assets2.7 / AC-portfolio.fe-assets2.10
   it("AC11.8.2/AC11.8.6/AC5.6.4 renders Annualized Income card with the four metric labels", async () => {
     mockDashboardApi()
 
@@ -481,6 +488,7 @@ describe("HomePage", () => {
     expect(screen.getByText(/As of May 20, 2026/)).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.8
   it("AC11.8.4 renders Restricted Holdings separately with vesting metadata", async () => {
     mockDashboardApi()
 
@@ -492,6 +500,7 @@ describe("HomePage", () => {
     expect(screen.getByText("$12,500")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.9
   it("AC11.8.5 defaults to liquid net worth and refetches when restricted holdings are included", async () => {
     mockDashboardApi()
 

--- a/apps/frontend/src/__tests__/eventsPage.test.tsx
+++ b/apps/frontend/src/__tests__/eventsPage.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/components/workflow/WorkflowNotifications", () => ({
 }))
 
 describe("EventsPage", () => {
+  // AC-platform.fe-workflow.3
   it("AC19.3.5 renders the workflow events content surface", () => {
     render(<EventsPage />)
     expect(screen.getByText("Workflow events page content")).toBeInTheDocument()

--- a/apps/frontend/src/__tests__/frontendTelemetry.test.tsx
+++ b/apps/frontend/src/__tests__/frontendTelemetry.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/lib/otel", () => ({ initOtel }))
 import { FrontendTelemetry } from "@/components/FrontendTelemetry"
 
 describe("FrontendTelemetry (AC24.1.1)", () => {
+  // AC-observability.fe-telemetry.1
   it("AC24.1.1 renders nothing and forwards runtime props to initOtel as the env map", () => {
     initOtel.mockClear()
     const { container } = render(

--- a/apps/frontend/src/__tests__/frontendVersionRoute.test.ts
+++ b/apps/frontend/src/__tests__/frontendVersionRoute.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { GET } from "@/app/frontend-version.json/route"
 
 describe("frontend version route", () => {
+  // AC-runtime.fe-deploy.1
   it("AC8.13.90 returns deployed frontend version metadata for PR preview readiness", async () => {
     const previousSha = process.env.GIT_COMMIT_SHA
     process.env.GIT_COMMIT_SHA = "test-sha-123"

--- a/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
+++ b/apps/frontend/src/__tests__/generalSettingsPage.test.tsx
@@ -25,6 +25,7 @@ beforeEach(() => {
 })
 
 describe("GeneralSettingsPage (EPIC-012 AC12.39.3)", () => {
+  // AC-pricing.fe-settings.1
   it("AC12.39.3 renders the effective base currency and keeps Save disabled until edited", async () => {
     render(<GeneralSettingsPage />)
     await waitFor(() => expect(screen.getByText("General Settings")).toBeInTheDocument())

--- a/apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx
+++ b/apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx
@@ -124,6 +124,7 @@ describe("GuidedEvidenceForm", () => {
 
   // ── AC11.9.6 — required-field validation ────────────────────────────
   describe("AC11.9.6 required-field validation", () => {
+    // AC-portfolio.fe-assets2.3
     it("AC11.9.6 validateEvidenceForm flags missing basis and as-of date", () => {
       const { errors, blockers } = validateEvidenceForm({
         source_class: "esop_rsu_plan",
@@ -264,6 +265,7 @@ describe("GuidedEvidenceForm", () => {
 
   // ── AC11.9.7 — typed manual-valuation persistence ───────────────────
   describe("AC11.9.7 typed persistence", () => {
+    // AC-portfolio.fe-assets2.4
     it("AC11.9.7 valid submit posts a Decimal-safe payload through the typed client", async () => {
       mockedApiFetch.mockImplementation((path: string, options?: RequestInit) => {
         if (path.startsWith("/api/assets/valuation-snapshots") && !options) {
@@ -395,6 +397,7 @@ describe("GuidedEvidenceForm", () => {
 
   // ── AC11.9.8 — manual-trusted disclosure label ──────────────────────
   describe("AC11.9.8 manual-trusted disclosure", () => {
+    // AC-portfolio.fe-assets2.5
     it("AC11.9.8 form shows a manual-trusted badge", () => {
       mockListOnly()
       render(<GuidedEvidenceForm />, { wrapper: createWrapper() })
@@ -439,6 +442,7 @@ describe("GuidedEvidenceForm", () => {
 
   // ── AC11.9.9 — mobile layout ────────────────────────────────────────
   describe("AC11.9.9 mobile layout", () => {
+    // AC-portfolio.fe-assets2.6
     it("AC11.9.9 renders accessible single-column form on a mobile viewport", async () => {
       mockMobileViewport()
       mockListOnly()

--- a/apps/frontend/src/__tests__/holdingDetailPage.test.tsx
+++ b/apps/frontend/src/__tests__/holdingDetailPage.test.tsx
@@ -152,6 +152,7 @@ describe("HoldingDetailPage", () => {
     expect(screen.getByText("AAPL")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.20
   it("AC17.7.1 renders Overview, Dividends, and Realized P&L tabs", async () => {
     mockHoldingDetailApi()
 
@@ -176,6 +177,7 @@ describe("HoldingDetailPage", () => {
     expect(screen.getAllByText("10.123456789").length).toBeGreaterThanOrEqual(1)
   })
 
+  // AC-portfolio.fe-assets2.21
   it("AC17.7.2/AC17.7.6 switches to Dividends tab and renders dividend row labels", async () => {
     mockHoldingDetailApi()
 
@@ -192,6 +194,7 @@ describe("HoldingDetailPage", () => {
     expect(screen.getByText("$42.50")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.22
   it("AC17.7.3 persists cost-basis method and refetches realized P&L", async () => {
     mockHoldingDetailApi()
 
@@ -212,6 +215,7 @@ describe("HoldingDetailPage", () => {
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/portfolio/AAPL/realized")
   })
 
+  // AC-portfolio.fe-assets2.23
   it("AC17.7.4 renders lot-level realized P&L table", async () => {
     mockHoldingDetailApi()
 

--- a/apps/frontend/src/__tests__/loginPage.test.tsx
+++ b/apps/frontend/src/__tests__/loginPage.test.tsx
@@ -97,6 +97,7 @@ describe("LoginPage", () => {
     })
   })
 
+  // AC-identity.fe-auth2.2
   it("AC8.19.1 login register controls expose distinct test ids and accessible names", () => {
     render(<LoginPage />)
 

--- a/apps/frontend/src/__tests__/otel.test.ts
+++ b/apps/frontend/src/__tests__/otel.test.ts
@@ -93,6 +93,7 @@ afterEach(() => {
 })
 
 describe("scrubUrl (AC24.1.2 — PII scrub)", () => {
+  // AC-observability.fe-telemetry.2
   it("AC24.1.2 strips query string and fragment from an absolute URL", () => {
     expect(scrubUrl("https://app.example.com/reports?email=a@b.com&amount=1000#frag")).toBe(
       "https://app.example.com/reports",
@@ -333,6 +334,7 @@ describe("makeDocumentLoadScrubHook (AC24.1.2)", () => {
 })
 
 describe("redactException (AC24.1.3)", () => {
+  // AC-observability.fe-telemetry.3
   it("AC24.1.3 keeps the error type but redacts the message/stack", () => {
     const err = new Error("user a@b.com owes $1,234 on account 999")
     expect(redactException(err)).toEqual({ name: "Error", message: "[redacted]" })

--- a/apps/frontend/src/__tests__/performanceCard.test.tsx
+++ b/apps/frontend/src/__tests__/performanceCard.test.tsx
@@ -63,6 +63,7 @@ describe("PerformanceCard", () => {
     expect(screen.getByText("Unable to load performance metrics")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.19
   it("AC17.14.4 leads with unrealized gain/loss, return on cost, and price freshness", () => {
     render(<PerformanceCard schedule={baseSchedule} />)
 

--- a/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
+++ b/apps/frontend/src/__tests__/personalReportPackagePage.test.tsx
@@ -1306,6 +1306,7 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.queryByText("Loading framework package...")).not.toBeInTheDocument();
   });
 
+  // AC-reporting.fe-remainder-reports.11
   it("AC19.5.4 renders package readiness before report package output", async () => {
     mockPackageApi();
 
@@ -1343,6 +1344,7 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.getByText("Manual Valuations")).toBeInTheDocument();
   });
 
+  // AC-reporting.fe-remainder-reports.12
   it("AC19.5.5 renders non-blocked readiness states without blocker cards", async () => {
     mockPackageApi({
       ...readiness,
@@ -1363,6 +1365,7 @@ describe("PersonalReportPackagePage", () => {
     expect(screen.queryByText("Pending source review")).not.toBeInTheDocument();
   });
 
+  // AC-reporting.fe-remainder-reports.14
   it("AC19.9.2 renders compact source trust summary before traceability details", async () => {
     mockPackageApi();
 
@@ -1614,6 +1617,7 @@ describe("PersonalReportPackagePage", () => {
     expectInsideClosedAuditDetails("explicit_manual_input_required");
   });
 
+  // AC-reporting.fe-remainder-reports.1 / AC-reporting.fe-remainder-reports.2 / AC-reporting.fe-remainder-reports.3
   it("AC18.9.4 AC18.9.5 AC18.9.6 opens an Evidence Graph lineage panel from report traceability", async () => {
     mockPackageApi();
 

--- a/apps/frontend/src/__tests__/portfolioPage.test.tsx
+++ b/apps/frontend/src/__tests__/portfolioPage.test.tsx
@@ -325,6 +325,7 @@ describe("PortfolioPage", () => {
     expect(mockedApiFetch).toHaveBeenCalledWith("/api/portfolio/holdings?include_disposed=true")
   })
 
+  // AC-portfolio.fe-assets2.16
   it("AC17.9.3 passes selected as-of date to holdings API", async () => {
     mockPortfolioApi()
 
@@ -364,6 +365,7 @@ describe("PortfolioPage", () => {
     expect(screen.getByTestId("total-portfolio-value")).toHaveTextContent("1,800")
   })
 
+  // AC-portfolio.fe-assets2.24
   it("AC17.7.5 renders realized P&L YTD and dividend income YTD from portfolio summary", async () => {
     mockPortfolioApi()
 
@@ -389,6 +391,7 @@ describe("PortfolioPage", () => {
     expect(screen.getByText("Cost basis uses FIFO where available.")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.18
   it("AC17.14.3 renders net-worth allocation from the report schedule", async () => {
     mockPortfolioApi()
 
@@ -453,6 +456,7 @@ describe("PortfolioPage", () => {
     expect(await within(panel).findByText("No allocation rows available")).toBeInTheDocument()
   })
 
+  // AC-portfolio.fe-assets2.17
   it("AC17.14.1 labels allocation and portfolio currencies instead of claiming a portfolio tie-out", async () => {
     mockPortfolioApi([mockHolding], "100.00", "SGD")
 

--- a/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
+++ b/apps/frontend/src/__tests__/sidebarAndTabs.test.tsx
@@ -120,6 +120,7 @@ describe("Sidebar and WorkspaceTabs", () => {
   })
 
   // AC-meta.fe-app-shell.13
+  // AC-ledger.fe-processing.6
   it("AC15.7.7 AC16.19.12 AC19.6.3 AC19.6.4 AC19.6.5 AC22.21.1 keeps the accounting machinery, sidebar badges and settings out of the sidebar (supersedes the Advanced drawer)", async () => {
     render(<Sidebar />)
 

--- a/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
+++ b/apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx
@@ -259,6 +259,7 @@ describe("AC8.13.48 Stage2ReviewQueue frontend coverage lift", () => {
   })
 
   // AC-reconciliation.fe-stage2-review.19
+  // AC-testing.fe-coverage.1
   it("AC16.23.4/AC8.13.48 persists Stage 2 filters in the URL while approving after filter changes", async () => {
     navState.pathname = "/review/run/run%201"
     navState.searchParams = new URLSearchParams("check_type=duplicate&status=pending&severity=high,medium&min_score=60")

--- a/apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx
+++ b/apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx
@@ -119,6 +119,7 @@ describe("StatementDetailPage - coverage additions", () => {
         expect(portfolioLink).toHaveAttribute("href", "/portfolio");
     });
 
+    // AC-portfolio.fe-assets2.13
     it("AC17.8.3 shows actionable import error banner without exposing sensitive data", async () => {
         mockedApi
             .mockResolvedValueOnce(parsedBrokerageStatement as any)
@@ -164,6 +165,7 @@ describe("StatementDetailPage - coverage additions", () => {
         expect(screen.getByText(/\[URL\]/)).toBeInTheDocument();
     });
 
+    // AC-portfolio.fe-assets2.15
     it("AC17.8.5 does not show Import to Portfolio for non-parsed statements", async () => {
         const uploadedStatement = {
             ...parsedBrokerageStatement,

--- a/apps/frontend/src/__tests__/statementsPage.test.tsx
+++ b/apps/frontend/src/__tests__/statementsPage.test.tsx
@@ -149,6 +149,7 @@ describe("StatementsPage", () => {
     await waitFor(() => expect(screen.getByText("stmt.pdf")).toBeInTheDocument())
   })
 
+  // AC-extraction.fe-remainder-extraction.2
   it("AC19.15.1 exposes exactly three intake entries: one statement uploader plus CSV and Manual", async () => {
     mockStatementsPageApi({ statements: [{ items: [] }] })
 
@@ -165,6 +166,7 @@ describe("StatementsPage", () => {
     expect(screen.getByTestId("manual-evidence-form")).toBeInTheDocument()
   })
 
+  // AC-extraction.fe-remainder-extraction.3
   it("AC19.15.2 keeps secondary intake passive: CSV and Manual folded, no per-class checklist, no readiness fetch", async () => {
     mockStatementsPageApi({ statements: [{ items: [] }] })
 

--- a/apps/frontend/src/__tests__/telemetryEmission.test.ts
+++ b/apps/frontend/src/__tests__/telemetryEmission.test.ts
@@ -42,6 +42,7 @@ describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
   // hands the span to `OTLPTraceExporter.export()` (the in-browser POST origin);
   // the real `POST /v1/traces` over the wire is asserted end-to-end in the
   // companion `playwright/telemetry-emission.spec.ts`.
+  // AC-observability.fe-telemetry.4
   it("emits a finished browser OTel span to the real OTLP exporter's export() (AC24.2.1)", async () => {
     // The SAME exporter class the app uses, pointed at a /v1/traces endpoint.
     const exporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT })
@@ -77,6 +78,7 @@ describe("AC24.2 FE telemetry + analytics emission (#1169)", () => {
 
   // AC24.2.2 — the analytics layer actually dispatches an OpenPanel event via
   // the global `window.op` command queue installed by the OpenPanel SDK.
+  // AC-observability.fe-telemetry.5
   it("dispatches an OpenPanel event via window.op when configured (AC24.2.2)", () => {
     const opCalls: unknown[][] = []
     // Recording stub for the OpenPanel global the real SDK installs. track()

--- a/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx
@@ -28,6 +28,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     mockedPatchUserSettings.mockReset();
   });
 
+  // AC-meta.fe-app-shell2.1
   it("AC18.5.1 — ConfidenceBadge renders confidence tier labels", () => {
     const tiers = ["TRUSTED", "HIGH", "MEDIUM", "LOW"] as const;
 
@@ -49,6 +50,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     }
   });
 
+  // AC-ledger.fe-accounts2.4
   it("AC18.5.2 — Journal page surfaces ConfidenceBadge tier", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [
@@ -73,6 +75,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     expect(screen.getByText("LOW")).toBeInTheDocument();
   });
 
+  // AC-reconciliation.fe-remainder-reconciliation.2
   it("AC18.5.3 — AI Suggestion Review Queue page renders suggestions", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [
@@ -94,6 +97,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     expect(screen.getAllByText("Merchant name indicates dining.").length).toBeGreaterThan(0);
   });
 
+  // AC-reconciliation.fe-remainder-reconciliation.3
   it("AC18.5.4 — feedback POST on accept/reject/edit", async () => {
     mockedApiFetch
       .mockResolvedValueOnce({
@@ -187,6 +191,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     expect(await screen.findByText("suggestions unavailable")).toBeInTheDocument();
   });
 
+  // AC-llm.fe-ai-settings2.1
   it("AC18.5.5 — Settings AI toggles persist", async () => {
     mockedFetchUserSettings.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: false });
     mockedPatchUserSettings.mockResolvedValue({ enable_ai_reconciliation: true, enable_ai_classification: true });
@@ -209,6 +214,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     );
   });
 
+  // AC-extraction.fe-remainder-extraction.1
   it("AC18.5.6 — Audit Trail panel renders provenance", async () => {
     mockedApiFetch.mockResolvedValueOnce({
       items: [
@@ -230,6 +236,7 @@ describe("EPIC-018 / UI Gap Audit / Phase 5 Confidence + AI Review UI", () => {
     expect(screen.getByText(/Food & Dining/)).toBeInTheDocument();
   });
 
+  // AC-llm.fe-ai-settings2.2
   it("AC18.5.7 — AI settings mount reflects saved toggles", async () => {
     mockedFetchUserSettings.mockResolvedValue({ enable_ai_reconciliation: false, enable_ai_classification: true });
 

--- a/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
+++ b/apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx
@@ -62,6 +62,7 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     });
   });
 
+  // AC-ledger.fe-processing.1
   it('AC15.7.2 / AC15.7.8 — ProcessingSummaryCard renders fields and current balance warning', async () => {
     mockedApiFetch.mockResolvedValue({
       pending_count: 3,
@@ -82,6 +83,7 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     });
   });
 
+  // AC-ledger.fe-processing.2
   it('AC15.7.3 — /processing listing renders pending transfers', async () => {
     mockedApiFetch.mockResolvedValue({
       items: [
@@ -122,6 +124,7 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     });
   });
 
+  // AC-ledger.fe-processing.3
   it('AC15.7.4 — warning badge for >7 day pending', async () => {
     mockedApiFetch.mockResolvedValue({
       items: [
@@ -180,6 +183,7 @@ describe('EPIC-015 / UI Gap Audit / Processing Account Visibility', () => {
     expect(backLink).toHaveAttribute("href", "/attention");
   });
 
+  // AC-ledger.fe-processing.4
   it('AC15.7.5 — ProcessingSummaryCard mount test', async () => {
     mockedApiFetch.mockImplementation((path) => {
       if (path === '/api/accounts/processing/summary') {

--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -282,6 +282,7 @@ describe("UnmatchedBoard", () => {
     expect(screen.getByRole("button", { name: "Create Entry" })).toBeEnabled()
   })
 
+  // AC-reconciliation.fe-remainder-reconciliation.1
   it("AC4.11.1 renders unmatched monetary amounts with Decimal-safe currency formatting", async () => {
     mockedApiFetch
       .mockResolvedValueOnce({

--- a/apps/frontend/src/__tests__/workflowApi.test.ts
+++ b/apps/frontend/src/__tests__/workflowApi.test.ts
@@ -34,6 +34,7 @@ describe("workflow API helpers", () => {
     vi.stubGlobal("localStorage", localStorageMock)
   })
 
+  // AC-platform.fe-workflow.1
   it("AC19.3.3 fetches typed workflow status through lib/api.ts", async () => {
     const fetchMock = makeFetchMock(200, {
       primary_state: "needs_action",

--- a/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
+++ b/apps/frontend/src/__tests__/workflowSurfaces.test.tsx
@@ -201,6 +201,7 @@ describe("workflow notification surfaces", () => {
   })
 
   // AC-platform.fe-ia-inbox.2
+  // AC-platform.fe-workflow.2
   it("AC19.3.4 AC22.2.3 shows the header badge from compact workflow counts and hides counts when quiet", async () => {
     renderWithQuery(<WorkflowNotificationCenter />)
 
@@ -230,6 +231,7 @@ describe("workflow notification surfaces", () => {
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Workflow events" })).not.toBeInTheDocument())
   })
 
+  // AC-platform.fe-workflow.6
   it("AC19.3.5 AC19.8.4 groups inbox events by workflow session timeline and supports lifecycle actions", async () => {
     renderWithQuery(<WorkflowNotificationCenter />)
 
@@ -313,6 +315,7 @@ describe("workflow notification surfaces", () => {
     expect(screen.getByRole("link", { name: "Upload statements" })).toHaveAttribute("href", "/statements/upload")
   })
 
+  // AC-platform.fe-workflow.7
   it("AC19.12.5 renders lightweight derived workflow events as user actions, not internal logs", () => {
     render(<WorkflowStatusFeed status={statusNeedsAction} events={workflowEvents.items} />)
 
@@ -422,6 +425,7 @@ describe("workflow notification surfaces", () => {
     expect(screen.getByText("1 blocker")).toBeInTheDocument()
   })
 
+  // AC-platform.fe-workflow.5
   it("AC19.4.8 AC19.12.5 does not duplicate the workflow-state sentence when next-action summary is absent", () => {
     render(
       <UploadToReportHome

--- a/common/advisor/contract.py
+++ b/common/advisor/contract.py
@@ -1209,5 +1209,39 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-advisor.fe-remainder-chat.1",
+            statement="`/chat` is a simple AI utility page with model selector, active conversation, and session-list drawer; it is not labeled AI Settings",
+            # was AC19.8.6
+            test="apps/frontend/src/__tests__/chatPanelComponent.test.tsx::AC19.8.6 shows chat sessions inside the AI page without workflow ownership",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-advisor.fe-remainder-chat.2",
+            statement="Advisor Brief renders blocked, ready, review-required, and stale-market-data cards with source basis, limitation, and safe internal action links",
+            # was AC21.3.2
+            test="apps/frontend/src/__tests__/advisorBrief.test.tsx::AC21.3.2 test_AC21_3_2_advisor_brief_renders_structured_cards_and_safe_routes",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-advisor.fe-remainder-chat.3",
+            statement="Chat and dashboard surfaces expose contextual Ask AI links that seed a scoped prompt without losing existing chat behavior",
+            # was AC21.3.3
+            test="apps/frontend/src/__tests__/chatPanelComponent.test.tsx::AC21.3.3 test_AC21_3_3_chat_panel_renders_contextual_advisor_brief",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-advisor.fe-remainder-chat.4",
+            statement="Advisor Brief keeps desktop and mobile layouts free of horizontal overflow",
+            # was AC21.3.4
+            test="apps/frontend/playwright/advisor-brief.spec.ts::${scenario.name} advisor-brief desktop and mobile layouts avoid horizontal overflow",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3616,5 +3616,39 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-extraction.fe-remainder-extraction.1",
+            statement="Audit Trail panel on transaction detail page lists chronological `{timestamp, actor, action, old_value, new_value}` from `GET /api/transactions/{id}/audit`, including AI-applied changes labeled with actor `ai`",
+            # was AC18.5.6
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.6 — Audit Trail panel renders provenance",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.fe-remainder-extraction.2",
+            statement="The Upload page exposes exactly three intake entries — one primary statement uploader (the AI identifies the type; the user never pre-classifies), one CSV import, and one Manual records entry — with no per-source-class checklist",
+            # was AC19.15.1
+            test="apps/frontend/src/__tests__/statementsPage.test.tsx::AC19.15.1 exposes exactly three intake entries: one statement uploader plus CSV and Manual",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.fe-remainder-extraction.3",
+            statement="The CSV import and Manual records entries are folded (collapsed) by default so they stay passive, the retired per-source-class checklist does not return, and the page does not fetch report readiness merely to render intake",
+            # was AC19.15.2
+            test="apps/frontend/src/__tests__/statementsPage.test.tsx::AC19.15.2 keeps secondary intake passive: CSV and Manual folded, no per-class checklist, no readiness fetch",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-extraction.fe-remainder-extraction.4",
+            statement='The primary statement uploader (`kind="statement"`) rejects `.csv` files by extension before setting a selected file, and the CSV import uploader (`kind="csv"`) rejects non-csv files and accepts `.csv` — each intake entry enforces its own kind\'s file-extension restriction, independent of the shared `all`-kind default',
+            # was AC19.15.3
+            test="apps/frontend/src/__tests__/StatementUploader.test.tsx::AC19.15.3 statement uploader rejects csv and csv uploader rejects non-csv, each enforcing its own kind's extensions",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -611,5 +611,23 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-identity.fe-auth2.1",
+            statement="Frontend storage keeps only non-secret user metadata, relying on the HttpOnly session cookie rather than localStorage for the bearer token",
+            # was AC1.10.3
+            test="apps/frontend/src/__tests__/apiFunctions.test.ts::AC1.10.3 sends HttpOnly auth cookies by default",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-identity.fe-auth2.2",
+            statement='Login auth controls (mode-toggle register button and inline register CTA) expose distinct `data-testid` hooks and accessible names, so no duplicate accessible-name ambiguity remains while the visible text stays "Register"',
+            # was AC8.19.1
+            test="apps/frontend/src/__tests__/loginPage.test.tsx::AC8.19.1 login register controls expose distinct test ids and accessible names",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -2053,6 +2053,88 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-ledger.fe-accounts2.1",
+            statement="Accounts page mobile filters and account rows avoid document-level horizontal scroll and content overlap",
+            # was AC2.17.1
+            test="apps/frontend/playwright/mobile-ux.spec.ts::AC2.17.1 mobile accounts avoids document horizontal scroll and overlapping row controls",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.1",
+            statement='Dashboard "Processing / In-Transit" card renders the four fields with currency code',
+            # was AC15.7.2
+            test="apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx::AC15.7.2 / AC15.7.8 — ProcessingSummaryCard renders fields and current balance warning",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-accounts2.2",
+            statement="The Accounts page offers a guided opening-balance flow: a non-accountant enters an as-of date and a starting balance per eligible (active, non-income/expense) account, and the UI posts the balances map to `POST /api/accounts/opening-balances` — never hand-written journal lines — validating positive two-decimal amounts and surfacing backend errors instead of silently closing",
+            # was AC2.15.8
+            test="apps/frontend/src/__tests__/accountsPage.test.tsx::AC2.15.8 opens the guided opening-balance modal and refreshes on success",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.2",
+            statement="Card click-through navigates to `/processing` listing pending transfers (existing or new page) with line items `{from_account, to_account, amount, initiated_date, days_outstanding}`",
+            # was AC15.7.3
+            test="apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx::AC15.7.3 — /processing listing renders pending transfers",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-accounts2.3",
+            statement="The Accounts page shows a warning nudge (with a CTA that opens the guided flow) when opening balances are missing, and hides it once they are recorded",
+            # was AC2.16.3
+            test="apps/frontend/src/__tests__/accountsPage.test.tsx::AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.3",
+            statement="Pending entries older than 7 days render a warning badge on the listing row",
+            # was AC15.7.4
+            test="apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx::AC15.7.4 — warning badge for >7 day pending",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.4",
+            statement="Frontend test mounts ProcessingSummaryCard and asserts `pending_count` + `pending_total` labels render",
+            # was AC15.7.5
+            test="apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx::AC15.7.5 — ProcessingSummaryCard mount test",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-accounts2.4",
+            statement="ConfidenceBadge mounted on every transaction row in Stage 1 review, Stage 2 listing, and processing-account listing; reads `confidence_tier` from API response",
+            # was AC18.5.2
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.2 — Journal page surfaces ConfidenceBadge tier",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.5",
+            statement="Processing is discoverable as a card in the Audit hub (`/audit`), superseding the old sidebar entry",
+            # was AC15.7.6
+            test="apps/frontend/src/__tests__/auditHub.test.tsx::AC15.7.6 aggregates the verify-on-demand machinery (incl. Processing) as deep-linking cards",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-ledger.fe-processing.6",
+            statement="The sidebar Processing badge was removed with the Advanced drawer; the non-zero-balance warning is carried by the Home Processing card and attention inbox",
+            # was AC15.7.7
+            test="apps/frontend/src/__tests__/sidebarAndTabs.test.tsx::AC15.7.7 AC16.19.12 AC19.6.3 AC19.6.4 AC19.6.5 AC22.21.1 keeps the accounting machinery, sidebar badges and settings out of the sidebar (supersedes the Advanced drawer)",
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -981,5 +981,23 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-llm.fe-ai-settings2.1",
+            statement="Settings page `/settings/ai` exposes toggles for `enable_ai_reconciliation`, `enable_ai_classification`, persisted via `PATCH /api/users/me/settings`; toggle reflects backend feature-flag state on load",
+            # was AC18.5.5
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.5 — Settings AI toggles persist",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-llm.fe-ai-settings2.2",
+            statement="Frontend tests: mount ConfidenceBadge for each tier; mount AI Suggestion Queue and assert Accept/Reject buttons render; mount Settings AI toggles and assert default state matches API",
+            # was AC18.5.7
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.7 — AI settings mount reflects saved toggles",
+            priority="P2",
+            status="done",
+        ),
     ],
 )

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2066,5 +2066,47 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-meta.fe-http-client.1",
+            statement="Frontend `apiFetch` throws `ApiError` carrying the parsed `errorId`",
+            # was AC12.27.3
+            test="apps/frontend/src/__tests__/apiErrorStructured.test.ts::test_AC12_27_3_api_error_carries_error_id parses error_id from the body",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.fe-app-shell2.1",
+            statement="`<ConfidenceBadge />` component renders `TRUSTED` / `HIGH` / `MEDIUM` / `LOW` pill with consistent color tokens (green / blue / amber / gray) and tooltip explaining source-type priority",
+            # was AC18.5.1
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.1 — ConfidenceBadge renders confidence tier labels",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.fe-contract-types.1",
+            statement="The list-response envelope has a single `ListResponse<T>` definition and the per-entity list responses derive from it; declared OpenAPI-mirrored contract types resolve to a real generated `Schemas[...]` key (drift guard)",
+            # was AC25.3.1
+            test="apps/frontend/src/__tests__/contractTypes.test.ts::AC25.3.1: every list response derives from the single ListResponse<T> envelope",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.fe-http-client.2",
+            statement="High-traffic call sites type responses against the generated schema",
+            # was AC12.28.3
+            test="apps/frontend/src/__tests__/apiTypedClient.test.ts::test_AC12_28_3_types_stage2_batch_responses_against_generated_schema",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.fe-contract-types.2",
+            statement="`lib/api.ts` is the single raw-`fetch` boundary — no other frontend source module issues a raw `fetch(` call",
+            # was AC25.3.2
+            test="apps/frontend/src/__tests__/contractTypes.test.ts::AC25.3.2: lib/api.ts is the single raw-fetch boundary in the frontend",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -1159,7 +1159,13 @@ CONTRACT = PackageContract(
         ),
         ACRecord(
             id="AC-observability.fe-telemetry.5",
-            statement="With the OpenPanel client id configured, the analytics layer actually dispatches an OpenPanel event/page-view (`window.op('track'\\",
+            statement=(
+                "With the OpenPanel client id configured, the analytics "
+                "layer actually dispatches an OpenPanel event/page-view "
+                "(`window.op('track'` or `'screenView', ...)` invoked); "
+                "asserted against a stubbed `window.op`/endpoint so the "
+                "test is hermetic"
+            ),
             # was AC24.2.2
             test="apps/frontend/src/__tests__/telemetryEmission.test.ts::dispatches an OpenPanel event via window.op when configured (AC24.2.2)",
             priority="P1",

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -1123,5 +1123,47 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-observability.fe-telemetry.1",
+            statement="The browser OTel module is config-gated (complete no-op until `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` is set), non-blocking, idempotent, and swallows SDK errors so it never throws into the app",
+            # was AC24.1.1
+            test="apps/frontend/src/__tests__/frontendTelemetry.test.tsx::AC24.1.1 renders nothing and forwards runtime props to initOtel as the env map",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-observability.fe-telemetry.2",
+            statement="The PII scrub strips query strings and fragments from captured URLs and drops sensitive attributes (emails, amounts, account numbers) before any span is emitted",
+            # was AC24.1.2
+            test="apps/frontend/src/__tests__/otel.test.ts::AC24.1.2 strips query string and fragment from an absolute URL",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-observability.fe-telemetry.3",
+            statement="Uncaught errors (`window.onerror`) and unhandled promise rejections are captured as span exceptions with a scrubbed page URL",
+            # was AC24.1.3
+            test="apps/frontend/src/__tests__/otel.test.ts::AC24.1.3 keeps the error type but redacts the message/stack",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-observability.fe-telemetry.4",
+            statement="With the OTLP endpoint configured, the real browser OTel exporter emits a span (span actually exported, not merely wired): the vitest proof asserts the span reaches `OTLPTraceExporter.export()`, and the Playwright spec asserts the actual outbound `POST /v1/traces` over the wire; both hermetic against a stubbed collector",
+            # was AC24.2.1
+            test="apps/frontend/src/__tests__/telemetryEmission.test.ts::emits a finished browser OTel span to the real OTLP exporter's export() (AC24.2.1)",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-observability.fe-telemetry.5",
+            statement="With the OpenPanel client id configured, the analytics layer actually dispatches an OpenPanel event/page-view (`window.op('track'\\",
+            # was AC24.2.2
+            test="apps/frontend/src/__tests__/telemetryEmission.test.ts::dispatches an OpenPanel event via window.op when configured (AC24.2.2)",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -1084,5 +1084,63 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-platform.fe-workflow.1",
+            statement="Frontend exposes typed workflow API helpers through `lib/api.ts` for status, events, and lifecycle patching",
+            # was AC19.3.3
+            test="apps/frontend/src/__tests__/workflowApi.test.ts::AC19.3.3 fetches typed workflow status through lib/api.ts",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.2",
+            statement="Header/app-shell badge reflects unread/action-required/blocked counts from the compact workflow API and stays quiet when no attention is needed",
+            # was AC19.3.4
+            test="apps/frontend/src/__tests__/workflowSurfaces.test.tsx::AC19.3.4 AC22.2.3 shows the header badge from compact workflow counts and hides counts when quiet",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.3",
+            statement="Event inbox groups events by workflow session timeline, keeps blocked/action-required events prominent, and supports read/archive actions and direct action links",
+            # was AC19.3.5
+            test="apps/frontend/src/__tests__/eventsPage.test.tsx::AC19.3.5 renders the workflow events content surface",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.4",
+            statement="Desktop and mobile Playwright smoke covers the workflow badge/inbox/feed without layout overflow",
+            # was AC19.3.7
+            test="apps/frontend/playwright/workflow-notifications.spec.ts::${scenario.name} shows workflow badge, inbox, and dashboard status feed",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.5",
+            statement="Workflow status returns cockpit-ready `next_action.label` and `next_action.summary`, routes processing to session history, and routes ready reports directly to `/reports/package`",
+            # was AC19.4.8
+            test="apps/frontend/src/__tests__/workflowSurfaces.test.tsx::AC19.4.8 AC19.12.5 does not duplicate the workflow-state sentence when next-action summary is absent",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.6",
+            statement="Notification drawer and Events page group timestamped events by workflow session, while Upload Pipeline shows only active-session latest state plus recent timeline preview",
+            # was AC19.8.4
+            test="apps/frontend/src/__tests__/workflowSurfaces.test.tsx::AC19.3.5 AC19.8.4 groups inbox events by workflow session timeline and supports lifecycle actions",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.fe-workflow.7",
+            statement="Dashboard status feed and event inbox render lightweight derived events as user actions while routine/internal details remain collapsed or absent",
+            # was AC19.12.5
+            test="apps/frontend/src/__tests__/workflowSurfaces.test.tsx::AC19.12.5 renders lightweight derived workflow events as user actions, not internal logs",
+            priority="P0",
+            status="done",
+        ),
     ],
 )

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -1843,5 +1843,199 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-portfolio.fe-assets2.1",
+            statement="The assets page labels retirement and benefit asset entry options as assets, with insurance represented only by cash value",
+            # was AC11.20.3
+            test="apps/frontend/src/__tests__/assetsPage.test.tsx::AC11.20.3 test_AC11_20_3_assets_page_surfaces_retirement_and_benefit_asset_labels",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.2",
+            statement="`/assets` exposes a manual valuation entry form and recent snapshot list using the shared API client.",
+            # was AC11.9.4
+            test="apps/frontend/src/__tests__/assetsPage.test.tsx::AC11.9.4 AC22.10.2 renders manual valuation snapshots and creates a new property valuation",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.3",
+            statement="([#706](https://github.com/wangzitian0/finance_report/issues/706)): the shared guided evidence form for the three source classes (`esop_rsu_plan`, `property_statement`, `liability_statement`) blocks submission and shows a readiness blocker when the required `valuation_basis` or `as_of_date` is missing, never calling the API; value is carried as a `Decimal`-safe string with no float math. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.6 *`.",
+            # was AC11.9.6
+            test="apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.6 validateEvidenceForm flags missing basis and as-of date",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.4",
+            statement="([#706](https://github.com/wangzitian0/finance_report/issues/706)): a valid guided evidence submission persists through the existing `POST /api/assets/valuation-snapshots` endpoint via the typed `lib/api.ts` client (never raw `fetch`), mapping the chosen source class to its `component_type`, `valuation_basis`, source label, anchor, and notes, with the monetary `value` sent as a string. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.7 *`.",
+            # was AC11.9.7
+            test="apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.7 valid submit posts a Decimal-safe payload through the typed client",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.5",
+            statement='([#706](https://github.com/wangzitian0/finance_report/issues/706)): the guided evidence flow surfaces a clear "Manual-trusted" disclosure badge for manually entered evidence so users and the traceability appendix can see the source-trust state of a value. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.8 *`.',
+            # was AC11.9.8
+            test="apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.8 form shows a manual-trusted badge",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.6",
+            statement="([#706](https://github.com/wangzitian0/finance_report/issues/706)): the guided evidence form renders an accessible single-column mobile layout (and the recent-evidence list) when a mobile viewport is reported by `matchMedia`, and degrades gracefully when `matchMedia` is unavailable. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.9 *`.",
+            # was AC11.9.9
+            test="apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.9 renders accessible single-column form on a mobile viewport",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.7",
+            statement='Dashboard "Annualized Income" card renders the four annualized figures with the currency code and `as_of` date subtitle',
+            # was AC11.8.2
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC11.8.2/AC11.8.6/AC5.6.4 renders Annualized Income card with the four metric labels",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.8",
+            statement='Dashboard "Restricted Holdings" card lists restricted holdings separated from liquid net worth, with vesting timeline tooltip',
+            # was AC11.8.4
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC11.8.4 renders Restricted Holdings separately with vesting metadata",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.9",
+            statement="Net worth calculation toggle on dashboard (`include_restricted=true|false`) re-fetches and updates total, defaulting to `false` (vision: liquid wealth is primary)",
+            # was AC11.8.5
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC11.8.5 defaults to liquid net worth and refetches when restricted holdings are included",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.10",
+            statement="Frontend test mounts AnnualizedIncomeCard and asserts the four metric labels render",
+            # was AC11.8.6
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC11.8.2/AC11.8.6/AC5.6.4 renders Annualized Income card with the four metric labels",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.11",
+            statement="Import to Portfolio button visible for parsed/approved statements",
+            # was AC17.8.1
+            test="apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx::AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.12",
+            statement="Import result banner with stats and portfolio link shown on success",
+            # was AC17.8.2
+            test="apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx::AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.13",
+            statement="Import failure shows actionable error without sensitive data",
+            # was AC17.8.3
+            test="apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx::AC17.8.3 shows actionable import error banner without exposing sensitive data",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.14",
+            statement="Portfolio page shows total portfolio value prominently after import",
+            # was AC17.8.4
+            test="apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx::AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.15",
+            statement="Import button hidden for non-parsed/approved statements (partial batch)",
+            # was AC17.8.5
+            test="apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx::AC17.8.5 does not show Import to Portfolio for non-parsed statements",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.16",
+            statement="Portfolio page exposes an as-of date selector and passes it to `/api/portfolio/holdings`",
+            # was AC17.9.3
+            test="apps/frontend/src/__tests__/portfolioPage.test.tsx::AC17.9.3 passes selected as-of date to holdings API",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.17",
+            statement="Portfolio page renders a unified allocation panel without claiming a portfolio-value tie-out when report and holdings currencies differ",
+            # was AC17.14.1
+            test="apps/frontend/src/__tests__/portfolioPage.test.tsx::AC17.14.1 labels allocation and portfolio currencies instead of claiming a portfolio tie-out",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.18",
+            statement="Portfolio page consumes the report-owned net-worth allocation schedule, showing asset class, liquidity, source currency, net-worth share, source labels, and restricted-inclusion filtering",
+            # was AC17.14.3
+            test="apps/frontend/src/__tests__/portfolioPage.test.tsx::AC17.14.3 renders net-worth allocation from the report schedule",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.19",
+            statement="The asset-dashboard performance surface leads with unrealized market-value gain/loss, a simple return on cost valued at the schedule as-of date, and a price-freshness flag; TWR/IRR/MWR are not presented as the asset-dashboard answer and stay on the reporting side as clearly-labelled analytical measures",
+            # was AC17.14.4
+            test="apps/frontend/src/__tests__/performanceCard.test.tsx::AC17.14.4 leads with unrealized gain/loss, return on cost, and price freshness",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.20",
+            statement="Holding detail page `/portfolio/[ticker]` renders three tabs: `Overview`, `Dividends`, `Realized P&L`",
+            # was AC17.7.1
+            test="apps/frontend/src/__tests__/holdingDetailPage.test.tsx::AC17.7.1 renders Overview, Dividends, and Realized P&L tabs",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.21",
+            statement="Dividends tab lists historical dividend events `{ex_date, pay_date, amount, currency, reinvested}` from `GET /api/portfolio/{ticker}/dividends`",
+            # was AC17.7.2
+            test="apps/frontend/src/__tests__/holdingDetailPage.test.tsx::AC17.7.2/AC17.7.6 switches to Dividends tab and renders dividend row labels",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.22",
+            statement="Cost-basis method selector (`FIFO` / `LIFO` / `AvgCost`) on holding detail page persists per-holding via `PATCH /api/portfolio/{ticker}` and re-fetches realized P&L",
+            # was AC17.7.3
+            test="apps/frontend/src/__tests__/holdingDetailPage.test.tsx::AC17.7.3 persists cost-basis method and refetches realized P&L",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.23",
+            statement="Realized P&L tab shows lot-level table `{lot_id, acquired_date, sold_date, quantity, basis, proceeds, gain_loss, holding_period}` from `GET /api/portfolio/{ticker}/realized`",
+            # was AC17.7.4
+            test="apps/frontend/src/__tests__/holdingDetailPage.test.tsx::AC17.7.4 renders lot-level realized P&L table",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-portfolio.fe-assets2.24",
+            statement="Portfolio summary card on dashboard adds `realized_pnl_ytd` and `dividend_income_ytd` figures from `GET /api/portfolio/summary`",
+            # was AC17.7.5
+            test="apps/frontend/src/__tests__/portfolioPage.test.tsx::AC17.7.5 renders realized P&L YTD and dividend income YTD from portfolio summary",
+            priority="P2",
+            status="done",
+        ),
     ],
 )

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -914,5 +914,15 @@ CONTRACT = PackageContract(
             priority="P2",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-pricing.fe-settings.1",
+            statement='The frontend General Settings page exposes a "Base currency" control that reads + updates the effective value via `lib/api.ts` (`fetchBaseCurrency`/`updateBaseCurrency`, never raw `fetch`)',
+            # was AC12.39.3
+            test="apps/frontend/src/__tests__/generalSettingsPage.test.tsx::AC12.39.3 renders the effective base currency and keeps Save disabled until edited",
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/reconciliation/contract.py
+++ b/common/reconciliation/contract.py
@@ -1862,5 +1862,31 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-reconciliation.fe-remainder-reconciliation.1",
+            statement="The unmatched transaction board models unmatched amounts as shared `MoneyValue` payloads and renders queue/detail/created-entry amounts through Decimal-safe currency formatting, not JavaScript number locale formatting",
+            # was AC4.11.1
+            test="apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx::AC4.11.1 renders unmatched monetary amounts with Decimal-safe currency formatting",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reconciliation.fe-remainder-reconciliation.2",
+            statement="AI Suggestion Review Queue page `/review/ai-suggestions` lists pending AI classifications and AI reconciliation matches in score band 60-84 with `{transaction, suggested_category_or_match, ai_score, ai_reasoning}`",
+            # was AC18.5.3
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.3 — AI Suggestion Review Queue page renders suggestions",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reconciliation.fe-remainder-reconciliation.3",
+            statement="Queue actions: `Accept`, `Reject`, `Edit-then-Accept`; each action calls `POST /api/ai/feedback` with `{suggestion_id, action, corrected_value?}` to feed the feedback loop",
+            # was AC18.5.4
+            test="apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx::AC18.5.4 — feedback POST on accept/reject/edit",
+            priority="P2",
+            status="done",
+        ),
     ],
 )

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -2770,5 +2770,119 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.1",
+            statement="The report package traceability surface exposes a lineage panel from at least one report traceability row",
+            # was AC18.9.4
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC18.9.4 AC18.9.5 AC18.9.6 opens an Evidence Graph lineage panel from report traceability",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.2",
+            statement="The lineage panel renders source document, extracted record, atomic fact, ledger entry, ledger line, and report-line anchors when present",
+            # was AC18.9.5
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC18.9.4 AC18.9.5 AC18.9.6 opens an Evidence Graph lineage panel from report traceability",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.3",
+            statement="Tests cover report line to source document navigation and source document to impacted ledger/report navigation",
+            # was AC18.9.6
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC18.9.4 AC18.9.5 AC18.9.6 opens an Evidence Graph lineage panel from report traceability",
+            priority="P2",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.4",
+            statement="Dashboard status feed renders primary state, report readiness, recent automation, blocker/action severity, and an empty no-action state without raw audit-log noise",
+            # was AC19.3.6
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.3.6 renders the workflow status feed on the dashboard landing surface",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.5",
+            statement="The first dashboard viewport renders the upload-to-report workflow home before KPI, chart, and activity content",
+            # was AC19.4.2
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.4.2 AC16.16.1 renders the upload-to-report home before secondary dashboard metrics",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.6",
+            statement="The dashboard primary CTA follows `workflow.status.next_action.href` and labels upload as the default action when no higher-priority blocker/action exists",
+            # was AC19.4.3
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.4.3 follows workflow next_action for blocker and upload primary CTAs",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.7",
+            statement="Report readiness state and blocker count are visible above secondary dashboard metrics and link to the readiness/report action path",
+            # was AC19.4.4
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.4.4 renders report readiness above analytics with blocker count and link",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.8",
+            statement="Recent workflow events are visible, grouped by actionability, and routine automation is summarized without dominating the page",
+            # was AC19.4.5
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.4.5 shows actionable recent events and summarizes routine automation",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.9",
+            statement="Secondary dashboard metric API failure does not hide the workflow home; the analytics section renders an isolated retry/error state",
+            # was AC19.4.6
+            test="apps/frontend/src/__tests__/dashboardPage.test.tsx::AC19.4.6 keeps upload-to-report home visible when secondary analytics fail",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.10",
+            statement="Desktop and mobile Playwright smoke covers the upload-first dashboard entry without layout overflow",
+            # was AC19.4.7
+            test="apps/frontend/playwright/upload-first-dashboard.spec.ts::${scenario.name} renders upload-to-report home before secondary analytics",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.11",
+            statement="Personal report package page renders readiness state and blocker links before package section output",
+            # was AC19.5.4
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC19.5.4 renders package readiness before report package output",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.12",
+            statement="Personal report package page renders non-blocked readiness states without stale blocker cards",
+            # was AC19.5.5
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC19.5.5 renders non-blocked readiness states without blocker cards",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.13",
+            statement="Report readiness has route-level Playwright smoke coverage before package output",
+            # was AC19.8.7
+            test="apps/frontend/playwright/report-readiness.spec.ts::${scenario.name} renders cover, contents, and readiness before package output",
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reporting.fe-remainder-reports.14",
+            statement="Personal report package page renders a compact source trust summary before detailed package output",
+            # was AC19.9.2
+            test="apps/frontend/src/__tests__/personalReportPackagePage.test.tsx::AC19.9.2 renders compact source trust summary before traceability details",
+            priority="P0",
+            status="done",
+        ),
     ],
 )

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -1152,6 +1152,16 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-runtime.fe-deploy.1",
+            statement="Frontend exposes `/frontend-version.json` with deployed `git_sha`/`version` metadata for PR preview readiness checks",
+            # was AC8.13.90
+            test="apps/frontend/src/__tests__/frontendVersionRoute.test.ts::AC8.13.90 returns deployed frontend version metadata for PR preview readiness",
+            priority="P0",
+            status="done",
+        ),
     ],
 )
 

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -3738,6 +3738,40 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── Wave B (#1821): frontend-proof rows migrated from the
+        # remaining EPIC files (EPIC-001/002/004/008/011/012/015/017/018/019/021/024/025) ──
+        ACRecord(
+            id="AC-testing.fe-coverage.1",
+            statement="Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99%",
+            # was AC8.13.48
+            test="apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx::AC16.23.4/AC8.13.48 persists Stage 2 filters in the URL while approving after filter changes",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.fe-coverage.2",
+            statement="Playwright mobile UX coverage proves Stage 1 and Stage 2 review workflows avoid document-level horizontal scroll and expose direct completion actions at phone widths",
+            # was AC8.13.76
+            test="apps/frontend/playwright/mobile-ux.spec.ts::AC8.13.76 stage 1 and stage 2 review routes remain usable at 375px",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.fe-coverage.3",
+            statement="Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and desktop local table clipping (AC16.27.2 removed and AC16.27.3 removed, canonical: the same shared spec also proves `AC-extraction.fe-stage1-review.11` and `AC-reconciliation.fe-stage2-review.17`, #1821 Wave B)",
+            # was AC8.13.82
+            test="apps/frontend/playwright/mobile-ux.spec.ts::AC8.13.82/AC16.27.2 desktop stage 1 review keeps transaction table readable at 1440px",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.fe-coverage.4",
+            statement="Frontend Vitest coverage keeps a code-owned 98% baseline for line, statement, and function metrics plus an explicit branch floor while representative low-coverage routes and workflow surfaces stay covered",
+            # was AC8.13.92
+            test="apps/frontend/src/__tests__/coverageBaseline.test.ts::AC8.13.92 keeps the frontend Vitest threshold baseline code-owned",
+            priority="P0",
+            status="done",
+        ),
     ],
 )
 

--- a/docs/project/EPIC-001.phase0-setup.md
+++ b/docs/project/EPIC-001.phase0-setup.md
@@ -188,14 +188,12 @@ Set up a runnable Monorepo development environment, complete user authentication
 > [`common/runtime/contract.py`](../../common/runtime/contract.py)'s
 > `roadmap`, migration closeout wave 3, #1663.)
 >
-> **AC1.10.3**'s backend half (`test_AC1_10_3_get_me_accepts_httponly_cookie`)
+> This row's backend half (`test_AC1_10_3_get_me_accepts_httponly_cookie`)
 > migrated to [`common/identity/contract.py`](../../common/identity/contract.py)'s
 > `roadmap` as **`AC-identity.2.5`** (migration closeout wave 3, #1663). The
-> row's frontend-storage half stays here (no backend package home):
+> row's frontend-storage half migrated separately below (#1821 Wave B):
 
-| ID | Requirement | Test Function | File |
-|----|-------------|---------------|------|
-| AC1.10.3 | Frontend storage keeps only non-secret user metadata, relying on the HttpOnly session cookie rather than localStorage for the bearer token | `AC1.10.3 sends HttpOnly auth cookies by default` / `auth.test.ts` session tests | `src/__tests__/apiFunctions.test.ts`, `src/__tests__/auth.test.ts` | <!-- epic-owned: fe-only -->
+(AC1.10.3 removed, canonical: migrated to the `identity` package roadmap as `AC-identity.fe-auth2.1`, #1821 Wave B)
 
 > **The former email-normalization criterion (the AC1.10 normalize-email row) is
 > no longer defined here.** It migrated into the `identity` package (#1428) as

--- a/docs/project/EPIC-002.double-entry-core.md
+++ b/docs/project/EPIC-002.double-entry-core.md
@@ -1,5 +1,10 @@
 # EPIC-002: Double-Entry Bookkeeping Core
 
+<!-- epic-file: design-doc -->
+<!-- 0 AC rows by design (#1821 Wave B): the delivered double-entry-core
+     design record; all ACs migrated to their owning package contract.py
+     roadmaps (mostly ledger, plus reporting/pricing/audit slices). -->
+
 > **Status**: ✅ Complete  
 > **Vision Anchor**: `decision-filter-accuracy-auditability`  
 > **Phase**: 1  
@@ -103,10 +108,10 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 > so the AC index counts them without an EPIC-table mirror. This note references
 > the new ids (keeping the registry↔EPIC link intact) but defines none of them —
 > the contract is the single definition source. The **non-double-entry** rows of
-> the AC2.13–AC2.23 range stay defined below, because they are not ledger ACs: the
-> frontend UI ACs `AC2.15.8` / `AC2.16.3` / `AC2.17.1` (the ledger package is
-> `fe=None`), the cross-EPIC framework-boundary doc-contract (now
-> `AC-meta.framework-neutrality.1`, #1821 Wave A), and the
+> the AC2.13–AC2.23 range are not ledger ACs: the three frontend UI ACs (the
+> ledger package is `fe=None`) migrated in #1821 Wave B once the governance gate
+> gained TS test-ref resolution (below), the cross-EPIC framework-boundary
+> doc-contract (now `AC-meta.framework-neutrality.1`, #1821 Wave A), and the
 > Money value-type extension `AC2.19.*`–`AC2.22.*` (owned by the `money` kernel).
 > Slice 3c-iii is the final AC batch of the #1420 cutover. *(AC2.16 group's
 > reporting-layer row and AC2.12's stream-redaction row removed — migration
@@ -170,10 +175,10 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 > **Database ledger invariant floor** (was AC2.14.*):
 > `AC-ledger.14.1` · `AC-ledger.14.2` · `AC-ledger.14.3` · `AC-ledger.14.4` · `AC-ledger.14.5` · `AC-ledger.14.6`
 >
-> **Guided opening balances — backend** (was the AC2.15.* backend rows; the frontend `AC2.15.8` stays in EPIC-002):
+> **Guided opening balances — backend** (was the AC2.15.* backend rows; the frontend row migrated separately to `AC-ledger.fe-accounts2.2`, #1821 Wave B):
 > `AC-ledger.15.1` · `AC-ledger.15.2` · `AC-ledger.15.3` · `AC-ledger.15.4` · `AC-ledger.15.5` · `AC-ledger.15.6` · `AC-ledger.15.7`
 >
-> **Opening-balance readiness — backend** (was the AC2.16.* backend detection rows; the frontend `AC2.16.3` stays in EPIC-002; *the AC2.16 group's reporting-layer row removed* — migrated to `reporting`, #1663):
+> **Opening-balance readiness — backend** (was the AC2.16.* backend detection rows; the frontend row migrated separately to `AC-ledger.fe-accounts2.3`, #1821 Wave B; *the AC2.16 group's reporting-layer row removed* — migrated to `reporting`, #1663):
 > `AC-ledger.16.1` · `AC-ledger.16.2`
 
 ### AC2.17: Account Management UI Responsiveness
@@ -181,9 +186,7 @@ SUM(DEBIT) = SUM(CREDIT)  // Each journal entry must balance
 > Renumbered from a second `AC2.12` group that collided with AC2.12 (Multi-Currency
 > Ledger Integrity); the AC IDs are unique, the namespaces were not.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC2.17.1 | Accounts page mobile filters and account rows avoid document-level horizontal scroll and content overlap | `AC2.17.1 mobile accounts avoids document horizontal scroll and overlapping row controls` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 | <!-- epic-owned: fe-only -->
+(AC2.17.1 removed, canonical: migrated to the `ledger` package roadmap as `AC-ledger.fe-accounts2.1`, #1821 Wave B)
 
 > The groups AC2.7–AC2.12 (API router & error handling, decimal safety, the data
 > model + endpoint checklists, must-have traceability, and multi-currency ledger
@@ -213,13 +216,11 @@ A user with pre-existing assets/liabilities can establish year-start balances vi
 
 > The backend opening-balance ACs in the `AC2.15.*` range (which post and validate
 > the balanced double-entry) migrated into the `ledger` package as
-> `AC-ledger.15.*` (#1420 slice 3c-iii). Only the **frontend** guided-flow AC
-> `AC2.15.8` stays here, because the ledger package is `fe=None` (the same rule
-> that kept EPIC-015's `AC15.7.*` frontend rows in their EPIC).
+> `AC-ledger.15.*` (#1420 slice 3c-iii). The **frontend** guided-flow AC could not
+> be homed there directly (the ledger package is `fe=None`) until #1820/#1825
+> gave the governance gate TS test-ref resolution, letting it migrate below.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC2.15.8 | The Accounts page offers a guided opening-balance flow: a non-accountant enters an as-of date and a starting balance per eligible (active, non-income/expense) account, and the UI posts the balances map to `POST /api/accounts/opening-balances` — never hand-written journal lines — validating positive two-decimal amounts and surfacing backend errors instead of silently closing | `AC2.15.8 lists only eligible accounts and hides income/expense and inactive ones`, `AC2.15.8 posts a balances map without requiring hand-written journal lines`, `AC2.15.8 blocks submission until at least one positive balance is entered`, `AC2.15.8 rejects non-positive or over-precise amounts before calling the API`, `AC2.15.8 surfaces a backend error instead of closing` | `apps/frontend/src/__tests__/openingBalanceModal.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC2.15.8 removed, canonical: migrated to the `ledger` package roadmap as `AC-ledger.fe-accounts2.2`, #1821 Wave B)
 
 ### AC2.16: Opening-Balance Readiness Nudge ([#949](https://github.com/wangzitian0/finance_report/issues/949)) — frontend AC only
 
@@ -230,14 +231,13 @@ that gap before the numbers are trusted.
 
 > The backend ledger-activity detection ACs in the `AC2.16.*` range migrated into
 > the `ledger` package as `AC-ledger.16.*` (#1420 slice 3c-iii). The **frontend**
-> nudge `AC2.16.3` stays here (ledger is `fe=None`). *(The AC2.16 group's
-> reporting-layer row removed — a report-assembly property, not a
-> double-entry posting one; migrated to `reporting`, migration closeout
+> nudge could not be homed there directly (ledger is `fe=None`) until #1820/#1825
+> gave the governance gate TS test-ref resolution, letting it migrate below.
+> *(The AC2.16 group's reporting-layer row removed — a report-assembly property,
+> not a double-entry posting one; migrated to `reporting`, migration closeout
 > wave 2, #1663 — see below.)*
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC2.16.3 | The Accounts page shows a warning nudge (with a CTA that opens the guided flow) when opening balances are missing, and hides it once they are recorded | `AC2.16.3 shows a readiness nudge and opens the modal when opening balances are missing`, `AC2.16.3 hides the readiness nudge when opening balances are already recorded` | `apps/frontend/src/__tests__/accountsPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC2.16.3 removed, canonical: migrated to the `ledger` package roadmap as `AC-ledger.fe-accounts2.3`, #1821 Wave B)
 
 > **Migrated**: the balance sheet and net-worth allocation confidence-tier
 > degrade (was the AC2.16 group's reporting-layer row) is report assembly,

--- a/docs/project/EPIC-004.reconciliation-engine.md
+++ b/docs/project/EPIC-004.reconciliation-engine.md
@@ -163,7 +163,7 @@ See: common/ledger/readme.md#decimal-rule
 
 | AC | Acceptance Criteria | Test(s) | File(s) | Priority |
 |----|--------------------|---------|---------|----------|
-| AC4.11.1 | The unmatched transaction board models unmatched amounts as shared `MoneyValue` payloads and renders queue/detail/created-entry amounts through Decimal-safe currency formatting, not JavaScript number locale formatting | `AC4.11.1 renders unmatched monetary amounts with Decimal-safe currency formatting` | `frontend/src/__tests__/unmatchedBoardComponent.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC4.11.1 removed, canonical: migrated to the `reconciliation` package roadmap as `AC-reconciliation.fe-remainder-reconciliation.1`, #1821 Wave B)
 
 ## 📏 Acceptance Criteria
 

--- a/docs/project/EPIC-008.testing-strategy.md
+++ b/docs/project/EPIC-008.testing-strategy.md
@@ -268,9 +268,10 @@ job inventories or scenario counts into this EPIC.
 > - (AC8.13.18 removed and AC8.13.19 removed — reporting-owned brokerage
 >   portfolio valuation semantics, migrated to the reporting bucket, #1716 /
 >   #1821.)
-> - AC8.13.48, AC8.13.76, AC8.13.82, AC8.13.90, AC8.13.92 are frontend-only
->   (Vitest/Playwright proofs); the package governance gate resolves Python
->   tests only, so they stay EPIC-owned for the #1719 frontend remainder.
+> - The five frontend-only (Vitest/Playwright) coverage/deploy-metadata rows
+>   in this group migrated to `testing`/`runtime` in #1821 Wave B once
+>   #1820/#1825 gave the governance gate TS test-ref resolution (see the
+>   migration note below).
 > - AC8.13.61 - AC8.13.63 are archive-residual ownership rows whose proofs
 >   assert EPIC-008 residency by design (and AC8.13.61 is P3, which the
 >   package `ACRecord` priority vocabulary does not carry); they are
@@ -284,16 +285,11 @@ job inventories or scenario counts into this EPIC.
 > `reporting` package roadmap as `AC-reporting.portfolio-valuation-gate.1-2`,
 > #1821 Wave A.)
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC8.13.48 | Frontend gap tests cover route, component, and API helper paths so frontend LCOV line coverage reaches 99% | `test_AC8_13_48_*` | `apps/frontend/src/__tests__/stage2ReviewQueueCoverage99.test.tsx`, `apps/frontend/src/__tests__/statementReviewPage.coverage.test.tsx`, `apps/frontend/src/__tests__/statementDetailPage.coverage.test.tsx`, `apps/frontend/src/__tests__/StatementUploader.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/reconciliationWorkbenchComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx`, `apps/frontend/src/__tests__/apiFunctions.test.ts`, `apps/frontend/src/__tests__/accountsPage.test.tsx`, `apps/frontend/src/__tests__/assetsPage.test.tsx`, `apps/frontend/src/__tests__/statementsPage.test.tsx`, `apps/frontend/src/__tests__/useWorkspaceHook.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.confidenceAndAiQueue.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.netWorthTimeSeries.test.tsx`, `apps/frontend/src/__tests__/uiGapAudit.processingVisibility.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC8.13.48 removed and AC8.13.76 removed and AC8.13.82 removed and AC8.13.92 removed, canonical: migrated to the `testing` package roadmap as `AC-testing.fe-coverage.1` through `.4`, #1821 Wave B)
 | AC8.13.61 | Visual regression residual is explicitly owned by EPIC-008 as a P3 future testing capability | `test_AC8_13_61_visual_regression_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P3 | <!-- epic-owned: horizontal -->
 | AC8.13.62 | Test observability residuals are explicitly owned by EPIC-008 with current replacements and future dashboard/notification/trend scope | `test_AC8_13_62_test_observability_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P2 | <!-- epic-owned: horizontal -->
 | AC8.13.63 | Performance testing residual is explicitly owned by EPIC-008 with current Locust/staging coverage and future P95 trend gate scope | `test_AC8_13_63_performance_testing_residual_is_epic_owned` | `tests/tooling/test_archive_residual_epic_ownership.py` | P2 | <!-- epic-owned: horizontal -->
-| AC8.13.76 | Playwright mobile UX coverage proves Stage 1 and Stage 2 review workflows avoid document-level horizontal scroll and expose direct completion actions at phone widths | `AC16.26.*` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC8.13.82 | Playwright responsive UX coverage proves account and review layouts avoid mobile document overflow and desktop local table clipping (AC16.27.2 removed and AC16.27.3 removed, canonical: the same shared spec also proves `AC-extraction.fe-stage1-review.11` and `AC-reconciliation.fe-stage2-review.17`, #1821 Wave B) | `AC2.17.1` | `apps/frontend/playwright/mobile-ux.spec.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC8.13.90 | Frontend exposes `/frontend-version.json` with deployed `git_sha`/`version` metadata for PR preview readiness checks | `AC8.13.90 returns deployed frontend version metadata for PR preview readiness` | `frontendVersionRoute.test.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC8.13.92 | Frontend Vitest coverage keeps a code-owned 98% baseline for line, statement, and function metrics plus an explicit branch floor while representative low-coverage routes and workflow surfaces stay covered | `AC8.13.92*` | `apps/frontend/src/__tests__/coverageBaseline.test.ts`, `apps/frontend/src/__tests__/personalReportPackagePage.test.tsx`, `apps/frontend/src/__tests__/workflowSurfaces.test.tsx`, `apps/frontend/src/__tests__/chatPanelComponent.test.tsx`, `apps/frontend/src/__tests__/investmentPerformanceSchedule.test.tsx`, `apps/frontend/src/__tests__/journalPage.test.tsx`, `apps/frontend/src/__tests__/sankeyChartComponent.test.tsx`, `apps/frontend/src/__tests__/toastProviderComponent.test.tsx`, `apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC8.13.90 removed, canonical: migrated to the `runtime` package roadmap as `AC-runtime.fe-deploy.1`, #1821 Wave B)
 > (AC8.13.164 removed and AC8.13.165 removed, canonical: migrated to the `llm`
 > package roadmap as `AC-llm.evidence-bundle.1-2` — routed to `llm` not
 > `testing` because the authority classifier bands
@@ -547,9 +543,7 @@ ACs require each control to carry a distinct, stable test hook and require the
 registration E2E to target the mode toggle unambiguously, with no visible-copy
 regression.
 
-| AC ID | Test Case | Test Function | File | Priority |
-|---|---|---|---|---|
-| AC8.19.1 | Login auth controls (mode-toggle register button and inline register CTA) expose distinct `data-testid` hooks and accessible names, so no duplicate accessible-name ambiguity remains while the visible text stays "Register" | `AC8.19.1 login register controls expose distinct test ids and accessible names` | `apps/frontend/src/__tests__/loginPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC8.19.1 removed, canonical: migrated to the `identity` package roadmap as `AC-identity.fe-auth2.2`, #1821 Wave B)
 
 > This group's second row removed — migrated to the `identity` package
 > roadmap as `AC-identity.journeys.5` (migration closeout continuation,
@@ -734,7 +728,7 @@ Product E2E ownership index:
 | `tests/e2e/test_e2e_flows.py` | Deployed extended flow E2E; AC references live in the test file |
 | `tests/e2e/test_four_asset_net_worth_golden_path.py` | Critical proof: AC-testing.product-gates.7, AC-extraction.813.10, AC-reporting.net-worth-timeseries.2, AC-pricing.manualvaluation.5, AC-pricing.manualvaluation.6, AC-pricing.manualvaluation.7, AC-portfolio.valuation.1 |
 | `tests/e2e/test_llm_provider_abstraction_epic023.py` | LLM provider abstraction product owner E2E; EPIC-023 / AC23.1 references live in the test file |
-| `tests/e2e/test_frontend_observability_epic024.py` | EPIC-024 frontend browser observability product owner E2E; AC24.1.1 reference lives in the test file |
+| `tests/e2e/test_frontend_observability_epic024.py` | EPIC-024 frontend browser observability product owner E2E |
 | `tests/e2e/test_market_data_price_paths.py` | Critical proof; ACs live in the `pricing` package roadmap (`AC-pricing.marketdata.7`, `AC-pricing.marketdata.11`, `common/pricing/contract.py`) |
 | `tests/e2e/test_personal_financial_report_package.py` | Critical proof: AC-reporting.balance-sheet.1, AC-reporting.balance-sheet.4, AC-reporting.income-statement.3, AC-reporting.cash-flow.1, AC-reporting.fe-viz-reports.2, AC-reporting.package-notes.3, AC-reporting.package-traceability.3, AC-reporting.package-traceability.4, AC-reporting.annualized-dashboard.2, AC-pricing.manualvaluation.5, AC-pricing.manualvaluation.6, AC-pricing.manualvaluation.7, AC-reporting.package-annualized.3, AC-reporting.package-annualized.4, AC-portfolio.report-schedule.1, AC-portfolio.report-schedule.2, AC-portfolio.fixtures.1, AC-portfolio.fixtures.2, AC-portfolio.fixtures.3, AC-testing.product-gates.8, AC-testing.product-gates.9, AC-testing.product-gates.10, AC-testing.product-gates.11, AC-testing.product-gates.12 |
 | `tests/e2e/test_production_readonly_smoke.py` | Production-readonly smoke E2E; AC references live in the test file |

--- a/docs/project/EPIC-011.asset-lifecycle.md
+++ b/docs/project/EPIC-011.asset-lifecycle.md
@@ -242,9 +242,7 @@ restricted compensation.
 > package roadmap as `AC-reporting.net-worth-components.1-2`; the frontend
 > row below stays here. Migration closeout continuation, #1663 / #1716.)*
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC11.20.3 | The assets page labels retirement and benefit asset entry options as assets, with insurance represented only by cash value | `test_AC11_20_3_assets_page_surfaces_retirement_and_benefit_asset_labels()` | `apps/frontend/src/__tests__/assetsPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC11.20.3 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.1`, #1821 Wave B)
 
 ### AC11.21-11.24: Valuation Taxonomy Stack (RETIRED — reinvented existing accounting primitives)
 
@@ -292,11 +290,7 @@ generated from the registry and tests, not from checkboxes in this file.
 *(AC11.9.1 removed and AC11.9.2 removed and AC11.9.3 removed and AC11.9.5
 removed, canonical: migrated to the `pricing` package roadmap as
 `AC-pricing.manualvaluation.5-8`, #1821 Wave A)*
-- **AC11.9.4 Frontend Entry**: `/assets` exposes a manual valuation entry form and recent snapshot list using the shared API client. <!-- epic-owned: fe-only -->
-- **AC11.9.6 Guided Evidence Form — required-field validation** ([#706](https://github.com/wangzitian0/finance_report/issues/706)): the shared guided evidence form for the three source classes (`esop_rsu_plan`, `property_statement`, `liability_statement`) blocks submission and shows a readiness blocker when the required `valuation_basis` or `as_of_date` is missing, never calling the API; value is carried as a `Decimal`-safe string with no float math. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.6 *`. <!-- epic-owned: fe-only -->
-- **AC11.9.7 Guided Evidence Form — typed manual-valuation persistence** ([#706](https://github.com/wangzitian0/finance_report/issues/706)): a valid guided evidence submission persists through the existing `POST /api/assets/valuation-snapshots` endpoint via the typed `lib/api.ts` client (never raw `fetch`), mapping the chosen source class to its `component_type`, `valuation_basis`, source label, anchor, and notes, with the monetary `value` sent as a string. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.7 *`. <!-- epic-owned: fe-only -->
-- **AC11.9.8 Manual-trusted disclosure label** ([#706](https://github.com/wangzitian0/finance_report/issues/706)): the guided evidence flow surfaces a clear "Manual-trusted" disclosure badge for manually entered evidence so users and the traceability appendix can see the source-trust state of a value. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.8 *`. <!-- epic-owned: fe-only -->
-- **AC11.9.9 Guided Evidence Form — mobile layout** ([#706](https://github.com/wangzitian0/finance_report/issues/706)): the guided evidence form renders an accessible single-column mobile layout (and the recent-evidence list) when a mobile viewport is reported by `matchMedia`, and degrades gracefully when `matchMedia` is unavailable. Proven by `apps/frontend/src/__tests__/guidedEvidenceForm.test.tsx::AC11.9.9 *`. <!-- epic-owned: fe-only -->
+(AC11.9.4 removed and AC11.9.6 removed and AC11.9.7 removed and AC11.9.8 removed and AC11.9.9 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.2` through `.6`, #1821 Wave B)
 *(AC11.9.10 removed, canonical: migrated to the `pricing` package roadmap as
 `AC-pricing.manualvaluation.9`, #1821 Wave A)*
 
@@ -338,12 +332,9 @@ lists; it must be represented by one of these owners:
 *(AC11.8.1 removed and AC11.8.7 removed, canonical: migrated to the
 `reporting` package roadmap as `AC-reporting.annualized-dashboard.1` and
 `.3`, #1821 Wave A)*
-- [x] **AC11.8.2** Dashboard "Annualized Income" card renders the four annualized figures with the currency code and `as_of` date subtitle <!-- epic-owned: fe-only -->
+(AC11.8.2 removed and AC11.8.4 removed and AC11.8.5 removed and AC11.8.6 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.7` through `.10`, #1821 Wave B)
 *(AC11.8.3 removed, canonical: migrated to the `reporting` package roadmap
 as `AC-reporting.annualized-dashboard.2`, #1821 Wave A)*
-- [x] **AC11.8.4** Dashboard "Restricted Holdings" card lists restricted holdings separated from liquid net worth, with vesting timeline tooltip <!-- epic-owned: fe-only -->
-- [x] **AC11.8.5** Net worth calculation toggle on dashboard (`include_restricted=true|false`) re-fetches and updates total, defaulting to `false` (vision: liquid wealth is primary) <!-- epic-owned: fe-only -->
-- [x] **AC11.8.6** Frontend test mounts AnnualizedIncomeCard and asserts the four metric labels render <!-- epic-owned: fe-only -->
 
 **Priority**: P1 (high) — closes the largest "vision parity" gap after net worth time series.
 **Estimated effort**: 4-6 days backend (income aggregation + restricted-flag schema check) + 3-4 days frontend.

--- a/docs/project/EPIC-012.foundation-libs.md
+++ b/docs/project/EPIC-012.foundation-libs.md
@@ -375,14 +375,12 @@ callers branch on a machine-readable code instead of matching `detail` text.
 > the AC12.27.* rows .1–.2) are owned by, and sourced directly from,
 > [`common/platform/contract.py`](../../common/platform/contract.py)'s `roadmap`
 > as `AC-platform.27.1`–`AC-platform.27.2` (the leading "12" is dropped and the
-> group/seq preserved). The **frontend** row AC12.27.3 stays defined below: its
-> anchor is a `.test.ts` (a vitest `it()`, not a Python `path::func`) and the
-> `platform` package is `fe=None`, so it cannot be homed in the package roadmap
-> (same precedent as the ledger cutover leaving EPIC-002's frontend rows defined).
+> group/seq preserved). The **frontend** row's anchor is a `.test.ts` (a
+> vitest `it()`, not a Python `path::func`), so it could not be homed in the
+> `platform` roadmap (`fe=None`) — #1820/#1825 later gave the governance gate
+> TS test-ref resolution, so it migrated to `meta` instead (below).
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC12.27.3 | Frontend `apiFetch` throws `ApiError` carrying the parsed `errorId` | `test_AC12_27_3_api_error_carries_error_id` | `__tests__/apiErrorStructured.test.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC12.27.3 removed, canonical: migrated to the `meta` package roadmap as `AC-meta.fe-http-client.1`, #1821 Wave B)
 
 ### AC12.28: Generated Frontend API Types from OpenAPI ([#1004](https://github.com/wangzitian0/finance_report/issues/1004))
 
@@ -400,13 +398,12 @@ enforcing the FE↔BE contract instead of leaving the generated client as dead c
 > the AC12.28.* rows .1–.2) are owned by, and sourced directly from,
 > [`common/platform/contract.py`](../../common/platform/contract.py)'s `roadmap`
 > as `AC-platform.28.1`–`AC-platform.28.2` (the leading "12" is dropped and the
-> group/seq preserved). The **frontend** row AC12.28.3 stays defined below: its
-> anchor is a `.test.ts` (a vitest `it()`, not a Python `path::func`) and the
-> `platform` package is `fe=None`, so it cannot be homed in the package roadmap.
+> group/seq preserved). The **frontend** row's anchor is a `.test.ts` (a
+> vitest `it()`, not a Python `path::func`), so it could not be homed in the
+> `platform` roadmap (`fe=None`) — #1820/#1825 later gave the governance gate
+> TS test-ref resolution, so it migrated to `meta` instead (below).
 
-| AC ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC12.28.3 | High-traffic call sites type responses against the generated schema | `test_AC12_28_3_types_stage2_batch_responses_against_generated_schema` | `__tests__/apiTypedClient.test.ts` | P2 | <!-- epic-owned: fe-only -->
+(AC12.28.3 removed, canonical: migrated to the `meta` package roadmap as `AC-meta.fe-http-client.2`, #1821 Wave B)
 
 ### AC12.29: API-Surface Consistency Sweep ([#1099](https://github.com/wangzitian0/finance_report/issues/1099))
 
@@ -660,9 +657,7 @@ Currency was resolved ad-hoc in ≥3 divergent ways (`or "SGD"`, `or settings.ba
 > **Frontend row retained** (below) — same `.test.tsx`/AST-resolver
 > limitation as EPIC-021's frontend rows.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC12.39.3 | The frontend General Settings page exposes a "Base currency" control that reads + updates the effective value via `lib/api.ts` (`fetchBaseCurrency`/`updateBaseCurrency`, never raw `fetch`) {tier:CODE-ONLY} | `AC12.39.3 renders the effective base currency`, `AC12.39.3 submits the edited currency via updateBaseCurrency` | `apps/frontend/src/__tests__/generalSettingsPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC12.39.3 removed, canonical: migrated to the `pricing` package roadmap as `AC-pricing.fe-settings.1`, #1821 Wave B)
 
 ### AC12.40: Currency established at ingest, never silent-defaulted — Phase E ([#1341](https://github.com/wangzitian0/finance_report/issues/1341))
 

--- a/docs/project/EPIC-015.processing-account.md
+++ b/docs/project/EPIC-015.processing-account.md
@@ -308,24 +308,20 @@ assert abs(assets - liabilities_equity) < Decimal("0.01")  # ✅ PASSED
 
 *(AC15.7.1 removed, canonical: migrated to the `ledger` package roadmap as
 `AC-ledger.processing.1`, #1821 Wave A)*
-- [x] **AC15.7.2** Dashboard "Processing / In-Transit" card renders the four fields with currency code <!-- epic-owned: fe-only -->
-- [x] **AC15.7.3** Card click-through navigates to `/processing` listing pending transfers (existing or new page) with line items `{from_account, to_account, amount, initiated_date, days_outstanding}` <!-- epic-owned: fe-only -->
-- [x] **AC15.7.4** Pending entries older than 7 days render a warning badge on the listing row <!-- epic-owned: fe-only -->
-- [x] **AC15.7.5** Frontend test mounts ProcessingSummaryCard and asserts `pending_count` + `pending_total` labels render <!-- epic-owned: fe-only -->
-- [x] **AC15.7.6** Processing is discoverable as a card in the Audit hub at `/audit` (superseded the old sidebar entry per EPIC-022's bottom-tab Audit hub) <!-- epic-owned: fe-only -->
-- [x] **AC15.7.7** The Processing Account non-zero-balance warning surfaces on the Home Processing card (AC15.7.8) and the attention inbox; the old sidebar badge was removed with the Advanced drawer (EPIC-022 AC22.21) <!-- epic-owned: fe-only -->
-- [x] **AC15.7.8** Dashboard Processing card shows the signed current balance and a non-zero balance warning <!-- epic-owned: fe-only -->
+(AC15.7.2 removed and AC15.7.3 removed and AC15.7.4 removed and AC15.7.5 removed and AC15.7.6 removed and AC15.7.7 removed, canonical: migrated to the `ledger` package roadmap as `AC-ledger.fe-processing.1` through `.6`, #1821 Wave B — AC15.7.6/AC15.7.7 were superseded-in-place by EPIC-022's bottom-tab Audit hub before migration: Processing discoverability moved to `/audit` and its balance warning is carried by the Home Processing card (AC15.7.8) and the attention inbox)
 
-> **AC15.7.6/AC15.7.7 superseded by EPIC-022 AC22.21**: the Advanced sidebar drawer
-> was removed, so Processing discoverability moved to the `/audit` hub and its
-> balance warning is carried by the Home Processing card (AC15.7.8) and the
-> attention inbox. Rows kept for history with Verification updated to current tests.
+> **Documented exception (#1821 Wave B):** AC15.7.8 stays EPIC-owned rather
+> than migrating. This EPIC's `decision-5-processing-account` Vision Anchor
+> is owned solely by EPIC-015 (`check_ac_index.py`'s `_vision_obligations`
+> gate), and the vision→registry matrix only resolves EPIC-numbered legacy
+> ids, not package-scoped roadmap ids — migrating every remaining row would
+> orphan the anchor ("backs no AC — dangling vision promise"). One row stays
+> behind to keep it backed, mirroring EPIC-006's `AC6.34.1` exception from
+> Wave A and EPIC-005's `AC5.37.2` from Wave B-2.
 
 | AC ID | Description | Test | Path | Priority |
 |-------|-------------|------|------|----------|
-| AC15.7.6 | Processing is discoverable as a card in the Audit hub (`/audit`), superseding the old sidebar entry | `AC15.7.6 aggregates the verify-on-demand machinery (incl. Processing) as deep-linking cards` | `apps/frontend/src/__tests__/auditHub.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC15.7.7 | The sidebar Processing badge was removed with the Advanced drawer; the non-zero-balance warning is carried by the Home Processing card and attention inbox | `AC15.7.7 ... keeps the accounting machinery, sidebar badges and settings out of the sidebar (supersedes the Advanced drawer)` (shared multi-AC test title; full name in `sidebarAndTabs.test.tsx`) | `apps/frontend/src/__tests__/sidebarAndTabs.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC15.7.8 | Dashboard Processing card shows the signed current balance and a non-zero balance warning | `shows the current Processing Account balance when transfers are unresolved` | `apps/frontend/src/components/__tests__/ProcessingSummaryCard.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+| AC15.7.8 | Dashboard Processing card shows the signed current balance and a non-zero balance warning | `shows the current Processing Account balance when transfers are unresolved` | `apps/frontend/src/components/__tests__/ProcessingSummaryCard.test.tsx` | P1 | <!-- epic-owned: pending-package -->
 
 **Priority**: P0-quick-win — small UI surface; backend already exposes processing-account state.
 **Estimated effort**: 1-2 days backend (summary endpoint) + 2-3 days frontend (card + listing).

--- a/docs/project/EPIC-017.portfolio-management.md
+++ b/docs/project/EPIC-017.portfolio-management.md
@@ -156,13 +156,7 @@ be treated as current work.
 
 ### AC17.8: Brokerage Import Completion UI
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.8.1 | Import to Portfolio button visible for parsed/approved statements | `AC17.8.1 shows Import to Portfolio button for parsed statement` | `frontend/src/__tests__/statementDetailPage.coverage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC17.8.2 | Import result banner with stats and portfolio link shown on success | `AC17.8.2 shows import result banner and portfolio link on success` | `frontend/src/__tests__/statementDetailPage.coverage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC17.8.3 | Import failure shows actionable error without sensitive data | `AC17.8.3 shows actionable import error banner without exposing sensitive data` | `frontend/src/__tests__/statementDetailPage.coverage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC17.8.4 | Portfolio page shows total portfolio value prominently after import | `AC17.8.4 shows total portfolio value banner when active holdings are loaded` | `frontend/src/__tests__/portfolioPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC17.8.5 | Import button hidden for non-parsed/approved statements (partial batch) | `AC17.8.5 does not show Import to Portfolio for non-parsed statements` | `frontend/src/__tests__/statementDetailPage.coverage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC17.8.1 removed and AC17.8.2 removed and AC17.8.3 removed and AC17.8.4 removed and AC17.8.5 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.11` through `.15`, #1821 Wave B)
 
 ### AC17.9: Point-in-Time Portfolio Snapshots
 
@@ -170,9 +164,7 @@ be treated as current work.
 > package roadmap as `AC-portfolio.as-of.1-2`; the frontend row below stays
 > here. Migration closeout continuation, #1663 / #1717.)*
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.9.3 | Portfolio page exposes an as-of date selector and passes it to `/api/portfolio/holdings` | `AC17.9.3 passes selected as-of date to holdings API` | `frontend/src/__tests__/portfolioPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC17.9.3 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.16`, #1821 Wave B)
 
 ### AC17.10: Investment Performance Report Schedule API
 
@@ -247,13 +239,9 @@ net-worth allocation schedule for the allocation surface. The investment
 performance schedule remains the source for period return, unrealized
 market-value gain/loss, and price freshness.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC17.14.1 | Portfolio page renders a unified allocation panel without claiming a portfolio-value tie-out when report and holdings currencies differ | `AC17.14.1 labels allocation and portfolio currencies instead of claiming a portfolio tie-out` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC17.14.1 removed and AC17.14.3 removed and AC17.14.4 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.17` through `.19`, #1821 Wave B)
 > (AC17.14.2 removed, canonical: migrated to the `reporting` package roadmap
 > as `AC-reporting.net-worth-components.3`, #1821 Wave A)
-| AC17.14.3 | Portfolio page consumes the report-owned net-worth allocation schedule, showing asset class, liquidity, source currency, net-worth share, source labels, and restricted-inclusion filtering | `AC17.14.3 renders net-worth allocation from the report schedule`, `AC17.14.3 shows the net-worth allocation loading state`, `AC17.14.3 shows the net-worth allocation error state`, `AC17.14.3 shows the empty net-worth allocation state`, `AC17.14.3 renders invalid net-worth allocation percentages as unavailable`, `AC17.14.3 renders missing net-worth allocation percentages as unavailable`, `AC17.14.3 refetches net-worth allocation when restricted holdings are excluded` | `apps/frontend/src/__tests__/portfolioPage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC17.14.4 | The asset-dashboard performance surface leads with unrealized market-value gain/loss, a simple return on cost valued at the schedule as-of date, and a price-freshness flag; TWR/IRR/MWR are not presented as the asset-dashboard answer and stay on the reporting side as clearly-labelled analytical measures | `AC17.14.4 leads with unrealized gain/loss, return on cost, and price freshness`, `AC17.14.4 does not present TWR/IRR/MWR as the asset-dashboard answer`, `AC17.14.4 flags stale prices`, `AC17.14.4 shows N/A return when cost basis is zero` | `apps/frontend/src/__tests__/performanceCard.test.tsx`, `apps/frontend/src/__tests__/investmentPerformanceSchedule.test.tsx` | P1 | <!-- epic-owned: fe-only -->
 
 ### AC17.15: Non-Ticker Identifier Guard
 
@@ -301,7 +289,7 @@ EPIC-008 remains the owner of the provider-backed staging AI/OCR gate.
 | Concurrent auto parse import and manual statement import share the same deduped position instead of failing with a duplicate-key 500 | EPIC-017 | AC-portfolio.brokerage-import.6 | `test_AC17_4_8_brokerage_import_survives_concurrent_auto_and_manual_import` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
 | Statement-scoped import creates holdings | EPIC-017 | AC-portfolio.brokerage-import.5 / AC-extraction.813.10 | `test_statement_import_flows_to_holdings_and_balance_sheet` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
 | Imported holdings affect balance sheet value | EPIC-005 / EPIC-017 | AC-portfolio.valuation.1 / AC-extraction.813.10 | `test_statement_import_flows_to_holdings_and_balance_sheet` | `apps/backend/tests/portfolio/test_brokerage_position_parsing.py` | Backend shard |
-| User completes import and navigates to portfolio value | EPIC-017 | AC17.8.1 / AC17.8.2 / AC17.8.4 | `AC17.8.1 AC17.8.2 AC17.8.4 completes parsed statement import and portfolio value navigation` | `apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx` | Frontend test |
+| User completes import and navigates to portfolio value | EPIC-017 | AC-portfolio.fe-assets2.11 / `.12` / `.14` | completes parsed statement import and portfolio value navigation (exact title in the package roadmap `test=`) | `apps/frontend/src/__tests__/brokerageImportCompletionFlow.test.tsx` | Frontend test |
 
 Provider-backed gate details live in
 [EPIC-008](EPIC-008.testing-strategy.md#ac813-tier-3-browser-e2e-full-statement-journey) and
@@ -366,12 +354,20 @@ The April 2026 FE/UI audit snapshot was removed from this EPIC. Current portfoli
 
 ### Acceptance Criteria
 
-- [x] **AC17.7.1** Holding detail page `/portfolio/[ticker]` renders three tabs: `Overview`, `Dividends`, `Realized P&L` <!-- epic-owned: fe-only -->
-- [x] **AC17.7.2** Dividends tab lists historical dividend events `{ex_date, pay_date, amount, currency, reinvested}` from `GET /api/portfolio/{ticker}/dividends` <!-- epic-owned: fe-only -->
-- [x] **AC17.7.3** Cost-basis method selector (`FIFO` / `LIFO` / `AvgCost`) on holding detail page persists per-holding via `PATCH /api/portfolio/{ticker}` and re-fetches realized P&L <!-- epic-owned: fe-only -->
-- [x] **AC17.7.4** Realized P&L tab shows lot-level table `{lot_id, acquired_date, sold_date, quantity, basis, proceeds, gain_loss, holding_period}` from `GET /api/portfolio/{ticker}/realized` <!-- epic-owned: fe-only -->
-- [x] **AC17.7.5** Portfolio summary card on dashboard adds `realized_pnl_ytd` and `dividend_income_ytd` figures from `GET /api/portfolio/summary` <!-- epic-owned: fe-only -->
-- [x] **AC17.7.6** Frontend test mounts HoldingDetailPage, switches to Dividends tab, and asserts dividend row labels render <!-- epic-owned: fe-only -->
+(AC17.7.1 removed and AC17.7.2 removed and AC17.7.3 removed and AC17.7.4 removed and AC17.7.5 removed, canonical: migrated to the `portfolio` package roadmap as `AC-portfolio.fe-assets2.20` through `.24`, #1821 Wave B)
+
+> **Documented exception (#1821 Wave B):** AC17.7.6 stays EPIC-owned rather
+> than migrating. This EPIC's `decision-1-portfolio-self-developed` Vision
+> Anchor is owned solely by EPIC-017 (`check_ac_index.py`'s
+> `_vision_obligations` gate), and the vision→registry matrix only resolves
+> EPIC-numbered legacy ids, not package-scoped roadmap ids — migrating every
+> remaining row would orphan the anchor ("backs no AC — dangling vision
+> promise"). One row stays behind to keep it backed, mirroring EPIC-006's
+> `AC6.34.1` exception from Wave A and EPIC-005's `AC5.37.2` from Wave B-2.
+
+| AC ID | Description | Verification | Priority |
+|---|---|---|---|
+| AC17.7.6 | Frontend test mounts HoldingDetailPage, switches to Dividends tab, and asserts dividend row labels render | switches to Dividends tab and renders dividend row labels (shared test title also carries the now-migrated `AC-portfolio.fe-assets2.21`) | `apps/frontend/src/__tests__/holdingDetailPage.test.tsx` | P2 | <!-- epic-owned: pending-package -->
 
 **Priority**: P1 — depends on backend portfolio API delivery; surfaces vision-critical metrics.
 **Estimated effort**: 5-7 days frontend (3 tabs + cost-basis selector + summary additions); backend dividend/realized endpoints tracked in core EPIC-017 scope.

--- a/docs/project/EPIC-018.ai-driven-pipeline.md
+++ b/docs/project/EPIC-018.ai-driven-pipeline.md
@@ -324,9 +324,7 @@ Dependencies: AC18.7 Evidence Graph foundation and AC18.8 first production sourc
 
 | AC ID | Phase | Description |
 |-------|-------|-------------|
-| AC18.9.4 | Evidence navigation UI | The report package traceability surface exposes a lineage panel from at least one report traceability row | <!-- epic-owned: fe-only -->
-| AC18.9.5 | Evidence navigation UI | The lineage panel renders source document, extracted record, atomic fact, ledger entry, ledger line, and report-line anchors when present | <!-- epic-owned: fe-only -->
-| AC18.9.6 | Evidence navigation proof | Tests cover report line to source document navigation and source document to impacted ledger/report navigation | <!-- epic-owned: fe-only -->
+(AC18.9.4 removed and AC18.9.5 removed and AC18.9.6 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.1` through `.3`, #1821 Wave B)
 
 ### AC18.10: Evidence Graph Lazy Materialization and Consistency Guardrails
 
@@ -534,13 +532,11 @@ rather than duplicated.
 
 ### Acceptance Criteria — Phase 5 (Confidence & AI Suggestion UI)
 
-- [x] **AC18.5.1** `<ConfidenceBadge />` component renders `TRUSTED` / `HIGH` / `MEDIUM` / `LOW` pill with consistent color tokens (green / blue / amber / gray) and tooltip explaining source-type priority <!-- epic-owned: fe-only -->
-- [x] **AC18.5.2** ConfidenceBadge mounted on every transaction row in Stage 1 review, Stage 2 listing, and processing-account listing; reads `confidence_tier` from API response <!-- epic-owned: fe-only -->
-- [x] **AC18.5.3** AI Suggestion Review Queue page `/review/ai-suggestions` lists pending AI classifications and AI reconciliation matches in score band 60-84 with `{transaction, suggested_category_or_match, ai_score, ai_reasoning}` <!-- epic-owned: fe-only -->
-- [x] **AC18.5.4** Queue actions: `Accept`, `Reject`, `Edit-then-Accept`; each action calls `POST /api/ai/feedback` with `{suggestion_id, action, corrected_value?}` to feed the feedback loop <!-- epic-owned: fe-only -->
-- [x] **AC18.5.5** Settings page `/settings/ai` exposes toggles for `enable_ai_reconciliation`, `enable_ai_classification`, persisted via `PATCH /api/users/me/settings`; toggle reflects backend feature-flag state on load <!-- epic-owned: fe-only -->
-- [x] **AC18.5.6** Audit Trail panel on transaction detail page lists chronological `{timestamp, actor, action, old_value, new_value}` from `GET /api/transactions/{id}/audit`, including AI-applied changes labeled with actor `ai` <!-- epic-owned: fe-only -->
-- [x] **AC18.5.7** Frontend tests: mount ConfidenceBadge for each tier; mount AI Suggestion Queue and assert Accept/Reject buttons render; mount Settings AI toggles and assert default state matches API <!-- epic-owned: fe-only -->
+(AC18.5.1 removed, canonical: migrated to the `meta` package roadmap as `AC-meta.fe-app-shell2.1`, #1821 Wave B)
+(AC18.5.2 removed, canonical: migrated to the `ledger` package roadmap as `AC-ledger.fe-accounts2.4`, #1821 Wave B)
+(AC18.5.3 removed and AC18.5.4 removed, canonical: migrated to the `reconciliation` package roadmap as `AC-reconciliation.fe-remainder-reconciliation.2` through `.3`, #1821 Wave B)
+(AC18.5.5 removed and AC18.5.7 removed, canonical: migrated to the `llm` package roadmap as `AC-llm.fe-ai-settings2.1` through `.2`, #1821 Wave B)
+(AC18.5.6 removed, canonical: migrated to the `extraction` package roadmap as `AC-extraction.fe-remainder-extraction.1`, #1821 Wave B)
 
 **Priority**: P0 — confidence visibility is a vision-critical trust signal; AI review queue is the human-in-the-loop hinge for the entire AI pipeline.
 **Estimated effort**: 2 days ConfidenceBadge + integration • 4-5 days AI Suggestion Queue • 2 days Settings AI toggles • 2-3 days Audit Trail panel • 1-2 days frontend tests. **Total ~11-14 days frontend**, assumes Phase 1-4 backend endpoints from this EPIC are landed.

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -323,13 +323,8 @@ workflow state exists.
 > roadmap as `AC-platform.32.1-2`, migration closeout continuation, #1663 /
 > #1712)*. The frontend rows below stay with their own owner.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.3.3 | Frontend exposes typed workflow API helpers through `lib/api.ts` for status, events, and lifecycle patching | `workflowApi.test.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC19.3.4 | Header/app-shell badge reflects unread/action-required/blocked counts from the compact workflow API and stays quiet when no attention is needed | `workflowSurfaces.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.3.5 | Event inbox groups events by workflow session timeline, keeps blocked/action-required events prominent, and supports read/archive actions and direct action links | `workflowSurfaces.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.3.6 | Dashboard status feed renders primary state, report readiness, recent automation, blocker/action severity, and an empty no-action state without raw audit-log noise | `workflowSurfaces.test.tsx`, `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.3.7 | Desktop and mobile Playwright smoke covers the workflow badge/inbox/feed without layout overflow | `workflow-notifications.spec.ts` | P0 | <!-- epic-owned: fe-only -->
+(AC19.3.3 removed and AC19.3.4 removed and AC19.3.5 removed and AC19.3.7 removed, canonical: migrated to the `platform` package roadmap as `AC-platform.fe-workflow.1` through `.4`, #1821 Wave B)
+(AC19.3.6 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.4`, #1821 Wave B)
 > (AC19.3.8 removed, canonical: migrated to the `meta` package roadmap as `AC-meta.workflow-events.1`, #1821 Wave A)
 
 ### AC19.4 — Upload-First Entry Surface
@@ -337,24 +332,14 @@ workflow state exists.
 > *(AC19.4.1 removed — migrated to the `platform` package roadmap as
 > `AC-platform.32.3`, migration closeout continuation, #1663 / #1712)*
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.4.2 | The first dashboard viewport renders the upload-to-report workflow home before KPI, chart, and activity content | `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.3 | The dashboard primary CTA follows `workflow.status.next_action.href` and labels upload as the default action when no higher-priority blocker/action exists | `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.4 | Report readiness state and blocker count are visible above secondary dashboard metrics and link to the readiness/report action path | `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.5 | Recent workflow events are visible, grouped by actionability, and routine automation is summarized without dominating the page | `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.6 | Secondary dashboard metric API failure does not hide the workflow home; the analytics section renders an isolated retry/error state | `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.7 | Desktop and mobile Playwright smoke covers the upload-first dashboard entry without layout overflow | `upload-first-dashboard.spec.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC19.4.8 | Workflow status returns cockpit-ready `next_action.label` and `next_action.summary`, routes processing to session history, and routes ready reports directly to `/reports/package` | `test_AC19_2_1_workflow_status_schema_contract`, `test_AC19_2_2_workflow_status_endpoint_returns_priority_summaries`, `workflowSurfaces.test.tsx`, `dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-half -->
+(AC19.4.2 removed and AC19.4.3 removed and AC19.4.4 removed and AC19.4.5 removed and AC19.4.6 removed and AC19.4.7 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.5` through `.10`, #1821 Wave B)
+(AC19.4.8 removed, canonical: migrated to the `platform` package roadmap as `AC-platform.fe-workflow.5`, #1821 Wave B)
 
 ### AC19.5 — Report Readiness and Blocker State
 
 > *(AC19.5.1 removed and AC19.5.2 removed and AC19.5.3 removed and AC19.5.6 removed and AC19.5.7 removed — this group's backend readiness rows migrated to the `reporting` package roadmap as `AC-reporting.readiness.1-5`, migration closeout continuation, #1663 / #1716)*. The frontend rows below stay here.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.5.4 | Personal report package page renders readiness state and blocker links before package section output | `personalReportPackagePage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC19.5.5 | Personal report package page renders non-blocked readiness states without stale blocker cards | `personalReportPackagePage.test.tsx` | P1 | <!-- epic-owned: fe-only -->
+(AC19.5.4 removed and AC19.5.5 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.11` through `.12`, #1821 Wave B)
 
 ### AC19.6 — Navigation Folding And Advanced Drill-Down
 
@@ -387,11 +372,9 @@ before marking US/HK personal reports trusted.
 > migrated, #1719.)* The frontend, IA, and report-readiness rows below stay
 > with their own owners.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.8.4 | Notification drawer and Events page group timestamped events by workflow session, while Upload Pipeline shows only active-session latest state plus recent timeline preview | `workflowSurfaces.test.tsx`, `workflow-notifications.spec.ts`, `upload-first-dashboard.spec.ts` | P0 | <!-- epic-owned: fe-only -->
-| AC19.8.6 | `/chat` is a simple AI utility page with model selector, active conversation, and session-list drawer; it is not labeled AI Settings | `chatPanelComponent.test.tsx`, `ChatPageClient.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC19.8.7 | Report readiness has route-level Playwright smoke coverage before package output | `report-readiness.spec.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC19.8.4 removed, canonical: migrated to the `platform` package roadmap as `AC-platform.fe-workflow.6`, #1821 Wave B)
+(AC19.8.6 removed, canonical: migrated to the `advisor` package roadmap as `AC-advisor.fe-remainder-chat.1`, #1821 Wave B)
+(AC19.8.7 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.13`, #1821 Wave B)
 > (AC19.8.8 removed — backend half migrated to the `reporting` package
 > roadmap as `AC-reporting.readiness.7`, #1821 Wave A. The
 > report-readiness.spec.ts Playwright assertion is not tracked by this
@@ -403,9 +386,7 @@ before marking US/HK personal reports trusted.
 > `AC-reporting.source-trust.1`, migration closeout continuation, #1663 /
 > #1716.)* The frontend row below stays here.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.9.2 | Personal report package page renders a compact source trust summary before detailed package output | `AC19.9.2 renders compact source trust summary before traceability details` | P0 | <!-- epic-owned: fe-only -->
+(AC19.9.2 removed, canonical: migrated to the `reporting` package roadmap as `AC-reporting.fe-remainder-reports.14`, #1821 Wave B)
 
 ### AC19.10 — Typed Package Source Anchors
 
@@ -414,6 +395,16 @@ before marking US/HK personal reports trusted.
 > #1716).
 
 ### AC19.11 — Run-Scoped Stage 2 Review
+
+> **Documented exception (#1821 Wave B):** no frontend test distinctly proves
+> "run-scoped queue and approval endpoints" as its own claim — the cited test
+> title (`AC19.11.1 run review uses run-scoped queue and approval endpoints`)
+> does not exist anywhere in the frontend suite. The closest real evidence
+> (`reviewRunPage.test.tsx`, already migrated as
+> `AC-reconciliation.fe-stage2-review.20-22`) proves general Stage-2 run
+> review behavior but not the run-scoping guarantee specifically — that
+> guarantee is proven server-side by `AC-reconciliation.run-scoped-review.1`.
+> Not migrated to avoid overclaiming.
 
 | AC ID | Description | Verification | Priority |
 |---|---|---|---|
@@ -424,9 +415,7 @@ before marking US/HK personal reports trusted.
 > **Partially migrated.** *(AC19.12.1 removed and AC19.12.2 removed and AC19.12.3 removed and AC19.12.4 removed — this group's backend derivation rows migrated to the `platform` package roadmap as `AC-platform.34.1-4`, migration closeout continuation, #1663 / #1712)*. *(AC19.12.6 removed — a coverage-summary row citing the same tests as .2-.4, a duplicate)*. The
 > frontend row below stays with its own owner.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.12.5 | Dashboard status feed and event inbox render lightweight derived events as user actions while routine/internal details remain collapsed or absent | `workflowSurfaces.test.tsx` | P0 | <!-- epic-owned: fe-only -->
+(AC19.12.5 removed, canonical: migrated to the `platform` package roadmap as `AC-platform.fe-workflow.7`, #1821 Wave B)
 
 ### AC19.13 — Durable Orchestration via Prefect
 
@@ -473,14 +462,10 @@ This slice is UI structure only; it does not introduce new parsers or change
 backend source-trust decisions. Required-source-class coverage remains governed
 independently by AC-extraction.112 over `common/testing/data/source-coverage-matrix.yaml`.
 
-| AC ID | Description | Verification | Priority |
-|---|---|---|---|
-| AC19.15.1 | The Upload page exposes exactly three intake entries — one primary statement uploader (the AI identifies the type; the user never pre-classifies), one CSV import, and one Manual records entry — with no per-source-class checklist | `AC19.15.1 exposes exactly three intake entries: one statement uploader plus CSV and Manual` | P1 | <!-- epic-owned: fe-only -->
-| AC19.15.2 | The CSV import and Manual records entries are folded (collapsed) by default so they stay passive, the retired per-source-class checklist does not return, and the page does not fetch report readiness merely to render intake | `AC19.15.2 keeps secondary intake passive: CSV and Manual folded, no per-class checklist, no readiness fetch` | P1 | <!-- epic-owned: fe-only -->
-| AC19.15.3 {tier:CODE-ONLY} | The primary statement uploader (`kind="statement"`) rejects `.csv` files by extension before setting a selected file, and the CSV import uploader (`kind="csv"`) rejects non-csv files and accepts `.csv` — each intake entry enforces its own kind's file-extension restriction, independent of the shared `all`-kind default | `AC19.15.3 statement uploader rejects csv and csv uploader rejects non-csv, each enforcing its own kind's extensions` | P1 | <!-- epic-owned: fe-only -->
+(AC19.15.1 removed and AC19.15.2 removed and AC19.15.3 removed, canonical: migrated to the `extraction` package roadmap as `AC-extraction.fe-remainder-extraction.2` through `.4`, #1821 Wave B)
 
-Traceability note: AC19.15 is tracked in this EPIC-local product UI table.
-`AC19.15.3` backfills coverage the [finance_report_ui] fix(e2e) #1542 gap exposed:
+Traceability note: `AC-extraction.fe-remainder-extraction.4` backfills
+coverage the [finance_report_ui] fix(e2e) #1542 gap exposed:
 `StatementUploader.test.tsx` only ever rendered the default `kind="all"`, and
 `statementsPage.test.tsx` mocks `StatementUploader` out entirely, so the
 per-kind extension contract that Tier-3 E2E depends on had no unit/component-tier

--- a/docs/project/EPIC-021.application-ai-advisor.md
+++ b/docs/project/EPIC-021.application-ai-advisor.md
@@ -88,13 +88,9 @@ Not owned here:
 
 ### AC21.3: Frontend Advisor Brief and Contextual Next Actions
 
-> *(This group's first row removed — migrated to [`common/advisor/contract.py`](../../common/advisor/contract.py)'s `roadmap` as `AC-advisor.suggestions.3`, migration closeout wave 2, #1663.)* The remaining three rows stay here: they are frontend/E2E tests (`.tsx`/`.spec.ts`), and the governance gate's `_resolve_test()` (AST-based, Python-only) cannot resolve a non-Python test path — same limitation as EPIC-012's `AC12.27.3`/`AC12.28.3`.
+> *(This group's first row removed — migrated to [`common/advisor/contract.py`](../../common/advisor/contract.py)'s `roadmap` as `AC-advisor.suggestions.3`, migration closeout wave 2, #1663.)* The remaining three rows were frontend/E2E tests (`.tsx`/`.spec.ts`); #1820/#1825 later gave the governance gate TS test-ref resolution, so they migrated too (below) instead of staying blocked on the old Python-only limitation.
 
-| ID | Test Case | Test Function | File | Priority |
-|----|-----------|---------------|------|----------|
-| AC21.3.2 | Advisor Brief renders blocked, ready, review-required, and stale-market-data cards with source basis, limitation, and safe internal action links {tier:CODE-ONLY} | `test_AC21_3_2_advisor_brief_renders_structured_cards_and_safe_routes` | `apps/frontend/src/__tests__/advisorBrief.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC21.3.3 | Chat and dashboard surfaces expose contextual Ask AI links that seed a scoped prompt without losing existing chat behavior {tier:CODE-ONLY} | `test_AC21_3_3_chat_panel_renders_contextual_advisor_brief`, `test_AC21_3_3_dashboard_renders_advisor_brief_before_analytics` | `apps/frontend/src/__tests__/chatPanelComponent.test.tsx`, `apps/frontend/src/__tests__/dashboardPage.test.tsx` | P0 | <!-- epic-owned: fe-only -->
-| AC21.3.4 | Advisor Brief keeps desktop and mobile layouts free of horizontal overflow {tier:CODE-ONLY} | `advisor-brief desktop and mobile layouts avoid horizontal overflow` | `apps/frontend/playwright/advisor-brief.spec.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC21.3.2 removed and AC21.3.3 removed and AC21.3.4 removed, canonical: migrated to the `advisor` package roadmap as `AC-advisor.fe-remainder-chat.2` through `.4`, #1821 Wave B)
 
 ## Planned Implementation Slices
 

--- a/docs/project/EPIC-022.everyday-user-ia.md
+++ b/docs/project/EPIC-022.everyday-user-ia.md
@@ -265,7 +265,8 @@ on the low-confidence tail) and **source→ledger→report traceability** — pl
 > look only at the low-confidence tail — so the reason must be legible). The
 > `/events`→`/notifications` dedup that #865 scoped is already handled by a
 > `next.config` redirect (so #865 closed); the residual `/events` page is left in
-> place because it still anchors EPIC-019's AC19.3.5. The cross-surface
+> place because it still anchors EPIC-019's event-inbox-grouping AC (now
+> `AC-platform.fe-workflow.3`). The cross-surface
 > attention return path is handled as a narrow follow-up: attention-origin links
 > carry their source into the destination, and the destination renders an
 > attention-queue return link without changing direct-entry fallbacks.

--- a/docs/project/EPIC-024.frontend-observability.md
+++ b/docs/project/EPIC-024.frontend-observability.md
@@ -1,5 +1,11 @@
 # EPIC-024: Frontend Browser Observability
 
+<!-- epic-file: design-doc -->
+<!-- 0 AC rows by design (#1821 Wave B): every registered AC migrated to the
+     `observability` package roadmap; remaining/future scope for this EPIC
+     is tracked by GitHub issues + the observability package contract, not
+     new EPIC-table rows. -->
+
 > **Status**: 🚧 In Progress
 > **Vision Anchor**: `decision-7-tech-stack`
 > **Owner**: Frontend / Platform
@@ -120,11 +126,7 @@ triaging issues.
 
 ### AC24.1: Browser OTel + OpenPanel Query CLI
 
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC24.1.1 | The browser OTel module is config-gated (complete no-op until `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT` is set), non-blocking, idempotent, and swallows SDK errors so it never throws into the app | `otel.test.ts`, `frontendTelemetry.test.tsx` | P1 | <!-- epic-owned: fe-only -->
-| AC24.1.2 | The PII scrub strips query strings and fragments from captured URLs and drops sensitive attributes (emails, amounts, account numbers) before any span is emitted | `otel.test.ts` | P1 | <!-- epic-owned: fe-only -->
-| AC24.1.3 | Uncaught errors (`window.onerror`) and unhandled promise rejections are captured as span exceptions with a scrubbed page URL | `otel.test.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC24.1.1 removed and AC24.1.2 removed and AC24.1.3 removed, canonical: migrated to the `observability` package roadmap as `AC-observability.fe-telemetry.1` through `.3`, #1821 Wave B)
 > (AC24.1.4 removed, canonical: migrated to the `observability` package roadmap as `AC-observability.openpanel-query.1`, #1821 Wave A)
 
 ### AC24.2: FE Telemetry + Analytics Emission Is Proven by an Automated Test
@@ -137,10 +139,7 @@ endpoint, and the analytics layer actually dispatches an OpenPanel
 event/page-view — both asserted hermetically (collector + OpenPanel stubbed, no
 real the observability backend/OpenPanel contacted).
 
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC24.2.1 | With the OTLP endpoint configured, the real browser OTel exporter emits a span (span actually exported, not merely wired): the vitest proof asserts the span reaches `OTLPTraceExporter.export()`, and the Playwright spec asserts the actual outbound `POST /v1/traces` over the wire; both hermetic against a stubbed collector | vitest `emits a finished browser OTel span to the real OTLP exporter's export() (AC24.2.1)` + Playwright `POST /v1/traces` spec | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 | <!-- epic-owned: fe-only -->
-| AC24.2.2 | With the OpenPanel client id configured, the analytics layer actually dispatches an OpenPanel event/page-view (`window.op('track'\|'screenView', …)` invoked); asserted against a stubbed `window.op`/endpoint so the test is hermetic | `dispatches an OpenPanel event via window.op when configured (AC24.2.2)` | `playwright/telemetry-emission.spec.ts`, `src/__tests__/telemetryEmission.test.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC24.2.1 removed and AC24.2.2 removed, canonical: migrated to the `observability` package roadmap as `AC-observability.fe-telemetry.4` through `.5`, #1821 Wave B)
 
 ---
 

--- a/docs/project/EPIC-025.dry-ssot-simplification.md
+++ b/docs/project/EPIC-025.dry-ssot-simplification.md
@@ -1,5 +1,11 @@
 # EPIC-025: DRY/SSOT Simplification — Reporting, Statements, FE Contracts, Tests
 
+<!-- epic-file: design-doc -->
+<!-- 0 AC rows by design (#1821 Wave B): every registered AC migrated to the
+     `meta` package roadmap (fe-contract-types group); remaining/future scope
+     for this EPIC is tracked by GitHub issues + owning package contracts,
+     not new EPIC-table rows. -->
+
 > **Status**: 🚧 In Progress
 > **Vision Anchor**: `decision-7-tech-stack`
 > **Owner**: Platform / Backend / Frontend
@@ -99,12 +105,11 @@ verifiable.
 
 ### AC25.3 — Frontend contract consolidation
 
-> **Retained** — both rows are `.test.ts` frontend tests; the governance gate's `_resolve_test()` (AST-based, Python-only) cannot resolve a non-Python test path, same limitation as EPIC-012's `AC12.27.3`/`AC12.28.3`.
+> Both rows were `.test.ts` frontend tests; #1820/#1825 later gave the
+> governance gate TS test-ref resolution, so they migrated too (below)
+> instead of staying blocked on the old Python-only limitation.
 
-| ID | Requirement | Test Function | File | Priority |
-|----|-------------|---------------|------|----------|
-| AC25.3.1 | The list-response envelope has a single `ListResponse<T>` definition and the per-entity list responses derive from it; declared OpenAPI-mirrored contract types resolve to a real generated `Schemas[...]` key (drift guard) | `contractTypes drift` | `apps/frontend/src/__tests__/contractTypes.test.ts` | P1 | <!-- epic-owned: fe-only -->
-| AC25.3.2 | `lib/api.ts` is the single raw-`fetch` boundary — no other frontend source module issues a raw `fetch(` call | `contractTypes fetch boundary` | `apps/frontend/src/__tests__/contractTypes.test.ts` | P1 | <!-- epic-owned: fe-only -->
+(AC25.3.1 removed and AC25.3.2 removed, canonical: migrated to the `meta` package roadmap as `AC-meta.fe-contract-types.1` through `.2`, #1821 Wave B)
 
 ### AC25.4 — Test fixture consolidation
 

--- a/docs/ssot/epic-residue-baseline.json
+++ b/docs/ssot/epic-residue-baseline.json
@@ -3,17 +3,13 @@
   "version": 1,
   "files": {
     "EPIC-001.phase0-setup.md": {
-      "fe-only": 1,
       "horizontal": 1
     },
-    "EPIC-002.double-entry-core.md": {
-      "fe-only": 3
-    },
+    "EPIC-002.double-entry-core.md": {},
     "EPIC-003.statement-parsing.md": {
       "pending-package": 3
     },
     "EPIC-004.reconciliation-engine.md": {
-      "fe-only": 1,
       "horizontal": 2
     },
     "EPIC-005.reporting-visualization.md": {
@@ -26,52 +22,42 @@
       "horizontal": 31
     },
     "EPIC-008.testing-strategy.md": {
-      "fe-only": 6,
       "horizontal": 3
     },
     "EPIC-010.observability-logging.md": {},
     "EPIC-011.asset-lifecycle.md": {
-      "fe-only": 10,
       "pending-package": 1
     },
     "EPIC-012.foundation-libs.md": {
-      "fe-only": 3,
       "horizontal": 6
     },
     "EPIC-013.statement-parsing-v2.md": {},
     "EPIC-014.ttd-transformation.md": {},
     "EPIC-015.processing-account.md": {
-      "fe-only": 10
+      "pending-package": 1
     },
     "EPIC-016.two-stage-review-ui.md": {
       "fe-only": 4,
       "horizontal": 1
     },
     "EPIC-017.portfolio-management.md": {
-      "fe-only": 15
+      "pending-package": 1
     },
     "EPIC-018.ai-driven-pipeline.md": {
-      "fe-only": 10,
       "pending-package": 6
     },
     "EPIC-019.event-driven-upload-to-report-ux.md": {
-      "fe-half": 2,
-      "fe-only": 21
+      "fe-half": 1
     },
     "EPIC-020.framework-aware-personal-reporting.md": {},
     "EPIC-021.application-ai-advisor.md": {
-      "fe-only": 3,
       "horizontal": 1
     },
     "EPIC-022.everyday-user-ia.md": {},
     "EPIC-022.pwa-bottom-tab-ia.design.md": {},
     "EPIC-023.llm-provider-abstraction.md": {},
-    "EPIC-024.frontend-observability.md": {
-      "fe-only": 5
-    },
-    "EPIC-025.dry-ssot-simplification.md": {
-      "fe-only": 2
-    },
+    "EPIC-024.frontend-observability.md": {},
+    "EPIC-025.dry-ssot-simplification.md": {},
     "EPIC-026.ac-authority-tiers.md": {
       "horizontal": 1
     }


### PR DESCRIPTION
## Summary

Wave B-3 of #1821 (Package-ization 2/4, parent #1819) — the final PR of this migration. Moves the mechanically-provable subset of the remaining 13 EPIC files' `<!-- epic-owned: fe-only|fe-half -->` rows into their owning package `contract.py` roadmaps: EPIC-001, EPIC-002, EPIC-004, EPIC-008, EPIC-011, EPIC-012, EPIC-015, EPIC-017, EPIC-018, EPIC-019, EPIC-021, EPIC-024, EPIC-025. Same atomic ritual as Wave B-1/B-2. This closes the fe-only/fe-half category of the EPIC-residue burndown started in #1719.

**88 of 92 rows migrated** into **88 new ACRecords** across 14 packages: `portfolio` (25), `reporting` (14), `ledger` (11), `platform` (7), `advisor` (4), `extraction` (4), `testing` (4), `observability` (5), `identity` (2), `meta` (5), `llm` (2), `reconciliation` (3), `pricing` (1), `runtime` (1).

**No rows deleted as duplicates**, but one data-quality defect fixed in-flight: EPIC-015's `AC15.7.6`/`.7`/`.8` each had **two** physical marked rows (a checkbox summary and a detailed table, both `epic-owned: fe-only`) — consolidated into one migration each using the table version's real per-file test citations as the canonical proof.

### 3 documented exceptions

- **`AC17.7.6`** (EPIC-017) and **`AC15.7.8`** (EPIC-015): each EPIC's Vision Anchor (`decision-1-portfolio-self-developed`, `decision-5-processing-account`) is owned solely by that EPIC. Migrating every remaining row would orphan the anchor ("backs no AC — dangling vision promise") since the vision→registry matrix (`generate_vision_proof_matrix.py`) only resolves EPIC-numbered legacy ids, not package-scoped roadmap ids. One row per file stays behind (residue marker changed to `pending-package`) to keep the anchor backed — same pattern as EPIC-006's `AC6.34.1` (Wave A) and EPIC-005's `AC5.37.2` (Wave B-2).
- **`AC19.11.1`** (EPIC-019): the cited test title does not exist anywhere in the frontend suite. The closest real evidence (`reviewRunPage.test.tsx`, already migrated as `AC-reconciliation.fe-stage2-review.20-22`) proves general Stage-2 run review behavior but not the run-scoping guarantee specifically — that's proven server-side by the already-migrated `AC-reconciliation.run-scoped-review.1`. Not migrated to avoid overclaiming.

### Package assignment rationale

Domain-obvious in most cases: portfolio/asset UI rows (EPIC-011, EPIC-017) → `portfolio`; Processing Account UI (EPIC-015) → `ledger` (matching its already-migrated Wave-A backend half); accounts/journal UI (EPIC-002, part of EPIC-018) → `ledger`; workflow/event-inbox rows (EPIC-019) → `platform` (matching its Wave-A backend half); dashboard-surface rows (EPIC-019) → `reporting`; AI-suggestion-queue rows (EPIC-018) → `reconciliation`; Settings/AI-toggle rows (EPIC-018) → `llm`; coverage/QA infra rows (EPIC-008) → `testing`; deploy-metadata row (EPIC-008) → `runtime`; telemetry rows (EPIC-024) → `observability`; generic HTTP-client/contract-type rows (EPIC-012, EPIC-025) → `meta`, extending Wave B-1/B-2's `fe-http-client` group where the same generic capability recurs.

### Fallout in other EPIC files

Fixed 12 stale prose cross-references broken by this migration across EPIC-001, EPIC-002 (5 mentions), EPIC-008 (2), EPIC-012 (2), EPIC-017 (2), EPIC-019 (2), EPIC-021, EPIC-022, and EPIC-025 — all bare legacy-id mentions reworded to describe without citing a now-dead id (package-scoped ids resolve fine in the registry and don't need this treatment — only bare legacy `ACx.y.z` mentions do). Also cleaned up 21 now-empty markdown table headers (header + separator with no data rows left) directly caused by this PR's row deletions.

### File-count ratchet

**EPIC-002, EPIC-024, and EPIC-025 reach zero residue rows** — each kept as a `<!-- epic-file: design-doc -->` delivered design record (matching EPIC-010/013/014/020 precedent), not deleted: each still carries substantial narrative/design content (600, 163, and 209 lines respectively) beyond its now-migrated AC tables.

### Census

`docs/ssot/epic-residue-baseline.json`: EPIC-001 `fe-only` 1→0 (`horizontal:1` stays); EPIC-002 `fe-only` 3→0 (file empty, design-doc); EPIC-004 `fe-only` 1→0 (`horizontal:2` stays); EPIC-008 `fe-only` 6→0 (`horizontal:3` stays); EPIC-011 `fe-only` 10→0 (`pending-package:1` stays, unrelated Wave-A residue); EPIC-012 `fe-only` 3→0 (`horizontal:6` stays); EPIC-015 `fe-only` 10→0, `pending-package` 0→1 (`AC15.7.8` exception); EPIC-017 `fe-only` 15→0, `pending-package` 0→1 (`AC17.7.6` exception); EPIC-018 `fe-only` 10→0 (`pending-package:6` stays, unrelated Wave-A residue); EPIC-019 `fe-half` 2→1 (`AC19.11.1` exception), `fe-only` 21→0; EPIC-021 `fe-only` 3→0 (`horizontal:1` stays); EPIC-024 `fe-only` 5→0 (file empty, design-doc); EPIC-025 `fe-only` 2→0 (file empty, design-doc).

This closes out #1821's fe-only/fe-half category: every EPIC file's `fe-only`/`fe-half` residue is now either migrated or a documented, individually-justified exception (5 total across all of Wave B: EPIC-016 ×4, EPIC-005 ×1 already landed in B-1/B-2, plus this PR's EPIC-015/EPIC-017/EPIC-019 ×3).

## Verification

- `tests/tooling/test_epic_residue_ratchet.py`: 4/4 passed.
- `tools/generate_ac_registry.py`, `tools/check_ac_index.py` (INTEGRITY 2044 nodes + PROTECTION, no regression), `tools/check_epic_package_dual.py`, `tools/check_package_contract.py` (all 16 packages OK) — all green.
- `tools/lint_doc_consistency.py`: green (0 violations after the cross-reference fixes).
- `apps/backend/.venv/bin/ruff check` / `ruff format --check` (pinned), scoped to this PR's touched Python files: clean.
- `tools/preflight.py --tier=static`: 3/4 diff gates green. One pre-existing/environmental red declared: `ssot-ownership` (uninitialized `repo/` submodule in this worktree — same condition Wave A/B-1/B-2 declared).
- Rebased onto `main` @ `62a1f961` (post Wave B-2 merge) via `git rebase --onto` before push; all gates re-verified after rebase with zero registry diff.

Constraints honored: dual gate green; no AC's standard lowered; both vision-anchor exceptions documented with the same rigor as Wave A/B-2's precedent; horizontal/pending-package rows outside this PR's scope untouched; `MANIFEST.yaml`/`CLAUDE.md`/`vision.md` untouched.

Refs #1821, #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
