### PR TITLE
[finance_report_audit] fix: sweep #1416/#1819 closeout drift — dead gates + stale docs

### DIFF
--- a/.claude/agents/oracle.md
+++ b/.claude/agents/oracle.md
@@ -10,11 +10,12 @@ You are invoked for the hard problems — design trade-offs, cross-system bugs,
 correctness/consistency reasoning — where careful thinking is worth the cost.
 
 Ground every recommendation in this project's actual constraints. Before
-advising, read the relevant code and the governing SSOT (`docs/ssot/`), vision
-(`vision.md`), and red lines (`docs/agents/red-lines.md`). Honor the project's
-non-negotiables: Decimal (never float) for money with `to_money()` banker's
-rounding; append-only fact versioning (Axiom A); SSOT-first; EPIC → AC → test →
-code → doc.
+advising, read the relevant code and the governing contracts (each concept's
+owning package `readme.md` / `contract.py`, routed by
+`common/meta/data/MANIFEST.yaml`), vision (`vision.md`), and red lines
+(`docs/agents/red-lines.md`). Honor the project's non-negotiables: Decimal
+(never float) for money with `to_money()` banker's rounding; append-only fact
+versioning (Axiom A); SSOT-first; contract → AC → test → code → doc.
 
 Operating rules:
 - Read-only and advisory. NEVER edit or write files; produce a recommendation the

--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -52,7 +52,7 @@ not contend with the operator's machine).
 | `.env*` | `check_env_keys.py` |
 | `apps/backend/*.py` | `ruff check` + `ruff format --check` |
 | `apps/backend/src/config.py` | `generate_env_reference.py --check` (.env.example / env-reference drift) |
-| `apps/backend/src/services/*.py` | `test_transaction_boundaries.py` |
+| `apps/backend/src/extraction/extension/statement_*.py` | `test_transaction_boundaries.py` |
 | `tools/*`, `common/*` | `pytest tests/tooling/` (tool-wrapper sys.path contract + dispatchers) |
 | `apps/frontend/*` | `npm run lint` + `npm run test:coverage` + `npm run build` |
 

--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ migration path is tracked in
 | Resource | Purpose |
 |---|---|
 | [vision.md](vision.md) | Decision filter and long-term direction |
-| [docs/project/](docs/project/) | EPIC documents and project audits |
-| [docs/ssot/](docs/ssot/) | Rationale docs, code-owner links, proof references |
+| [docs/project/](docs/project/) | EPIC documents (terminal residue) and project audits |
+| [common/meta/data/MANIFEST.yaml](common/meta/data/MANIFEST.yaml) | Concept ownership registry — routes to each owning package's `readme.md` / `contract.py` |
 | `python tools/analyze_test_ac_coverage.py --no-write --stdout` | Live local AC-to-test coverage report |
 | [docs/agents/](docs/agents/) | Agent workflow and red-line rules |
 

--- a/apps/backend/src/advisor/extension/app_reads.py
+++ b/apps/backend/src/advisor/extension/app_reads.py
@@ -1,12 +1,14 @@
-"""Injection ports for reads whose owners still live in the app remainder.
+"""Injection ports for reads across a domain boundary the app-boundary gate forbids.
 
-The advisor's bounded read context includes two facts whose owning domain has
-not physically migrated out of ``apps/backend/src/services/`` yet:
+The advisor's bounded read context includes two facts no longer reachable by
+a direct import now that ``apps/backend/src/services/`` is deleted (#1610):
 
-* the observed-FX-pair composer — ``services/market_data_scheduler.py``
-  (cross-domain delivery-layer composition; #1610 absorbs it);
+* the observed-FX-pair composer — ``src.composition.observed_fx_pairs``
+  (cross-domain delivery-layer composition, re-homed from the deleted
+  ``services/market_data_scheduler.py`` to the composition root);
 * windowed FX conversion (used by the annualized-income schedule) —
-  ``services/fx.py`` (also #1610).
+  ``src.pricing.extension.fx.convert_amount`` (pricing's published surface,
+  re-homed from the deleted ``services/fx.py``).
 
 (The reporting summary trio, report-package readiness, and the income bucket
 classifier were originally ported here too, but #1666 folded their owner —
@@ -14,14 +16,12 @@ classifier were originally ported here too, but #1666 folded their owner —
 this PR was in flight; the advisor now imports them directly from that root
 instead, so those three ports were removed.)
 
-A carved package may not import ``src.services.*`` (the app-boundary gate is
-shrink-only), so these two reads are inverted the same way #1676 inverted
-``platform → report_readiness``: the package exposes module-scoped provider
-slots, and the composition root (``src/main.py`` — L4, allowed to import
-everything) wires the real functions at startup; tests wire them via the
-autouse fixture in ``apps/backend/tests/conftest.py``.  When #1610 lands,
-each port collapses into a direct published-root import plus a
-``depends_on`` edge.
+``advisor`` may not import ``src.composition`` or ``src.pricing.*`` directly
+(the app-boundary gate is shrink-only), so these two reads are inverted the
+same way #1676 inverted ``platform → report_readiness``: the package exposes
+module-scoped provider slots, and the composition root (``src/main.py`` —
+L4, allowed to import everything) wires the real functions at startup; tests
+wire them via the autouse fixture in ``apps/backend/tests/conftest.py``.
 """
 
 from __future__ import annotations

--- a/apps/backend/tests/infra/test_transaction_boundaries.py
+++ b/apps/backend/tests/infra/test_transaction_boundaries.py
@@ -16,7 +16,10 @@ from src.pricing.extension import market_data
 from src.pricing.orm.market_data import FxRate, StockPrice
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
-SERVICE_ROOT = PROJECT_ROOT / "apps" / "backend" / "src" / "services"
+# statement_parsing.py / statement_parsing_supervisor.py / statement_workflow.py
+# moved out of the deleted src/services/ into extraction (#1610/#1666); this
+# scan follows them so the boundary gate stays live instead of scanning zero files.
+SERVICE_ROOT = PROJECT_ROOT / "apps" / "backend" / "src" / "extraction" / "extension"
 PRICING_ROOT = PROJECT_ROOT / "apps" / "backend" / "src" / "pricing"
 
 ALLOWED_SERVICE_COMMIT_BOUNDARIES = {

--- a/common/testing/change_classifier.py
+++ b/common/testing/change_classifier.py
@@ -231,7 +231,6 @@ STAGING_AI_OCR_PREFIXES = (
     # its chat path is provider-backed, so it stays a staging AI-OCR trigger.
     "apps/backend/src/advisor",
     "apps/backend/src/extraction",
-    "apps/backend/src/services/statement",
     "apps/backend/src/routers/ai",
     "apps/backend/src/routers/statements",
     "common/testing/fixtures/pdf/data/",

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -166,7 +166,7 @@ CHECKS: tuple[Check, ...] = (
     ),
     Check(
         name="transaction-boundary",
-        globs=("apps/backend/src/services/*.py",),
+        globs=("apps/backend/src/extraction/extension/statement_*.py",),
         commands=(
             (
                 PY,

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -38,9 +38,13 @@ class TestSelectChecks:
         assert "taxonomy-drift" in names
 
     def test_service_edit_selects_format_and_transaction_boundary(self):
+        # apps/backend/src/services/ is retired (#1610/#1666); the watched
+        # commit-boundary files live under extraction/extension/ now.
         names = [
             c.name
-            for c in preflight.select_checks(["apps/backend/src/services/foo.py"])
+            for c in preflight.select_checks(
+                ["apps/backend/src/extraction/extension/statement_parsing.py"]
+            )
         ]
         assert "backend-format" in names
         assert "transaction-boundary" in names

--- a/vision.md
+++ b/vision.md
@@ -271,4 +271,5 @@ owners:
 - **Agent process & governance** → `AGENTS.md` and `docs/agents/`.
 
 Vision changes should be rare and directional. Implementation belongs in
-EPIC -> AC -> test, or in code-owned contracts referenced by `docs/ssot/`.
+contract -> AC -> test, in each concept's owning package `readme.md` /
+`contract.py` routed by `common/meta/data/MANIFEST.yaml`.


### PR DESCRIPTION
## Summary
- End-to-end audit of the #1416 package-model migration (and its #1819 successor, closed 2026-07-14) found 7 stale references to paths physically retired by the migration (`docs/ssot/`, `apps/backend/src/services/`).
- Two of these were **live gates gone silently vacuous**: `common/testing/preflight.py`'s `transaction-boundary` glob and `change_classifier.py`'s AI-OCR staging-trigger prefix both watched a directory that no longer exists, so they could never trigger. Repointed both to `apps/backend/src/extraction/extension/` (where `statement_parsing.py` / `statement_parsing_supervisor.py` / `statement_workflow.py` actually live now, per #1610/#1666) and repointed `test_transaction_boundaries.py`'s `SERVICE_ROOT` the same way — verified the broadened scan surfaces zero new undocumented commit-boundary sites (all 8 `commit()` calls in that directory already match `ALLOWED_SERVICE_COMMIT_BOUNDARIES`).
- The rest are stale doc/docstring references: `.claude/agents/oracle.md`, `README.md`, `vision.md` (dead `docs/ssot/` mentions/links, replaced with the current per-package `readme.md`/`contract.py` routing via `common/meta/data/MANIFEST.yaml`), `.opencode/skills/domain/preflight/SKILL.md` (doc table sync), and `apps/backend/src/advisor/extension/app_reads.py` (docstring named `services/fx.py`/`services/market_data_scheduler.py` as still-live; neither exists — fx moved to `pricing.extension.fx`, the FX-pair composer to `src.composition`).
- `tests/tooling/test_preflight.py` had a test hardcoding the retired `services/foo.py` glob mapping — updated to the new path.

## Test plan
- [x] `pytest tests/infra/test_transaction_boundaries.py -q` — 4/4 pass with the repointed `SERVICE_ROOT`
- [x] `pytest tests/tooling/test_preflight.py -q` — 38/38 pass with the updated fixture
- [x] `tools/preflight.py --tier=full --base main` — all 5 relevant gates green (doc-consistency, taxonomy-drift, backend-format, tooling [2120 passed], app-boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)