### PR TITLE
[finance_report_ui] feat(observability): lock the log-level ownership contract, generalize #1652 (#1655)

### DIFF
--- a/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
+++ b/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
@@ -136,6 +136,60 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     assert failed["error_type"] == "ExtractionError"
     assert failed["safe_error_message"] == "provider failed without raw document content"
     assert "secret source bytes" not in failed["safe_error_message"]
+    # AC-observability.11.4 (#1655): the original #1652 regression — this expected,
+    # user-input parse failure must never ALSO log at ERROR. The assertion above
+    # only proved the WARNING fired; it did not prove ERROR stayed silent, so a
+    # future re-add of a logger.error() on this exact path would have passed
+    # undetected.
+    mock_error.assert_not_called()
+
+
+async def test_AC_observability_11_4_expected_parse_failure_never_logs_at_error(db, test_user, monkeypatch):
+    """AC-observability.11.4 (#1655, generalizes #1652, finance_report#1851 G3).
+
+    A statement that fails extraction because the source document itself is bad
+    (not a system fault) is an expected, routine outcome — logging it at ERROR
+    is exactly what let one bad user upload fire a zero-threshold critical Lark
+    alert before #1652 shipped. This is a dedicated contract test (distinct from
+    AC-observability.8.2's "logs are structured" assertion above) so the
+    log-level contract itself — not just log content — has its own named,
+    discoverable proof.
+    """
+    user_id = test_user.id
+    statement = await _create_statement(db, user_id, file_hash="contract-hash")
+    mock_error = MagicMock()
+    mock_warning = MagicMock()
+
+    async def fail_parse_document(*_args, **_kwargs):
+        raise ExtractionError("could not read a bank statement from this document")
+
+    monkeypatch.setattr(statement_parsing.logger, "error", mock_error)
+    monkeypatch.setattr(statement_parsing.logger, "warning", mock_warning)
+    monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fail_parse_document)
+    monkeypatch.setattr(
+        statement_parsing.StorageService,
+        "generate_presigned_url",
+        lambda *_args, **_kwargs: "https://example.com/contract.pdf",
+    )
+
+    await parse_statement_background(
+        statement_id=statement.id,
+        filename="contract.pdf",
+        institution="DBS",
+        user_id=user_id,
+        account_id=None,
+        file_hash="contract-hash",
+        storage_key="statements/contract.pdf",
+        content=b"%PDF-1.7",
+        model="glm-5.1",
+        session_maker=create_session_maker_from_db(db),
+        request_id="req-contract",
+    )
+
+    mock_error.assert_not_called()
+    assert any(call.args[0] == "statement.parse.failed" for call in mock_warning.call_args_list), (
+        "expected the routine statement.parse.failed WARNING to fire"
+    )
 
 
 async def test_AC10_8_3_brokerage_review_routing_audit_checkpoints(db, test_user, monkeypatch):

--- a/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
+++ b/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
@@ -53,6 +53,7 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     mock_info = MagicMock()
     mock_error = MagicMock()
     mock_warning = MagicMock()
+    mock_exception = MagicMock()
 
     async def fake_parse_document(*_args, **_kwargs):
         return _parsed_statement(user_id, "success-hash"), []
@@ -60,6 +61,7 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     monkeypatch.setattr(statement_parsing.logger, "info", mock_info)
     monkeypatch.setattr(statement_parsing.logger, "error", mock_error)
     monkeypatch.setattr(statement_parsing.logger, "warning", mock_warning)
+    monkeypatch.setattr(statement_parsing.logger, "exception", mock_exception)
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fake_parse_document)
     monkeypatch.setattr(
         statement_parsing.StorageService,
@@ -111,6 +113,7 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
 
     mock_error.reset_mock()
     mock_warning.reset_mock()
+    mock_exception.reset_mock()
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fail_parse_document)
 
     await parse_statement_background(
@@ -137,11 +140,13 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     assert failed["safe_error_message"] == "provider failed without raw document content"
     assert "secret source bytes" not in failed["safe_error_message"]
     # AC-observability.11.4 (#1655): the original #1652 regression — this expected,
-    # user-input parse failure must never ALSO log at ERROR. The assertion above
-    # only proved the WARNING fired; it did not prove ERROR stayed silent, so a
-    # future re-add of a logger.error() on this exact path would have passed
+    # user-input parse failure must never ALSO log at ERROR (or its equally-error-
+    # level sibling, .exception()). The assertion above only proved the WARNING
+    # fired; it did not prove ERROR/exception stayed silent, so a future re-add of
+    # a logger.error()/logger.exception() on this exact path would have passed
     # undetected.
     mock_error.assert_not_called()
+    mock_exception.assert_not_called()
 
 
 async def test_AC_observability_11_4_expected_parse_failure_never_logs_at_error(db, test_user, monkeypatch):
@@ -159,12 +164,14 @@ async def test_AC_observability_11_4_expected_parse_failure_never_logs_at_error(
     statement = await _create_statement(db, user_id, file_hash="contract-hash")
     mock_error = MagicMock()
     mock_warning = MagicMock()
+    mock_exception = MagicMock()
 
     async def fail_parse_document(*_args, **_kwargs):
         raise ExtractionError("could not read a bank statement from this document")
 
     monkeypatch.setattr(statement_parsing.logger, "error", mock_error)
     monkeypatch.setattr(statement_parsing.logger, "warning", mock_warning)
+    monkeypatch.setattr(statement_parsing.logger, "exception", mock_exception)
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fail_parse_document)
     monkeypatch.setattr(
         statement_parsing.StorageService,
@@ -187,6 +194,7 @@ async def test_AC_observability_11_4_expected_parse_failure_never_logs_at_error(
     )
 
     mock_error.assert_not_called()
+    mock_exception.assert_not_called()
     assert any(call.args[0] == "statement.parse.failed" for call in mock_warning.call_args_list), (
         "expected the routine statement.parse.failed WARNING to fire"
     )

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -483,6 +483,30 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        ACRecord(
+            id="AC-observability.11.4",
+            statement=(
+                "Telemetry↔alerting ownership contract (#1655, generalizes #1652, "
+                "finance_report#1851 G3): an expected/user-input parse outcome "
+                "(a statement that fails extraction because the source document "
+                "itself is bad — not a system fault) logs at WARNING, never "
+                "ERROR. ERROR is reserved for actionable system faults; a "
+                "routine bad upload must never be indistinguishable, at the log "
+                "level, from an infra incident — that conflation is exactly what "
+                "let a single bad upload fire a zero-threshold critical alert "
+                "before #1652. Changing which outcomes are routine vs. faulty is "
+                "an infra alerting-policy question (thresholds/rules), never an "
+                "app log-level question — this contract is what makes that "
+                "boundary hold without requiring an app release to fix alert "
+                "noise."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_parsing_audit_logging.py"
+                "::test_AC_observability_11_4_expected_parse_failure_never_logs_at_error"
+            ),
+            priority="P0",
+            status="done",
+        ),
         # ── group 12: Async parse failure visibility (was EPIC-010 AC10.12.*) ──
         ACRecord(
             id="AC-observability.12.1",

--- a/common/observability/observability.md
+++ b/common/observability/observability.md
@@ -39,7 +39,7 @@
 | Runtime contract | `apps/backend/src/observability/runtime.py` | Redacted observability status for health checks, startup logs, and alert triage |
 | Env settings | `apps/backend/src/config.py` | OTEL environment variables |
 | Env documentation | `.env.example` | Developer guidance for OTEL variables |
-| Infra reference | `repo/docs/ssot/ops.observability.md`, `repo/docs/ssot/ops.alerting.md` | the observability backend platform, collector, alert rule, and Lark delivery details |
+| Infra reference | `repo/docs/ssot/ops.observability.md` | the observability backend platform, collector, alert rule, and Lark delivery details |
 
 ---
 
@@ -205,9 +205,31 @@ uv run python -m invoke alerting.shared.ensure-log-error-rule \
 ```
 
 The shared owner for the observability backend channels, bridge deployment, and Lark delivery is
-`repo/docs/ssot/ops.alerting.md`. This application must not duplicate that
+`repo/docs/ssot/ops.observability.md`. This application must not duplicate that
 automation; it only declares the service metadata and emits structured logs that
 the shared rule can query.
+
+#### 7.2.1 Log-level semantics (AC-observability.11.4, #1655)
+
+**打点是 app 的事情,要求准;告警是 infra 的事情,风格可以不同.** (2026-07-07
+decision.) This application owns instrumentation *accuracy* — which level a
+given outcome logs at; infra2 owns alerting *policy* — rules, thresholds,
+dedup, routing, runbooks. Changing an alert must be an infra2-only deploy; it
+must never require an app release.
+
+| Level | Meaning | Example |
+|---|---|---|
+| `ERROR` | An actionable system fault — something *this service* is responsible for fixing (a crashed dependency, an unhandled exception, data corruption risk). Feeds `FinanceReportBackendErrorLogs` (zero-threshold — every ERROR is expected to be individually actionable). | Unresolvable statement id after rollback; unhandled exception in a request handler. |
+| `WARNING` | An expected, routine, or user-input-driven outcome — nothing for an operator to act on. A bad upload, a degraded-but-recovered fallback, an unmet-but-tracked business condition. | A statement fails extraction because the source document is unparseable (`statement.parse.failed`); auth/rate-limit rejection. |
+
+Before #1652, a routine statement-parse failure (bad user upload — always
+expected to happen at some rate) logged at `ERROR`, so a single bad upload
+fired the zero-threshold `FinanceReportBackendErrorLogs` alert. The correct
+signal for *volume* of routine parse failures is the dedicated business metric
++ its own threshold rule (`FinanceReportStatementParseFailureSpike`, >3/15m —
+see `alert_rules.json`), not the ERROR-log channel. `AC-observability.11.4`
+locks this in behaviorally (an expected parse failure must never also log at
+ERROR) so the next regression is caught at PR time, not as Lark noise.
 
 ### 7.3 Manual Verification
 
@@ -230,7 +252,7 @@ metadata used by the shared alert rule.
 
 Use the runtime incident SSOT for missing logs, wrong environment labels,
 502/503 responses, route failures, stale deployed versions, and flapping
-recovery proof. Use `repo/docs/ssot/ops.alerting.md` for shared the observability backend alert
+recovery proof. Use `repo/docs/ssot/ops.observability.md` for shared the observability backend alert
 automation, bridge delivery, and Lark channel behavior.
 
 ---

--- a/common/observability/observability.md
+++ b/common/observability/observability.md
@@ -211,7 +211,7 @@ the shared rule can query.
 
 #### 7.2.1 Log-level semantics (AC-observability.11.4, #1655)
 
-**打点是 app 的事情,要求准;告警是 infra 的事情,风格可以不同.** (2026-07-07
+**Instrumentation accuracy is this application's responsibility; alerting policy is infra2's, and the two may evolve independently.** (2026-07-07
 decision.) This application owns instrumentation *accuracy* — which level a
 given outcome logs at; infra2 owns alerting *policy* — rules, thresholds,
 dedup, routing, runbooks. Changing an alert must be an infra2-only deploy; it
@@ -252,7 +252,7 @@ metadata used by the shared alert rule.
 
 Use the runtime incident SSOT for missing logs, wrong environment labels,
 502/503 responses, route failures, stale deployed versions, and flapping
-recovery proof. Use `repo/docs/ssot/ops.observability.md` for shared the observability backend alert
+recovery proof. Use `repo/docs/ssot/ops.observability.md` for the shared observability-backend alert
 automation, bridge delivery, and Lark channel behavior.
 
 ---


### PR DESCRIPTION
## Summary

Resolves [#1655](https://github.com/wangzitian0/finance_report/issues/1655), tracked under [#1851](https://github.com/wangzitian0/finance_report/issues/1851) G3.

**打点是 app 的事情要求准；告警是 infra 的事情风格可以不同** (2026-07-07 decision). Before #1652, a routine statement-parse failure (bad user upload — always expected to happen at some rate) logged at `ERROR`, feeding the zero-threshold `FinanceReportBackendErrorLogs` rule — one bad upload fired a critical Lark alert. #1652 fixed the one call site, but its regression test only asserted the WARNING fired; it never asserted ERROR stayed silent, so the same regression could return unnoticed at that exact site, and no contract existed to catch it anywhere else.

## Changes

- `common/observability/contract.py`: new `AC-observability.11.4` — an expected/user-input parse outcome must log at WARNING, never ERROR; ERROR is reserved for actionable system faults.
- `apps/backend/tests/extraction/test_statement_parsing_audit_logging.py`:
  - New dedicated test `test_AC_observability_11_4_expected_parse_failure_never_logs_at_error` (`mock_error.assert_not_called()`), given its own AC so the log-level contract has its own named, discoverable proof — separate from `AC-observability.8.2`'s "logs are structured" assertion.
  - Same `mock_error.assert_not_called()` assertion added to the original `#1652` regression test, which previously only checked the WARNING fired.
- `common/observability/observability.md` §7.2.1: promotes the level-semantics table (ERROR vs WARNING) from informal/undocumented into a versioned contract, and fixes two more stale `docs/ssot/ops.alerting.md` pointers (a redirect-only tombstone — content moved to `ops.observability.md`; same class of drift already fixed in `alert_rules.json` in infra2 PR #483).

## Scope note

infra2-side alert dedup/hysteresis (infra2#475) and publishing the alerting-standard doc are a separate, larger follow-up per #1851's scope decision — not in this PR.

## Test plan

- [x] `pytest apps/backend/tests/extraction/test_statement_parsing_audit_logging.py` — 4 passed.
- [x] `pytest tests/tooling/test_check_package_contract.py` — 36 passed (whole-repo contract validator).
- [x] `ruff check` + `ruff format --check` clean on all 3 changed files, verified under both the pinned `apps/backend/.venv` ruff (0.14.11) and system ruff (0.15.17).
- [x] pre-commit hooks (ruff, ruff-format, secret detection, submodule pin) all passed.

**preflight skipped: backend-format gate false-positives on `apps/backend/src/schemas/workflow.py`** (65 pre-existing UP042 findings on a file this PR never touches — confirmed via `git log`/`git status`). Root cause: `common/testing/preflight.py`'s `backend-format` check shells out to a bare `"ruff"` resolved via `PATH` (picks up system ruff 0.15.17) instead of the pinned `apps/backend/.venv` ruff (0.14.11); the newer version enables `UP042` by default. Verified my 3 actually-changed files are clean under **both** ruff versions, from both `apps/backend` and repo-root `cwd`. Matches a previously-recorded "3 ruff versions" environment gotcha, not a new one.