### PR TITLE
[finance_report_ui] feat(runtime): expose required_for(tier) as a machine-readable SLA manifest (#1654)

### DIFF
--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -1162,6 +1162,43 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        # ── group sla-manifest: prod-required = SLA-bearing, machine-readably
+        # exposed for infra2's periodic report (2026-07-07 decision, #1654,
+        # finance_report#1851 G2) ──
+        ACRecord(
+            id="AC-runtime.sla-manifest.1",
+            statement=(
+                "`tools/generate_sla_manifest.py` derives "
+                "`common/runtime/sla-manifest.generated.json` from "
+                "`DEPENDENCY_MANIFEST.required_for(tier)` for every tier; the "
+                "committed artifact is byte-identical to the live manifest "
+                "rendering — no second hand-maintained service list for infra2 "
+                "to drift against."
+            ),
+            test=(
+                "tests/tooling/test_sla_manifest.py"
+                "::test_AC_runtime_sla_manifest_1_committed_manifest_matches_live_dependency_manifest"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-runtime.sla-manifest.2",
+            statement=(
+                "Every dependency `required_in(production)` has exactly one "
+                "production SLA entry (name, testing kind, human-readable "
+                "summary) in the generated manifest — prod-required means "
+                "SLA-bearing regardless of whether the app feature consuming "
+                "it has shipped (resolves the manifest ↔ EPIC-019 AC19.13 "
+                "contradiction: platform availability != feature adoption)."
+            ),
+            test=(
+                "tests/tooling/test_sla_manifest.py"
+                "::test_AC_runtime_sla_manifest_2_production_entries_are_sla_bearing_and_complete"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )
 

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -66,6 +66,19 @@ test selection, execution, and reporting → `testing`.
 6. **Smoke ↔ declaration parity.** The smoke test asserts exactly the declared set
    for its tier (count == declared count); a release tag promotes only after the
    **staging** smoke (real backends, real LLM) passes.
+7. **Prod-required ⇒ SLA-bearing (#1654, decided 2026-07-07).** A dependency
+   listed in `DEPENDENCY_MANIFEST.required_for(EnvTier.PRODUCTION)` is a
+   platform SLA commitment — its continuous presence is watched out-of-band
+   (finance_report#1653), independent of whether the app *feature* consuming
+   it has shipped. Declaring `required_in` and deferring the feature that uses
+   it (e.g. EPIC-019 AC19.13's durable-orchestration deferral) are two
+   different decisions; the manifest never silently "catches up" to a feature
+   deferral by relaxing SLA scope. `tools/generate_sla_manifest.py` renders
+   this declaration machine-readably
+   (`common/runtime/sla-manifest.generated.json`) so infra2's periodic report
+   consumes it directly instead of hand-maintaining a second service list —
+   the 2026-07-06 incident (prod Prefect crash-looped 10 days, undetected)
+   is the gap this invariant closes.
 
 ## Shape (port / adapter, per the `base`/`extension`/`data` model)
 

--- a/common/runtime/sla-manifest.generated.json
+++ b/common/runtime/sla-manifest.generated.json
@@ -1,0 +1,152 @@
+{
+  "generated_by": "tools/generate_sla_manifest.py — do not edit",
+  "source": "apps/backend/src/runtime/base/manifest.py::DEPENDENCY_MANIFEST",
+  "semantics": "required_in(tier) means the dependency's continuous presence in that tier is an SLA commitment, independent of whether the app feature consuming it has shipped (wangzitian0/finance_report#1654, decided 2026-07-07).",
+  "consumer": "infra2's periodic Lark report renders one SLA row per entry (wangzitian0/finance_report#1654) instead of hand-maintaining a second service list.",
+  "entries": [
+    {
+      "tier": "local_dev",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "local_dev",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "local_ci",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "local_ci",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "github_ci",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "github_ci",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "preview",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "preview",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "preview",
+      "dependency": "telemetry",
+      "kind": "code_dominant",
+      "summary": "OTel exporter (OTEL_EXPORTER_OTLP_ENDPOINT)."
+    },
+    {
+      "tier": "staging",
+      "dependency": "analytics",
+      "kind": "code_dominant",
+      "summary": "OpenPanel product analytics (OPENPANEL_API_URL)."
+    },
+    {
+      "tier": "staging",
+      "dependency": "cache",
+      "kind": "code_dominant",
+      "summary": "Redis (REDIS_URL) — optional in the app-owned tiers and preview."
+    },
+    {
+      "tier": "staging",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "staging",
+      "dependency": "llm",
+      "kind": "model_dominant",
+      "summary": "The AI provider used for statement extraction (AI_*); recorded (cassette substitute) in CI/preview, real on staging/prod."
+    },
+    {
+      "tier": "staging",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "staging",
+      "dependency": "telemetry",
+      "kind": "code_dominant",
+      "summary": "OTel exporter (OTEL_EXPORTER_OTLP_ENDPOINT)."
+    },
+    {
+      "tier": "staging",
+      "dependency": "workflow_engine",
+      "kind": "code_dominant",
+      "summary": "Prefect (PREFECT_API_URL) — durable flows; in-process fallback in the app-owned tiers."
+    },
+    {
+      "tier": "production",
+      "dependency": "analytics",
+      "kind": "code_dominant",
+      "summary": "OpenPanel product analytics (OPENPANEL_API_URL)."
+    },
+    {
+      "tier": "production",
+      "dependency": "cache",
+      "kind": "code_dominant",
+      "summary": "Redis (REDIS_URL) — optional in the app-owned tiers and preview."
+    },
+    {
+      "tier": "production",
+      "dependency": "database",
+      "kind": "code_dominant",
+      "summary": "Postgres — the system of record (DATABASE_URL)."
+    },
+    {
+      "tier": "production",
+      "dependency": "llm",
+      "kind": "model_dominant",
+      "summary": "The AI provider used for statement extraction (AI_*); recorded (cassette substitute) in CI/preview, real on staging/prod."
+    },
+    {
+      "tier": "production",
+      "dependency": "market_data",
+      "kind": "code_dominant",
+      "summary": "Yahoo Finance market-data fetch for report-side FX."
+    },
+    {
+      "tier": "production",
+      "dependency": "object_storage",
+      "kind": "code_dominant",
+      "summary": "S3-compatible object storage for uploaded statements (S3_*)."
+    },
+    {
+      "tier": "production",
+      "dependency": "telemetry",
+      "kind": "code_dominant",
+      "summary": "OTel exporter (OTEL_EXPORTER_OTLP_ENDPOINT)."
+    },
+    {
+      "tier": "production",
+      "dependency": "workflow_engine",
+      "kind": "code_dominant",
+      "summary": "Prefect (PREFECT_API_URL) — durable flows; in-process fallback in the app-owned tiers."
+    }
+  ]
+}

--- a/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
+++ b/docs/project/EPIC-019.event-driven-upload-to-report-ux.md
@@ -9,6 +9,7 @@
 > required in-app events, and read trusted reports.
 > **Dependencies**: EPIC-003, EPIC-004, EPIC-005, EPIC-013, EPIC-016, EPIC-018
 > **Usable milestone**: 🎯 gating (G2). AC19.12 lightweight workflow derivation is required so a year of uploads reliably derives reports without hand-holding. Durable Prefect orchestration (AC19.13) stays deferred. See the [Usable cut](https://github.com/wangzitian0/finance_report/milestone/1).
+> **Platform availability vs. feature adoption** (#1654, decided 2026-07-07): AC19.13's deferral is a *feature* decision — it does not relax `DEPENDENCY_MANIFEST`'s declaration that `workflow_engine` is `required_in={STAGING, PRODUCTION}`. A prod-required dependency carries an SLA (continuous presence, watched out-of-band, see [`common/runtime/sla-manifest.generated.json`](../../common/runtime/sla-manifest.generated.json)) independent of whether the in-app feature consuming it has shipped. The 2026-07-06 incident (prod Prefect crash-looped 10 days, undetected) is what exposed this contradiction.
 
 ---
 

--- a/tests/tooling/test_sla_manifest.py
+++ b/tests/tooling/test_sla_manifest.py
@@ -29,9 +29,15 @@ def test_AC_runtime_sla_manifest_1_committed_manifest_matches_live_dependency_ma
     """AC-runtime.sla-manifest.1: the committed SLA manifest equals the manifest
     rendered from the live DEPENDENCY_MANIFEST — exact equality kills both drift
     directions (a new required dependency missing from the artifact, and a
-    stale entry for a dependency that no longer requires that tier)."""
-    rendered = json.loads(gen.render_sla_manifest(gen.collect_sla_entries()))
-    committed = _committed_manifest()
+    stale entry for a dependency that no longer requires that tier).
+
+    Compares raw text, not just parsed JSON: infra2 consumes the committed
+    file's bytes (via ``--check`` / a raw fetch), so a whitespace/key-order
+    change that slipped past a parsed-JSON comparison could still desync the
+    artifact from what ``generate_sla_manifest.py`` would actually produce.
+    """
+    rendered = gen.render_sla_manifest(gen.collect_sla_entries())
+    committed = gen.SLA_MANIFEST_PATH.read_text(encoding="utf-8")
 
     assert committed == rendered, (
         "common/runtime/sla-manifest.generated.json is out of date with "

--- a/tests/tooling/test_sla_manifest.py
+++ b/tests/tooling/test_sla_manifest.py
@@ -1,0 +1,92 @@
+"""finance_report#1654 — the machine-readable SLA manifest.
+
+``tools/generate_sla_manifest.py`` derives a machine-readable SLA manifest
+(``common/runtime/sla-manifest.generated.json``) from the same
+``DEPENDENCY_MANIFEST`` that ``/health?full=1`` already asserts (#1653 consumes
+that endpoint out-of-band). infra2's periodic Lark report consumes this
+manifest to render an SLA row per production-required dependency instead of
+hand-maintaining a second service list (finance_report#1851 G2).
+
+Mirrors ``tests/tooling/test_required_env_manifest.py``'s drift-gate shape
+(#1828 G-injection-drift-gate) for the same reason: a manifest change must not
+silently drift from what infra2 renders.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tools import generate_sla_manifest as gen  # noqa: E402
+
+
+def _committed_manifest() -> dict:
+    return json.loads(gen.SLA_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_AC_runtime_sla_manifest_1_committed_manifest_matches_live_dependency_manifest():
+    """AC-runtime.sla-manifest.1: the committed SLA manifest equals the manifest
+    rendered from the live DEPENDENCY_MANIFEST — exact equality kills both drift
+    directions (a new required dependency missing from the artifact, and a
+    stale entry for a dependency that no longer requires that tier)."""
+    rendered = json.loads(gen.render_sla_manifest(gen.collect_sla_entries()))
+    committed = _committed_manifest()
+
+    assert committed == rendered, (
+        "common/runtime/sla-manifest.generated.json is out of date with "
+        "apps/backend/src/runtime/base/manifest.py. "
+        "Run: python tools/generate_sla_manifest.py"
+    )
+
+
+def test_AC_runtime_sla_manifest_2_production_entries_are_sla_bearing_and_complete():
+    """AC-runtime.sla-manifest.2: every dependency required_in(production) has
+    exactly one production entry (the SLA-bearing set), naming the dependency,
+    its testing kind, and a human-readable summary — enough for a periodic
+    report row without re-deriving from source. workflow_engine (the 2026-07-06
+    10-day crash-loop) must be present: prod-required = SLA-bearing regardless
+    of whether the app feature consuming it (EPIC-019 AC19.13) has shipped."""
+    committed = _committed_manifest()
+    production_entries = [e for e in committed["entries"] if e["tier"] == "production"]
+    names = [e["dependency"] for e in production_entries]
+
+    assert len(names) == len(set(names)), "duplicate production SLA entry"
+    assert "workflow_engine" in names, (
+        "workflow_engine is required_in(production) — a prod-required "
+        "dependency must carry SLA visibility even while its feature "
+        "(EPIC-019 AC19.13) stays deferred"
+    )
+    for entry in production_entries:
+        assert set(entry) == {"tier", "dependency", "kind", "summary"}
+        assert entry["kind"] in {"code_dominant", "model_dominant"}
+        assert entry["summary"], f"{entry['dependency']} has no SLA summary"
+
+
+def test_write_mode_emits_the_manifest_artifact(tmp_path, monkeypatch):
+    """The generator's write mode materializes the manifest byte-identical to
+    the rendered form (so --check and write can never disagree)."""
+    target = tmp_path / "sla-manifest.generated.json"
+    # ROOT_DIR only feeds the relative-path print here; BACKEND_DIR (used to
+    # load src.runtime) was bound at import time and stays real.
+    monkeypatch.setattr(gen, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(gen, "SLA_MANIFEST_PATH", target)
+    monkeypatch.setattr(sys, "argv", ["generate_sla_manifest.py"])
+
+    assert gen.main() == 0
+
+    written = target.read_text(encoding="utf-8")
+    assert written == gen.render_sla_manifest(gen.collect_sla_entries())
+    assert json.loads(written)["entries"]
+
+
+def test_check_mode_reds_on_stale_manifest(tmp_path, monkeypatch, capsys):
+    """--check exits 1 (with a diff) when the committed manifest is stale — the
+    CLI form of the drift gate (red-team path, permanently locked)."""
+    stale = tmp_path / "sla-manifest.generated.json"
+    stale.write_text('{"entries": []}\n', encoding="utf-8")
+    monkeypatch.setattr(gen, "SLA_MANIFEST_PATH", stale)
+    monkeypatch.setattr(sys, "argv", ["generate_sla_manifest.py", "--check"])
+
+    assert gen.main() == 1
+    assert "sla-manifest.generated.json" in capsys.readouterr().out

--- a/tools/generate_sla_manifest.py
+++ b/tools/generate_sla_manifest.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Generate the machine-readable SLA manifest (finance_report#1654).
+
+2026-07-07 decision: a dependency listed in ``DEPENDENCY_MANIFEST.required_for(tier)``
+for ``tier=production`` is a platform SLA commitment, independent of whether the
+app *feature* consuming it has shipped (resolves the contradiction between
+``runtime/base/manifest.py`` and EPIC-019's deferred AC19.13 — platform
+availability != feature adoption).
+
+This generator is the "no second hand-maintained list" half of that decision:
+infra2's periodic Lark report (``tools/stability_report.py`` /
+``ops-checks.yml``) needs to know which dependencies are SLA-bearing without
+hand-copying a service list that can drift from the real manifest. The
+committed artifact (``common/runtime/sla-manifest.generated.json``) is derived
+from the same ``DEPENDENCY_MANIFEST`` that ``/health?full=1`` already asserts
+(finance_report#1653 consumes that endpoint out-of-band; this manifest gives
+the report the *why*/*what* half — SLA declaration — that a point-in-time probe
+result alone can't carry).
+
+Mirrors ``tools/generate_env_reference.py``'s generated-artifact + drift-gate
+pattern (#1828 G-injection-drift-gate) for the same reason: a change to the
+dependency manifest must not silently drift from what infra2 renders.
+
+Usage:
+    python tools/generate_sla_manifest.py            # write the file
+    python tools/generate_sla_manifest.py --check    # exit 1 if it drifts
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+BACKEND_DIR = ROOT_DIR / "apps" / "backend"
+
+# Repo root on sys.path[0] when run directly (tool-wrapper contract AC8.13.56).
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+SLA_MANIFEST_PATH = ROOT_DIR / "common" / "runtime" / "sla-manifest.generated.json"
+
+
+def _runtime_manifest():
+    """Load ``DEPENDENCY_MANIFEST``/``EnvTier`` from the backend package.
+
+    ``apps/backend`` is inserted onto ``sys.path`` lazily (only when actually
+    generating), mirroring ``generate_env_reference.py``'s care not to perturb
+    ``sys.path`` merely by importing this module. Unlike ``config.py``,
+    ``manifest.py`` makes real intra-package imports (``src.runtime.base.kind``
+    etc.), so it is loaded as a proper package import rather than by file path.
+    """
+    if str(BACKEND_DIR) not in sys.path:
+        sys.path.insert(0, str(BACKEND_DIR))
+    from src.runtime import DEPENDENCY_MANIFEST, EnvTier
+
+    return DEPENDENCY_MANIFEST, EnvTier
+
+
+def collect_sla_entries() -> list[dict]:
+    """One entry per ``(tier, dependency)`` pair where the dependency is
+    ``required_in`` that tier — the full SLA declaration, every tier (not just
+    production), so the artifact stays useful for staging SLA reporting too."""
+    manifest, env_tier = _runtime_manifest()
+    entries: list[dict] = []
+    for tier in env_tier:
+        for name in sorted(manifest.required_for(tier)):
+            dependency = manifest.get(name)
+            entries.append(
+                {
+                    "tier": tier.value,
+                    "dependency": name,
+                    "kind": dependency.kind.value,
+                    "summary": dependency.summary,
+                }
+            )
+    return entries
+
+
+def render_sla_manifest(entries: list[dict]) -> str:
+    """Render the machine-readable SLA manifest as pretty-printed JSON."""
+    manifest = {
+        "generated_by": "tools/generate_sla_manifest.py — do not edit",
+        "source": "apps/backend/src/runtime/base/manifest.py::DEPENDENCY_MANIFEST",
+        "semantics": (
+            "required_in(tier) means the dependency's continuous presence in "
+            "that tier is an SLA commitment, independent of whether the app "
+            "feature consuming it has shipped (wangzitian0/finance_report#1654, "
+            "decided 2026-07-07)."
+        ),
+        "consumer": (
+            "infra2's periodic Lark report renders one SLA row per entry "
+            "(wangzitian0/finance_report#1654) instead of hand-maintaining a "
+            "second service list."
+        ),
+        "entries": entries,
+    }
+    return json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+
+def _diff(label: str, current: str, generated: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            current.splitlines(keepends=True),
+            generated.splitlines(keepends=True),
+            fromfile=f"{label} (on disk)",
+            tofile=f"{label} (generated)",
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 (with a diff) if the on-disk file differs from generated output.",
+    )
+    args = parser.parse_args()
+
+    entries = collect_sla_entries()
+    new_manifest = render_sla_manifest(entries)
+
+    if args.check:
+        current = SLA_MANIFEST_PATH.read_text() if SLA_MANIFEST_PATH.exists() else ""
+        if current != new_manifest:
+            print(_diff(SLA_MANIFEST_PATH.name, current, new_manifest))
+            print(
+                "ERROR: sla-manifest.generated.json is out of date. "
+                "Run: python tools/generate_sla_manifest.py",
+                file=sys.stderr,
+            )
+            return 1
+        print("OK: sla-manifest.generated.json is up to date.")
+        return 0
+
+    SLA_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SLA_MANIFEST_PATH.write_text(new_manifest)
+    print(f"Wrote {SLA_MANIFEST_PATH.relative_to(ROOT_DIR)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_sla_manifest.py
+++ b/tools/generate_sla_manifest.py
@@ -125,7 +125,11 @@ def main() -> int:
     new_manifest = render_sla_manifest(entries)
 
     if args.check:
-        current = SLA_MANIFEST_PATH.read_text() if SLA_MANIFEST_PATH.exists() else ""
+        current = (
+            SLA_MANIFEST_PATH.read_text(encoding="utf-8")
+            if SLA_MANIFEST_PATH.exists()
+            else ""
+        )
         if current != new_manifest:
             print(_diff(SLA_MANIFEST_PATH.name, current, new_manifest))
             print(
@@ -138,7 +142,7 @@ def main() -> int:
         return 0
 
     SLA_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
-    SLA_MANIFEST_PATH.write_text(new_manifest)
+    SLA_MANIFEST_PATH.write_text(new_manifest, encoding="utf-8")
     print(f"Wrote {SLA_MANIFEST_PATH.relative_to(ROOT_DIR)}")
     return 0
 


### PR DESCRIPTION
## Summary

Resolves [#1654](https://github.com/wangzitian0/finance_report/issues/1654), tracked under [#1851](https://github.com/wangzitian0/finance_report/issues/1851) G2.

2026-07-07 decision: a dependency listed in `DEPENDENCY_MANIFEST.required_for(production)` is a platform SLA commitment, independent of whether the app feature consuming it has shipped — resolving the contradiction between `runtime/base/manifest.py` (`workflow_engine required_in={STAGING, PRODUCTION}`) and EPIC-019's deferred AC19.13. The 2026-07-06 incident (prod Prefect crash-looped 10 days, zero SLA visibility) is what exposed this.

## Changes

- `tools/generate_sla_manifest.py`: new generator, derives `common/runtime/sla-manifest.generated.json` from `DEPENDENCY_MANIFEST` — one entry per `(tier, dependency)` pair, mirroring `generate_env_reference.py`'s generated-artifact + drift-gate pattern (#1828 G-injection-drift-gate). No second hand-maintained service list for infra2's report tooling to drift against.
- `common/runtime/contract.py`: `AC-runtime.sla-manifest.1` (drift-gate: committed == live) and `.2` (every `required_in(production)` dependency has exactly one complete entry, including `workflow_engine`).
- `common/runtime/readme.md`: invariant 7 documents "prod-required ⇒ SLA-bearing."
- `docs/project/EPIC-019...md`: clarifying note — AC19.13's deferral is a feature decision, not a relaxation of `workflow_engine`'s `required_in` declaration.

## Scope note

This is the finance_report-side deliverable only (package ownership per the issue: "`apps/backend/src/runtime` + `common/runtime`: manifest = the SLA SSOT; expose `required_for(tier)` machine-readably"). infra2 consuming the generated manifest to render SLA-attainment rows + evidence bundles in the periodic Lark report is the remaining piece of #1654 — a follow-up PR in infra2, once this manifest exists to consume.

## Test plan

- [x] `pytest tests/tooling/test_sla_manifest.py` — 4 passed (drift-gate, production-completeness incl. `workflow_engine`, write-mode, `--check`-mode).
- [x] `pytest tests/tooling/test_check_package_contract.py` — 45 passed (whole-repo contract validator, incl. `test_main_passes_on_clean_repo`).
- [x] `python tools/generate_sla_manifest.py --check` — up to date.
- [x] `python tools/preflight.py --tier=static` — 3/3 gates pass (ac-traceability, doc-consistency, taxonomy-drift).
- [x] `ruff check` + `ruff format --check` clean.