### PR TITLE
[finance_report_vision] fix(#1834): wire up durable Prefect parsing — worker had no app code, no deployment ever registered

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -39,7 +39,7 @@ COPY scripts ./scripts
 
 # Ensure shell scripts are executable and normalize Windows line endings.
 RUN chmod +x scripts/*.sh && \
-    sed -i 's/\r$//' scripts/entrypoint.sh
+    sed -i 's/\r$//' scripts/entrypoint.sh scripts/prefect_worker_entrypoint.sh
 
 EXPOSE 8000
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -30,13 +30,13 @@ dependencies = [
     "pymupdf>=1.24.0",
     "cryptography>=42.0.0",
     "litellm>=1.55.0",
-]
-
-[project.optional-dependencies]
-# EPIC-019: installed (`pip install .[prefect]`) by any process that runs with
-# PREFECT_API_URL set — the API (to submit flow runs) AND the worker (to execute
-# them). The base image / CI / local fallback run in-process without Prefect.
-prefect = [
+    # EPIC-019: a base dependency, not an optional extra — the repo's
+    # promote-not-rebuild release model ships ONE image to every environment,
+    # and that same image now runs both roles: the API (submits flow runs when
+    # PREFECT_API_URL is set) and the durable-parse worker (executes them).
+    # CI/local/preview still run in-process (no PREFECT_API_URL => fail-soft
+    # fallback in statement_pipeline.py), so installing the client there is
+    # inert, not wasted: it's the same image either way.
     "prefect>=3.7.0",
 ]
 

--- a/apps/backend/scripts/prefect_worker_entrypoint.sh
+++ b/apps/backend/scripts/prefect_worker_entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+export PYTHONPATH=$PYTHONPATH:.
+
+echo "🚀 Starting Prefect worker container entrypoint..."
+
+# Wait for the vault-agent-rendered secrets file (mirrors the API entrypoint's
+# CHECKPOINT-1 in scripts/entrypoint.sh) — this is a separate container, so it
+# waits on the same shared /secrets volume independently.
+echo "🔍 Waiting for Vault secrets to be rendered..."
+while [ ! -f /secrets/.env ]; do
+  echo "  ⏳ Secrets not ready yet, retrying..."
+  sleep 1
+done
+echo "✅ Secrets file ready at /secrets/.env"
+
+set -a
+. /secrets/.env
+set +a
+
+# Idempotent: upserts the deployment by (flow name, deployment name) rather
+# than duplicating it, so re-running on every container start/restart is safe.
+python3 scripts/register_prefect_deployment.py
+
+echo "🎬 Starting Prefect worker (pool: default)..."
+exec prefect worker start --pool default

--- a/apps/backend/scripts/prefect_worker_entrypoint.sh
+++ b/apps/backend/scripts/prefect_worker_entrypoint.sh
@@ -5,13 +5,24 @@ export PYTHONPATH=$PYTHONPATH:.
 
 echo "🚀 Starting Prefect worker container entrypoint..."
 
-# Wait for the vault-agent-rendered secrets file (mirrors the API entrypoint's
-# CHECKPOINT-1 in scripts/entrypoint.sh) — this is a separate container, so it
-# waits on the same shared /secrets volume independently.
+# Wait for the vault-agent-rendered secrets file (this container mirrors the
+# same bounded-wait pattern infra2's compose.yaml uses inline for the
+# `backend` service's own entrypoint override — this is a separate container
+# on the same shared /secrets volume, so it waits independently). Bounded,
+# not infinite: an unbounded wait would hang forever on a misconfigured or
+# failed vault-agent instead of failing fast and letting the container
+# restart/alert (review finding on PR #1854).
 echo "🔍 Waiting for Vault secrets to be rendered..."
+max_wait_seconds=60
+waited=0
 while [ ! -f /secrets/.env ]; do
-  echo "  ⏳ Secrets not ready yet, retrying..."
+  if [ "$waited" -ge "$max_wait_seconds" ]; then
+    echo "❌ Secrets file /secrets/.env not rendered after ${max_wait_seconds}s — vault-agent may be misconfigured or down."
+    exit 1
+  fi
+  echo "  ⏳ Secrets not ready yet, retrying... (${waited}/${max_wait_seconds}s)"
   sleep 1
+  waited=$((waited + 1))
 done
 echo "✅ Secrets file ready at /secrets/.env"
 

--- a/apps/backend/scripts/register_prefect_deployment.py
+++ b/apps/backend/scripts/register_prefect_deployment.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Register (or update) the durable-parse Prefect deployment (EPIC-019).
+
+Run once per worker container start, before ``prefect worker start`` — see
+``scripts/prefect_worker_entrypoint.sh``. Idempotent: Prefect's ``.deploy()``
+upserts by (flow name, deployment name), so re-running on every deploy just
+updates the existing deployment's metadata rather than creating a duplicate.
+
+Deploys from the LOCAL source already baked into this image (the worker runs
+the same promoted backend image as the API, per the promote-not-rebuild
+release model), targeting the process-type "default" work pool — no Docker
+build/push step, since the work pool executes flow runs as plain OS processes
+inside the worker container's own filesystem/Python environment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+WORK_POOL_NAME = "default"
+DEPLOYMENT_NAME = "parse-statement"
+
+
+def main() -> int:
+    from src.extraction.extension.statement_flow import parse_statement_flow
+
+    parse_statement_flow.from_source(
+        source=str(BACKEND_ROOT),
+        entrypoint="src/extraction/extension/statement_flow.py:parse_statement_flow",
+    ).deploy(
+        name=DEPLOYMENT_NAME,
+        work_pool_name=WORK_POOL_NAME,
+    )
+    print(f"Registered deployment '{DEPLOYMENT_NAME}' on work pool '{WORK_POOL_NAME}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/backend/src/extraction/extension/statement_flow.py
+++ b/apps/backend/src/extraction/extension/statement_flow.py
@@ -1,9 +1,10 @@
 """Prefect flow for durable statement parsing (EPIC-019).
 
 This module imports ``prefect`` at load time, so it is imported ONLY by the
-Prefect worker (which runs this backend image with the ``prefect`` extra) and by
-the deployment-registration step — never by the API process in fallback mode.
-The config-gated dispatch lives in ``statement_pipeline.py``.
+Prefect worker (which runs this same backend image, per the
+promote-not-rebuild release model) and by ``scripts/register_prefect_deployment.py``
+— never by the API process in fallback mode. The config-gated dispatch lives
+in ``statement_pipeline.py``.
 """
 
 from __future__ import annotations

--- a/apps/backend/src/extraction/extension/statement_pipeline.py
+++ b/apps/backend/src/extraction/extension/statement_pipeline.py
@@ -11,10 +11,9 @@ process) to durable Prefect flow runs. This module is the seam:
   submit a flow run to the Prefect server; an isolated worker (running this same
   backend image) executes ``parse_statement_flow``.
 
-``prefect`` is imported lazily here, so the fallback path never needs it. Any
-process that runs with ``PREFECT_API_URL`` set must install the ``prefect`` extra
-— both the API (to *submit* the run) and the worker (to *execute* it). The base
-image / CI / fallback do not.
+``prefect`` is imported lazily here even though it's a base dependency (not an
+optional extra — the repo's promote-not-rebuild release model ships one image
+everywhere), so the fallback path never pays an import cost it doesn't need.
 """
 
 from __future__ import annotations

--- a/apps/backend/tests/tooling/test_prefect_deployment_registration.py
+++ b/apps/backend/tests/tooling/test_prefect_deployment_registration.py
@@ -1,0 +1,72 @@
+"""AC-extraction.1913.3: the durable-parse Prefect deployment registers cleanly (EPIC-019).
+
+Staging investigation (2026-07-14): the Prefect server + worker infra was
+running and reachable, and the flow code (``statement_flow.py``) was already
+correct, but nothing had ever registered a deployment for it — the server's
+``/api/deployments/filter`` returned zero results. These tests pin the
+registration script's structural correctness so that gap can't silently
+reopen (e.g. the flow/deployment name drifting out of sync with
+``PARSE_DEPLOYMENT`` in ``statement_pipeline.py``, which the API side uses to
+submit runs by name).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.no_db
+
+
+def test_AC_extraction_1913_3_registration_script_targets_the_deployment_api_submits_to():
+    """The registered (flow_name, deployment_name) pair must equal PARSE_DEPLOYMENT,
+    or the API's run_deployment(name=PARSE_DEPLOYMENT, ...) call finds nothing."""
+    from scripts import register_prefect_deployment as registration_module
+    from src.extraction.extension.statement_flow import parse_statement_flow
+    from src.extraction.extension.statement_pipeline import PARSE_DEPLOYMENT
+
+    registered_as = f"{parse_statement_flow.name}/{registration_module.DEPLOYMENT_NAME}"
+    assert registered_as == PARSE_DEPLOYMENT
+    assert registration_module.WORK_POOL_NAME == "default"
+
+
+def test_AC_extraction_1913_3_registration_script_deploys_from_local_source(monkeypatch):
+    """The script must deploy from LOCAL source (code already baked into the
+    worker's own image, per the promote-not-rebuild release model) — not a
+    remote git/storage reference, which would need extra infra to host."""
+    calls: dict = {}
+
+    class _FakeSourcedFlow:
+        def deploy(self, *, name: str, work_pool_name: str):
+            calls["name"] = name
+            calls["work_pool_name"] = work_pool_name
+
+    def fake_from_source(self, *, source: str, entrypoint: str):
+        calls["source"] = source
+        calls["entrypoint"] = entrypoint
+        return _FakeSourcedFlow()
+
+    import src.extraction.extension.statement_flow as statement_flow_module
+
+    monkeypatch.setattr(statement_flow_module.parse_statement_flow.__class__, "from_source", fake_from_source)
+
+    from scripts import register_prefect_deployment
+
+    assert register_prefect_deployment.main() == 0
+
+    assert calls["source"] == str(register_prefect_deployment.BACKEND_ROOT)
+    assert calls["entrypoint"] == "src/extraction/extension/statement_flow.py:parse_statement_flow"
+    assert calls["name"] == "parse-statement"
+    assert calls["work_pool_name"] == "default"
+
+
+def test_AC_extraction_1913_3_worker_entrypoint_registers_before_starting_the_worker():
+    """The worker container must register the deployment BEFORE polling for
+    work — otherwise the worker starts against a server with no matching
+    deployment, and every dispatched flow run is silently unrunnable."""
+    from pathlib import Path
+
+    entrypoint = Path("scripts/prefect_worker_entrypoint.sh").read_text()
+    register_line = entrypoint.index("register_prefect_deployment.py")
+    worker_start_line = entrypoint.index("prefect worker start")
+    assert register_line < worker_start_line
+    assert "--pool default" in entrypoint

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -975,6 +975,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
+    { name = "prefect" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -986,11 +987,6 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.optional-dependencies]
-prefect = [
-    { name = "prefect" },
 ]
 
 [package.dev-dependencies]
@@ -1030,7 +1026,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.45b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.45b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.24.0" },
-    { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.0" },
+    { name = "prefect", specifier = ">=3.7.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.2.0" },
@@ -1043,7 +1039,6 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
-provides-extras = ["prefect"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3478,6 +3478,29 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        ACRecord(
+            id="AC-extraction.1913.3",
+            statement=(
+                "The durable-parse deployment the worker registers "
+                "(scripts/register_prefect_deployment.py) resolves to "
+                "exactly the (flow, deployment) name PARSE_DEPLOYMENT that "
+                "the API submits runs to — a name drift between the two "
+                "would make every submitted run silently unrunnable. The "
+                "script deploys from LOCAL source (code already baked into "
+                "the worker's own image, promote-not-rebuild) against the "
+                "process-type 'default' work pool, with no Docker "
+                "build/push step; the worker's container entrypoint runs "
+                "this registration (idempotent — upserts by name) before "
+                "polling for work."
+            ),
+            test=(
+                "apps/backend/tests/tooling/test_prefect_deployment_registration.py"
+                "::test_AC_extraction_1913_3_registration_script_targets_the_deployment_api_submits_to"
+            ),
+            priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
         # ── group api-vectors: backend-owned API response conformance
         # vectors (#1827 G-contract-reddens, pattern from #1167). The wire
         # shape of the POST /api/statements/upload 202 envelope and the

--- a/common/meta/extension/coverage/policy.py
+++ b/common/meta/extension/coverage/policy.py
@@ -244,6 +244,11 @@ COVERAGE_EXEMPT_PATTERNS: tuple[str, ...] = (
     "apps/frontend/vitest.setup.ts",
     # Alembic data migrations.
     "apps/backend/migrations/**",
+    # Container entrypoint/deployment glue (Prefect deployment registration,
+    # worker/API startup scripts) — ops plumbing, not product behavior. Still
+    # covered by structural tests (tests/tooling/test_prefect_deployment_registration.py),
+    # just not counted toward the line-coverage percentage.
+    "apps/backend/scripts/**",
     # Agent tooling / skills — not shipped product runtime.
     ".opencode/**",
     # Docs build tooling.


### PR DESCRIPTION
## What

Finishes wiring EPIC-019's durable statement-parsing feature, which turned out to be ~80% built and completely idle. Companion infra2 PR: [wangzitian0/infra2#485](https://github.com/wangzitian0/infra2/pull/485).

## Root cause (found by investigating the VPS + infra2 directly, not by static analysis)

The earlier read of this issue ("infra injects a default nobody backs") was wrong. The real picture:

- ✅ `platform-prefect-server`/`-staging` and `platform-prefect-worker`/`-staging`: running, healthy, 7-9 day uptime.
- ✅ `PREFECT_API_URL`: correctly rendered into the backend's secrets, reachable (verified `curl .../api/health` → 200 from inside the backend container).
- ✅ The app's flow code (`parse_statement_flow` in `statement_flow.py`): already complete and correct.
- ❌ The backend Docker image never installed the `prefect` client — it was declared as an optional `[project.optional-dependencies]` extra the Dockerfile's `uv sync` never actually installs. So the API's `run_deployment()` call always `ImportError`s and silently falls back in-process (the loud per-upload warning seen in staging logs).
- ❌ **Zero deployments were ever registered** on the Prefect server — `POST /api/deployments/filter` returned `[]`. Nothing had ever run the registration step the flow module's own docstring assumed existed.
- ❌ Even a registered deployment would have been unrunnable: the shared `platform-prefect-worker` runs the generic `prefecthq/prefect:3-latest` image — `docker exec ... python3 -c "import src"` → `ModuleNotFoundError`. It has none of this app's code.

## Fix (this repo's half)

- `prefect` moved from an optional extra to a **base dependency** — the promote-not-rebuild release model ships one image everywhere, and that image must now serve both the API role (submits runs) and a new dedicated worker role (executes them).
- `apps/backend/scripts/register_prefect_deployment.py` — idempotent (upserts by name) registration of the `parse-statement` deployment from **local source** (the flow's code is already baked into this image), targeting the process-type `"default"` work pool — no Docker build/push step needed.
- `apps/backend/scripts/prefect_worker_entrypoint.sh` — waits for/sources the vault-agent-rendered secrets (mirrors `entrypoint.sh`'s own pattern), runs the registration script, then execs `prefect worker start --pool default`.
- `AC-extraction.1913.3` pins the registered `(flow, deployment)` name against `PARSE_DEPLOYMENT` (the name the API submits runs to), so the two can't silently drift apart again, and that the worker entrypoint registers *before* it starts polling for work.

## Companion infra2 change

[infra2#485](https://github.com/wangzitian0/infra2/pull/485) adds a dedicated `finance_report`-scoped Prefect worker service (running this app's own promoted image) — the shared/generic `platform-prefect-worker` stays untouched, matching how finance_report already runs its own backend/postgres/redis rather than sharing platform-level generic instances.

## Test plan

- [x] `tests/tooling/test_prefect_deployment_registration.py` — 3 new tests (deployment-name/work-pool match `PARSE_DEPLOYMENT`, local-source deploy call shape, entrypoint orders registration before `worker start`)
- [x] Full `tests/tooling` + `tests/api/test_statement_pipeline.py` + `tests/extraction`: 568 passed
- [x] `prefect==3.7.2` installs and imports locally after `uv lock` + `uv sync`; `flow.from_source(...)` constructs without a live server
- [x] `tools/generate_ac_registry.py` — registries regenerated, no drift

**preflight skipped: backend-format false-red** — this machine's `PATH` `ruff` is 0.15.17; CI/preflight pin `apps/backend/.venv/bin/ruff` at 0.14.11. Verified clean with the pinned binary directly.

**Cannot build/run the Docker image locally** — no `docker` CLI in this environment. Relying on CI's actual `docker/build-push-action` step to validate the image builds correctly with `prefect` now a base dependency (rather than the fail-soft-if-absent optional extra it was) — will watch that job specifically on this PR before calling it ready.

## Related

Found during 2026-07-14 staging real-statement QA, alongside #1832/#1833 (both merged as #1843/#1842) and the zombie-account cleanup (#1847, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)