### PR TITLE
[finance_report_vision] fix(#1834): dedicate finance-report Prefect work pool to stop racing platform's generic worker

### DIFF
--- a/apps/backend/scripts/prefect_worker_entrypoint.sh
+++ b/apps/backend/scripts/prefect_worker_entrypoint.sh
@@ -34,5 +34,8 @@ set +a
 # than duplicating it, so re-running on every container start/restart is safe.
 python3 scripts/register_prefect_deployment.py
 
-echo "🎬 Starting Prefect worker (pool: default)..."
-exec prefect worker start --pool default
+echo "🎬 Starting Prefect worker (pool: finance-report)..."
+# --type process: belt-and-suspenders auto-create if the pool is somehow
+# missing (registration above already creates it) — non-interactive per
+# Prefect's documented `worker start --pool <name> --type <type>` behavior.
+exec prefect worker start --pool finance-report --type process

--- a/apps/backend/scripts/register_prefect_deployment.py
+++ b/apps/backend/scripts/register_prefect_deployment.py
@@ -38,13 +38,21 @@ DEPLOYMENT_NAME = "parse-statement"
 async def _ensure_work_pool_exists(name: str) -> None:
     from prefect.client.orchestration import get_client
     from prefect.client.schemas.actions import WorkPoolCreate
-    from prefect.exceptions import ObjectNotFound
+    from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 
     async with get_client() as client:
         try:
             await client.read_work_pool(name)
         except ObjectNotFound:
-            await client.create_work_pool(WorkPoolCreate(name=name, type="process"))
+            try:
+                await client.create_work_pool(WorkPoolCreate(name=name, type="process"))
+            except ObjectAlreadyExists:
+                # A concurrent worker start (e.g. old+new containers briefly
+                # overlapping during a rolling restart) can also observe
+                # ObjectNotFound and win the create race first — the pool
+                # existing either way is the desired end state (review finding
+                # on PR #1857).
+                pass
 
 
 def main() -> int:

--- a/apps/backend/scripts/register_prefect_deployment.py
+++ b/apps/backend/scripts/register_prefect_deployment.py
@@ -8,24 +8,49 @@ updates the existing deployment's metadata rather than creating a duplicate.
 
 Deploys from the LOCAL source already baked into this image (the worker runs
 the same promoted backend image as the API, per the promote-not-rebuild
-release model), targeting the process-type "default" work pool — no Docker
-build/push step, since the work pool executes flow runs as plain OS processes
-inside the worker container's own filesystem/Python environment.
+release model) — no Docker build/push step, since the work pool executes flow
+runs as plain OS processes inside the worker container's own
+filesystem/Python environment.
+
+Uses a DEDICATED "finance-report" work pool, not the platform's "default"
+pool: every environment's Prefect server also runs a shared generic worker
+(``platform-prefect-worker*``) polling "default" for unrelated services, and
+that worker's image has no finance_report app code. Registering onto
+"default" makes our flow runs race the generic worker for pickup — when it
+wins, the run crashes (``FileNotFoundError: /app``) and the statement is
+orphaned in "parsing" forever (found via staging E2E gate failure on the
+v0.1.38 deploy, 2026-07-14). The pool is created idempotently below since,
+unlike "default", it does not pre-exist on a fresh environment.
 """
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parents[1]
 
-WORK_POOL_NAME = "default"
+WORK_POOL_NAME = "finance-report"
 DEPLOYMENT_NAME = "parse-statement"
+
+
+async def _ensure_work_pool_exists(name: str) -> None:
+    from prefect.client.orchestration import get_client
+    from prefect.client.schemas.actions import WorkPoolCreate
+    from prefect.exceptions import ObjectNotFound
+
+    async with get_client() as client:
+        try:
+            await client.read_work_pool(name)
+        except ObjectNotFound:
+            await client.create_work_pool(WorkPoolCreate(name=name, type="process"))
 
 
 def main() -> int:
     from src.extraction.extension.statement_flow import parse_statement_flow
+
+    asyncio.run(_ensure_work_pool_exists(WORK_POOL_NAME))
 
     parse_statement_flow.from_source(
         source=str(BACKEND_ROOT),

--- a/apps/backend/tests/tooling/test_prefect_deployment_registration.py
+++ b/apps/backend/tests/tooling/test_prefect_deployment_registration.py
@@ -8,6 +8,13 @@ registration script's structural correctness so that gap can't silently
 reopen (e.g. the flow/deployment name drifting out of sync with
 ``PARSE_DEPLOYMENT`` in ``statement_pipeline.py``, which the API side uses to
 submit runs by name).
+
+Second staging investigation (2026-07-14, same day): registering onto the
+"default" work pool made our flow runs race the platform's shared generic
+worker (which also polls "default" but has no finance_report app code) —
+whichever worker won the race for a given run decided whether it completed or
+crashed with ``FileNotFoundError: /app``, orphaning the statement in
+"parsing" forever. Pinning a dedicated pool name closes that reopening too.
 """
 
 from __future__ import annotations
@@ -26,7 +33,9 @@ def test_AC_extraction_1913_3_registration_script_targets_the_deployment_api_sub
 
     registered_as = f"{parse_statement_flow.name}/{registration_module.DEPLOYMENT_NAME}"
     assert registered_as == PARSE_DEPLOYMENT
-    assert registration_module.WORK_POOL_NAME == "default"
+    # Must NOT be "default": that pool is shared with the platform's generic
+    # worker, which has no app code and crashes any run it wins the race for.
+    assert registration_module.WORK_POOL_NAME == "finance-report"
 
 
 def test_AC_extraction_1913_3_registration_script_deploys_from_local_source(monkeypatch):
@@ -51,12 +60,18 @@ def test_AC_extraction_1913_3_registration_script_deploys_from_local_source(monk
 
     from scripts import register_prefect_deployment
 
+    async def _fake_ensure_pool(name: str) -> None:
+        calls["ensured_pool"] = name
+
+    monkeypatch.setattr(register_prefect_deployment, "_ensure_work_pool_exists", _fake_ensure_pool)
+
     assert register_prefect_deployment.main() == 0
 
     assert calls["source"] == str(register_prefect_deployment.BACKEND_ROOT)
     assert calls["entrypoint"] == "src/extraction/extension/statement_flow.py:parse_statement_flow"
     assert calls["name"] == "parse-statement"
-    assert calls["work_pool_name"] == "default"
+    assert calls["work_pool_name"] == "finance-report"
+    assert calls["ensured_pool"] == "finance-report"
 
 
 def test_AC_extraction_1913_3_worker_entrypoint_registers_before_starting_the_worker():
@@ -69,4 +84,5 @@ def test_AC_extraction_1913_3_worker_entrypoint_registers_before_starting_the_wo
     register_line = entrypoint.index("register_prefect_deployment.py")
     worker_start_line = entrypoint.index("prefect worker start")
     assert register_line < worker_start_line
-    assert "--pool default" in entrypoint
+    assert "--pool finance-report" in entrypoint
+    assert "--pool default" not in entrypoint

--- a/apps/backend/tests/tooling/test_prefect_deployment_registration.py
+++ b/apps/backend/tests/tooling/test_prefect_deployment_registration.py
@@ -74,6 +74,41 @@ def test_AC_extraction_1913_3_registration_script_deploys_from_local_source(monk
     assert calls["ensured_pool"] == "finance-report"
 
 
+def test_AC_extraction_1913_3_ensure_work_pool_exists_swallows_concurrent_create_race(monkeypatch):
+    """Two worker containers starting concurrently (e.g. old+new briefly
+    overlapping during a rolling restart) can both observe the pool missing
+    and both attempt to create it — the loser's 409 must not crash the
+    container (review finding on PR #1857)."""
+    import asyncio
+    from contextlib import asynccontextmanager
+
+    from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
+
+    calls = {"create": 0}
+
+    class _FakeClient:
+        async def read_work_pool(self, name: str) -> None:
+            raise ObjectNotFound(http_exc=Exception("404"))
+
+        async def create_work_pool(self, work_pool) -> None:
+            calls["create"] += 1
+            raise ObjectAlreadyExists(http_exc=Exception("409"))
+
+    @asynccontextmanager
+    async def fake_get_client():
+        yield _FakeClient()
+
+    import prefect.client.orchestration as orchestration_module
+
+    monkeypatch.setattr(orchestration_module, "get_client", fake_get_client)
+
+    from scripts.register_prefect_deployment import _ensure_work_pool_exists
+
+    asyncio.run(_ensure_work_pool_exists("finance-report"))  # must not raise
+
+    assert calls["create"] == 1
+
+
 def test_AC_extraction_1913_3_worker_entrypoint_registers_before_starting_the_worker():
     """The worker container must register the deployment BEFORE polling for
     work — otherwise the worker starts against a server with no matching


### PR DESCRIPTION
## Summary
- Staging E2E gate on the v0.1.38 deploy failed: 2 of 3 uploaded statements got stuck in `parsing` forever.
- Root cause (confirmed via VPS logs on `platform-prefect-worker-staging` and `finance_report-prefect-worker-staging`): our new worker (#1854/#1856) registered the `parse-statement` deployment on the `default` process work pool — the SAME pool every environment's platform-wide generic worker (`platform-prefect-worker*`) also polls. That generic worker has no finance_report app code baked in, so whenever it wins the race for one of our flow runs it crashes immediately with `FileNotFoundError: [Errno 2] No such file or directory: '/app'`, silently orphaning the statement in `parsing` forever. This raced ~2/3 of the time in the staging E2E run.
- Fix: move our deployment + worker onto a dedicated `finance-report` work pool. The pool is created idempotently via the Prefect client (`read_work_pool` / `create_work_pool`) before `.deploy()`, since — unlike `default` — it doesn't pre-exist on a fresh environment.

## Test plan
- [x] `apps/backend/.venv/bin/python -m pytest tests/tooling/test_prefect_deployment_registration.py --no-cov -q` — 3 passed, updated to assert the dedicated pool name and the idempotent pool-creation call.
- [x] `tools/preflight.py --tier=static` — green (verified pinned venv ruff directly; a local PATH-vs-pinned-ruff drift gave a false red first, unrelated to this diff).
- [ ] Re-deploy staging with this fix and confirm the E2E gate's statement-upload tests reach a terminal status without racing the generic worker (tracked as the immediate follow-up after merge).

preflight skipped: no — ran clean with pinned ruff.