### PR TITLE
[finance_report_ui] fix(#1864): S1 red-line hardening — PII-safe error text, no validation bypass, decimal-SSOT gate gap, bounded endpoints

### DIFF
--- a/apps/backend/src/audit/money/exchange_rate.py
+++ b/apps/backend/src/audit/money/exchange_rate.py
@@ -5,21 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 
+from src.audit.decimal_scalar import coerce_decimal
 from src.audit.money.currency import Currency
 from src.audit.money.errors import FloatNotAllowedError, InvalidExchangeRateError
 
 
 def _coerce_rate(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid FX rate")
-    if isinstance(value, float):
-        raise FloatNotAllowedError("float is not allowed for FX rates (IEEE-754 precision loss); use Decimal")
-    if isinstance(value, Decimal):
-        rate = value
-    elif isinstance(value, int):
-        rate = Decimal(value)
-    else:
-        raise FloatNotAllowedError(f"FX rate must be Decimal or int, got {type(value).__name__}")
+    """Coerce via the shared codec (AC-audit.36.2); positivity stays FX-specific."""
+    rate = coerce_decimal(value, "FX rate", float_error=FloatNotAllowedError)
     if not rate.is_finite() or rate <= 0:
         raise InvalidExchangeRateError("FX rate must be finite and positive")
     return rate

--- a/apps/backend/src/extraction/__init__.py
+++ b/apps/backend/src/extraction/__init__.py
@@ -58,6 +58,7 @@ from src.extraction.extension.brokerage_statement_payload import (
     _brokerage_import_not_ready_reason,
     _brokerage_payload_from_persisted_extraction,
     _brokerage_payload_from_statement,
+    reject_json_floats,
 )
 from src.extraction.extension.correction_loop import CorrectionLoopService
 from src.extraction.extension.correction_service import (
@@ -197,6 +198,7 @@ __all__ = [
     "TransactionDirection",
     "UploadedDocument",
     "_brokerage_import_not_ready_reason",
+    "reject_json_floats",
     "_brokerage_payload_from_persisted_extraction",
     "_brokerage_payload_from_statement",
     "approve_statement_workflow",

--- a/apps/backend/src/extraction/extension/brokerage_statement_payload.py
+++ b/apps/backend/src/extraction/extension/brokerage_statement_payload.py
@@ -15,6 +15,24 @@ from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
 
 
+def reject_json_floats(value: object, path: str) -> None:
+    """Recursively reject JSON floats in an import payload (money wire policy).
+
+    ``bool``/``int`` stay allowed (exact); a float anywhere in the brokerage
+    payload would launder IEEE-754 precision into position quantities or
+    market values via the importer's ``str(value)`` coercion (#1864 S1,
+    AC-portfolio.brokerage-import.10).
+    """
+    if isinstance(value, float):
+        raise ValueError(f"{path}: JSON floats are not allowed; encode amounts as decimal strings")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_json_floats(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_json_floats(item, f"{path}[{index}]")
+
+
 def _brokerage_payload_from_statement(
     statement: StatementSummary,
     transactions: list[AtomicTransaction],

--- a/apps/backend/src/extraction/extension/brokerage_statement_payload.py
+++ b/apps/backend/src/extraction/extension/brokerage_statement_payload.py
@@ -16,21 +16,23 @@ from src.extraction.orm.statement_summary import StatementSummary
 
 
 def reject_json_floats(value: object, path: str) -> None:
-    """Recursively reject JSON floats in an import payload (money wire policy).
+    """Reject JSON floats anywhere in an import payload (money wire policy).
 
     ``bool``/``int`` stay allowed (exact); a float anywhere in the brokerage
     payload would launder IEEE-754 precision into position quantities or
     market values via the importer's ``str(value)`` coercion (#1864 S1,
-    AC-portfolio.brokerage-import.10).
+    AC-portfolio.brokerage-import.10). Iterative (explicit stack) so a deeply
+    nested payload cannot trigger ``RecursionError``.
     """
-    if isinstance(value, float):
-        raise ValueError(f"{path}: JSON floats are not allowed; encode amounts as decimal strings")
-    if isinstance(value, dict):
-        for key, item in value.items():
-            reject_json_floats(item, f"{path}.{key}")
-    elif isinstance(value, list):
-        for index, item in enumerate(value):
-            reject_json_floats(item, f"{path}[{index}]")
+    stack: list[tuple[object, str]] = [(value, path)]
+    while stack:
+        current, at = stack.pop()
+        if isinstance(current, float):
+            raise ValueError(f"{at}: JSON floats are not allowed; encode amounts as decimal strings")
+        if isinstance(current, dict):
+            stack.extend((item, f"{at}.{key}") for key, item in current.items())
+        elif isinstance(current, list):
+            stack.extend((item, f"{at}[{index}]") for index, item in enumerate(current))
 
 
 def _brokerage_payload_from_statement(

--- a/apps/backend/src/extraction/extension/statement_parsing.py
+++ b/apps/backend/src/extraction/extension/statement_parsing.py
@@ -19,7 +19,7 @@ from src.extraction.orm.layer1 import DocumentStatus, DocumentType, UploadedDocu
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
 from src.extraction.orm.statement_summary import StatementSummary
 from src.identity import User
-from src.observability import get_logger, record_statement_parse_outcome
+from src.observability import get_logger, record_statement_parse_outcome, safe_error_message
 from src.runtime import StorageError, StorageService
 
 if TYPE_CHECKING:
@@ -28,8 +28,9 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _safe_error_message(message: str | None) -> str | None:
-    return message[:500] if message else message
+def _redacted(message: str | None, *, limit: int = 500) -> str | None:
+    """PII-redact and bound failure text, preserving ``None`` (no error)."""
+    return safe_error_message(message, limit=limit) if message else None
 
 
 def _count_brokerage_positions(payload: dict[str, Any] | None) -> int | None:
@@ -134,7 +135,7 @@ async def route_brokerage_for_review_if_present(
             phase="brokerage_review_routing_failed",
             model_to_use=model_to_use,
             error_type=type(exc).__name__,
-            safe_error_message=_safe_error_message(str(exc)),
+            safe_error_message=safe_error_message(str(exc)),
         )
         await db.rollback()
         refreshed = await db.get(StatementSummary, summary.id)
@@ -268,7 +269,7 @@ async def handle_parse_failure(
         except Exception as id_exc:
             logger.warning(
                 "Could not read statement id before rollback; will retry after rollback",
-                original_error=message,
+                original_error=_redacted(message),
                 id_error=str(id_exc),
             )
     try:
@@ -287,7 +288,7 @@ async def handle_parse_failure(
         except Exception as id_exc:
             logger.error(
                 "Could not resolve statement id in parse failure handler",
-                original_error=message,
+                original_error=_redacted(message),
                 id_error=str(id_exc),
             )
             return
@@ -297,11 +298,11 @@ async def handle_parse_failure(
             logger.error(
                 "Statement not found after rollback",
                 statement_id=str(statement_id),
-                reason=message,
+                reason=_redacted(message),
             )
             return
         refreshed.status = BankStatementStatus.REJECTED
-        refreshed.validation_error = message[:500] if message else message
+        refreshed.validation_error = _redacted(message)
         refreshed.confidence_score = 0
         refreshed.balance_validated = False
         if file_hash and storage_key:
@@ -322,7 +323,7 @@ async def handle_parse_failure(
             progress=progress,
             model_to_use=model_to_use,
             error_type=error_type,
-            safe_error_message=_safe_error_message(message),
+            safe_error_message=_redacted(message, limit=300),
         )
         # AC-observability.10.4: business metric for the parse outcome (failure path).
         record_statement_parse_outcome(outcome="failure")
@@ -330,7 +331,7 @@ async def handle_parse_failure(
         logger.exception(
             "Failed to mark statement as rejected",
             statement_id=str(statement_id),
-            original_error=message,
+            original_error=_redacted(message),
             inner_error=str(inner_exc),
         )
 

--- a/apps/backend/src/observability/telemetry_metrics.py
+++ b/apps/backend/src/observability/telemetry_metrics.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import src.config
+from src.observability.audit import safe_error_message
 from src.observability.logger import get_logger
 
 # Bound from the bare published root (see logger.py; config publishes no names).
@@ -196,15 +197,6 @@ def increment_async_parse_in_flight(delta: int = 1) -> None:
     set_async_parse_in_flight(_async_parse_in_flight + delta)
 
 
-def _safe_error_message(message: str | None, *, limit: int = 300) -> str | None:
-    if not message:
-        return message
-    compact = " ".join(str(message).split())
-    if len(compact) <= limit:
-        return compact
-    return f"{compact[:limit]}..."
-
-
 def record_async_parse_failure(*, error_type: str, task_name: str = "statement_parse") -> None:
     counter = _instruments.get("async_parse_failure")
     if counter is not None:
@@ -232,7 +224,7 @@ async def run_with_async_parse_tracking(
             request_id=request_id,
             task_name=task_name,
             error_type=error_type,
-            safe_error_message=_safe_error_message(str(exc)),
+            safe_error_message=safe_error_message(str(exc)),
         )
         raise
     finally:

--- a/apps/backend/src/reconciliation/extension/review_queue.py
+++ b/apps/backend/src/reconciliation/extension/review_queue.py
@@ -47,18 +47,20 @@ async def get_pending_items(
 
 async def accept_match(
     db: AsyncSession,
-    match_id: str,
+    match_id: UUID,
     *,
     user_id: UUID,
-    skip_amount_validation: bool = False,
 ) -> ReconciliationMatch:
     """Accept a pending reconciliation match.
+
+    Amount validation is unconditional: entry balance validation is never
+    skippable (red line; the former ``skip_amount_validation`` flag had zero
+    production callers and existed only to bypass it — removed in #1864).
 
     Args:
         db: Database session
         match_id: ID of the match to accept
         user_id: User ID for authorization
-        skip_amount_validation: If True, skip amount sum validation (for edge cases)
 
     Raises:
         ValueError: If match not found or amount validation fails
@@ -97,7 +99,7 @@ async def accept_match(
             match.journal_entry_ids = [str(created_entry.id)]
 
     # Validate that journal entry amounts match transaction amount
-    if match.journal_entry_ids and txn and not skip_amount_validation:
+    if match.journal_entry_ids and txn:
         entry_ids = [UUID(entry_id) for entry_id in match.journal_entry_ids]
         entries_result = await db.execute(
             select(JournalEntry)
@@ -199,7 +201,7 @@ async def batch_accept(
 
     accepted: list[ReconciliationMatch] = []
     for match in matches:
-        accepted.append(await accept_match(db, str(match.id), user_id=user_id))
+        accepted.append(await accept_match(db, match.id, user_id=user_id))
 
     await db.flush()
     return accepted

--- a/apps/backend/src/routers/ai_feedback.py
+++ b/apps/backend/src/routers/ai_feedback.py
@@ -1,6 +1,6 @@
 """AI suggestion feedback endpoints."""
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
 
 from src.deps import CurrentUserId, DbSession
@@ -41,8 +41,8 @@ async def create_ai_feedback(
 async def list_ai_suggestions(
     db: DbSession,
     user_id: CurrentUserId,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=200, description="Maximum items to return"),
+    offset: int = Query(0, ge=0),
 ) -> AiSuggestionListResponse:
     """List pending AI classification and reconciliation suggestions in the 60-84 review band."""
     items: list[AiSuggestionResponse] = []

--- a/apps/backend/src/routers/ai_feedback.py
+++ b/apps/backend/src/routers/ai_feedback.py
@@ -1,5 +1,7 @@
 """AI suggestion feedback endpoints."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
 
@@ -41,8 +43,8 @@ async def create_ai_feedback(
 async def list_ai_suggestions(
     db: DbSession,
     user_id: CurrentUserId,
-    limit: int = Query(50, ge=1, le=200, description="Maximum items to return"),
-    offset: int = Query(0, ge=0),
+    limit: Annotated[int, Query(ge=1, le=200, description="Maximum items to return")] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> AiSuggestionListResponse:
     """List pending AI classification and reconciliation suggestions in the 60-84 review band."""
     items: list[AiSuggestionResponse] = []

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -15,7 +15,7 @@ from src.extraction import create_entry_from_txn
 from src.extraction.orm.layer2 import AtomicTransaction
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Direction, JournalEntry
-from src.observability import get_logger, log_financial_mutation
+from src.observability import get_logger, log_financial_mutation, safe_error_message
 from src.platform import get_owned_or_404, raise_bad_request, raise_not_found
 from src.reconciliation import (
     ReconciliationMatch,
@@ -55,10 +55,6 @@ def _current_request_id() -> str:
     generated = str(uuid4())
     structlog.contextvars.bind_contextvars(request_id=generated)
     return generated
-
-
-def _safe_error_message(message: str | None) -> str | None:
-    return message[:500] if message else message
 
 
 def _unmatched_atomic_txn_query():
@@ -220,7 +216,7 @@ async def run_reconciliation(
             model_to_use=None,
             limit=payload.limit,
             error_type=type(exc).__name__,
-            safe_error_message=_safe_error_message(str(exc)),
+            safe_error_message=safe_error_message(str(exc)),
         )
         await db.rollback()
         raise
@@ -346,7 +342,7 @@ async def accept_match(
     user_id: CurrentUserId,
 ) -> ReconciliationMatchResponse:
     try:
-        match = await accept_match_service(db, str(match_id), user_id=user_id)
+        match = await accept_match_service(db, match_id, user_id=user_id)
         await db.commit()
     except ValueError as exc:
         if "not found" in str(exc).lower():

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 
 from src.audit import STATEMENT_SOURCE_TYPES
@@ -258,8 +258,8 @@ async def list_consistency_checks(
     status: CheckStatus | None = None,
     check_type: CheckType | None = None,
     run_id: str | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=200, description="Maximum items to return"),
+    offset: int = Query(0, ge=0),
 ) -> ConsistencyCheckListResponse:
     """List/filter consistency checks."""
     checks, total = await list_checks(
@@ -331,7 +331,7 @@ async def batch_approve_matches(
             had_source_entry = existing_entry_result.scalar_one_or_none() is not None
 
         try:
-            accepted_match = await accept_match_service(db, str(match.id), user_id=user_id)
+            accepted_match = await accept_match_service(db, match.id, user_id=user_id)
         except ValueError as exc:
             await db.rollback()
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -1,5 +1,6 @@
 """Stage 2 review endpoints for bank statement reconciliation."""
 
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -258,8 +259,8 @@ async def list_consistency_checks(
     status: CheckStatus | None = None,
     check_type: CheckType | None = None,
     run_id: str | None = None,
-    limit: int = Query(50, ge=1, le=200, description="Maximum items to return"),
-    offset: int = Query(0, ge=0),
+    limit: Annotated[int, Query(ge=1, le=200, description="Maximum items to return")] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> ConsistencyCheckListResponse:
     """List/filter consistency checks."""
     checks, total = await list_checks(

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -37,7 +37,7 @@ from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Account, AccountType
 from src.llm import LitellmCatalog, Modality
-from src.observability import ErrorIds, get_logger
+from src.observability import ErrorIds, get_logger, safe_error_message
 from src.platform import (
     get_owned_or_404,
     raise_bad_request,
@@ -88,10 +88,6 @@ def _current_request_id() -> str | None:
     generated = str(uuid4())
     structlog.contextvars.bind_contextvars(request_id=generated)
     return generated
-
-
-def _safe_error_message(message: str | None) -> str | None:
-    return message[:500] if message else message
 
 
 async def _resolve_uploaded_document(
@@ -351,7 +347,7 @@ async def upload_statement(
             file_size_bytes=len(content),
             file_hash_prefix=file_hash_prefix,
             error_type=type(exc).__name__,
-            safe_error_message=_safe_error_message(str(exc)),
+            safe_error_message=safe_error_message(str(exc)),
         )
         raise_service_unavailable(str(exc), cause=exc)
     logger.info(
@@ -658,7 +654,7 @@ async def import_brokerage_statement_positions(
             phase="brokerage_import_failed",
             model_to_use=None,
             error_type=type(exc).__name__,
-            safe_error_message=_safe_error_message(str(exc)),
+            safe_error_message=safe_error_message(str(exc)),
         )
         await db.rollback()
         raise

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, computed_field, field_validator
 
+from src.extraction import reject_json_floats
 from src.extraction.orm.layer3 import CostBasisMethod, PositionStatus
 from src.schemas.base import BaseResponse, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Percent, Quantity
 from src.schemas.provenance import DataProvenance
@@ -258,24 +259,6 @@ class CostBasisMethodUpdateRequest(BaseModel):
     cost_basis_method: CostBasisMethod
 
 
-def _reject_json_floats(value: object, path: str) -> None:
-    """Recursively reject JSON floats (money wire policy: decimal strings only).
-
-    ``bool``/``int`` stay allowed (exact); a float anywhere in the brokerage
-    payload would launder IEEE-754 precision into position quantities or
-    market values via the importer's ``str(value)`` coercion (#1864 S1,
-    AC-portfolio.brokerage-import.10).
-    """
-    if isinstance(value, float):
-        raise ValueError(f"{path}: JSON floats are not allowed; encode amounts as decimal strings")
-    if isinstance(value, dict):
-        for key, item in value.items():
-            _reject_json_floats(item, f"{path}.{key}")
-    elif isinstance(value, list):
-        for index, item in enumerate(value):
-            _reject_json_floats(item, f"{path}[{index}]")
-
-
 class BrokerageImportRequest(BaseModel):
     """Request to import parsed brokerage positions."""
 
@@ -286,7 +269,7 @@ class BrokerageImportRequest(BaseModel):
     @field_validator("payload")
     @classmethod
     def _payload_carries_no_floats(cls, value: dict) -> dict:
-        _reject_json_floats(value, "payload")
+        reject_json_floats(value, "payload")
         return value
 
 

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from src.extraction.orm.layer3 import CostBasisMethod, PositionStatus
 from src.schemas.base import BaseResponse, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Percent, Quantity
@@ -258,12 +258,36 @@ class CostBasisMethodUpdateRequest(BaseModel):
     cost_basis_method: CostBasisMethod
 
 
+def _reject_json_floats(value: object, path: str) -> None:
+    """Recursively reject JSON floats (money wire policy: decimal strings only).
+
+    ``bool``/``int`` stay allowed (exact); a float anywhere in the brokerage
+    payload would launder IEEE-754 precision into position quantities or
+    market values via the importer's ``str(value)`` coercion (#1864 S1,
+    AC-portfolio.brokerage-import.10).
+    """
+    if isinstance(value, float):
+        raise ValueError(f"{path}: JSON floats are not allowed; encode amounts as decimal strings")
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _reject_json_floats(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_json_floats(item, f"{path}[{index}]")
+
+
 class BrokerageImportRequest(BaseModel):
     """Request to import parsed brokerage positions."""
 
     payload: dict
     filename: str | None = None
     source_document_id: str | None = None
+
+    @field_validator("payload")
+    @classmethod
+    def _payload_carries_no_floats(cls, value: dict) -> dict:
+        _reject_json_floats(value, "payload")
+        return value
 
 
 class BrokerageImportResponse(BaseModel):

--- a/apps/backend/tests/api/test_ai_feedback_router.py
+++ b/apps/backend/tests/api/test_ai_feedback_router.py
@@ -326,3 +326,14 @@ async def test_ac18_5_6_get_ai_suggestions_scopes_to_current_user(
     body = response.json()
     assert body["items"] == []
     assert body["total"] == 0
+
+
+async def test_AC_ai_suggestions_1_list_rejects_unbounded_limit(
+    client: AsyncClient,
+) -> None:
+    """AC-identity.ai-suggestions.1: over-limit page size is rejected with 422 (#1864)."""
+    response = await client.get("/ai/suggestions", params={"limit": 10_000})
+    assert response.status_code == 422
+
+    response = await client.get("/ai/suggestions", params={"limit": 0})
+    assert response.status_code == 422

--- a/apps/backend/tests/audit/money/test_money_backend_module.py
+++ b/apps/backend/tests/audit/money/test_money_backend_module.py
@@ -164,3 +164,20 @@ def test_AC2_22_1_statement_summary_typed_currency_balances():
     # NULL/empty -> empty typed container (scalar degenerate case lives elsewhere).
     empty = StatementSummary()
     assert len(empty.typed_currency_balances()) == 0
+
+
+def test_exchange_rate_coercion_routes_through_shared_codec_and_keeps_fx_invariants():
+    """AC-audit.36.2 (#1864 backfill): backend ``_coerce_rate`` delegates to the shared
+    codec (float/bool rejection) while the finite-and-positive rule stays FX-specific."""
+    from src.audit.money.errors import FloatNotAllowedError, InvalidExchangeRateError
+
+    with pytest.raises(FloatNotAllowedError):
+        ExchangeRate(Currency.of("USD"), Currency.of("SGD"), 1.35)
+    with pytest.raises(FloatNotAllowedError):
+        ExchangeRate(Currency.of("USD"), Currency.of("SGD"), True)
+    with pytest.raises(FloatNotAllowedError):
+        ExchangeRate(Currency.of("USD"), Currency.of("SGD"), "1.35")
+    for bad_rate in (Decimal("0"), Decimal("-1.35"), Decimal("NaN"), Decimal("Infinity")):
+        with pytest.raises(InvalidExchangeRateError):
+            ExchangeRate(Currency.of("USD"), Currency.of("SGD"), bad_rate)
+    assert ExchangeRate(Currency.of("USD"), Currency.of("SGD"), Decimal("1.35")).rate == Decimal("1.35")

--- a/apps/backend/tests/extraction/test_parse_failure_redaction.py
+++ b/apps/backend/tests/extraction/test_parse_failure_redaction.py
@@ -1,0 +1,43 @@
+"""Parse-failure text is PII-redacted before persistence/logging (#1864 S1).
+
+AC-observability.safe-error-ssot.2: ``handle_parse_failure`` routes the failure
+message through ``safe_error_message`` for both the ``validation_error`` column
+and the failure-log fields, so an exception message quoting statement content
+(emails, account numbers) never lands raw.
+"""
+
+from src.extraction.extension.statement_parsing import handle_parse_failure
+from src.extraction.orm.statement_enums import BankStatementStatus
+from src.extraction.orm.statement_summary import StatementSummary
+from tests.factories import StatementSummaryFactory, UploadedDocumentFactory
+
+PII_MESSAGE = "Failed to parse row 12: unexpected value for john.doe@example.com (account 123456789012)"
+
+
+async def test_AC_safe_error_ssot_2_handle_parse_failure_redacts_pii(db, test_user):
+    """AC-observability.safe-error-ssot.2: validation_error is redacted and bounded."""
+    doc = await UploadedDocumentFactory.create_async(db, user_id=test_user.id)
+    summary = await StatementSummaryFactory.create_async(
+        db,
+        user_id=test_user.id,
+        uploaded_document_id=doc.id,
+        file_hash=doc.file_hash,
+    )
+    await db.commit()
+
+    await handle_parse_failure(
+        summary,
+        db,
+        message=PII_MESSAGE,
+        statement_id=summary.id,
+        error_type="ValueError",
+    )
+
+    refreshed = await db.get(StatementSummary, summary.id)
+    assert refreshed is not None
+    assert refreshed.status == BankStatementStatus.REJECTED
+    stored = refreshed.validation_error or ""
+    assert stored, "failure message must be persisted for the rejection reason"
+    assert "john.doe@example.com" not in stored, "raw email persisted to validation_error"
+    assert "123456789012" not in stored, "raw account number persisted to validation_error"
+    assert "[EMAIL]" in stored, "redaction label missing — message did not go through safe_error_message"

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -390,7 +390,9 @@ def test_AC10_12_3_parse_failure_state_and_log_contract_are_preserved() -> None:
 
     assert "refreshed.status = BankStatementStatus.REJECTED" in source
     assert '"statement.parse.failed"' in source
-    assert "safe_error_message=_safe_error_message(message)" in source
+    # #1864 S1: the failure log's safe_error_message field routes through the
+    # PII-redacting sanitizer (None-preserving wrapper around safe_error_message).
+    assert "safe_error_message=_redacted(message, limit=300)" in source
 
 
 def test_AC10_10_4_business_metric_helpers_record_outcomes(monkeypatch) -> None:

--- a/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
+++ b/apps/backend/tests/portfolio/test_brokerage_position_parsing.py
@@ -962,3 +962,41 @@ async def test_AC17_4_14_brokerage_import_links_statement_to_broker_account(clie
     assert account is not None
     assert account.type == AccountType.ASSET
     assert account.name == "Moomoo"
+
+
+async def test_AC_brokerage_import_10_payload_rejects_json_floats(client):
+    """AC-portfolio.brokerage-import.10: JSON floats anywhere in the payload → 422 (#1864).
+
+    Amounts travel as decimal strings (money wire policy); a float would launder
+    IEEE-754 precision into position quantities/market values via str(value).
+    """
+    response = await client.post(
+        "/portfolio/brokerage/import",
+        json={
+            "filename": "ibkr.csv",
+            "payload": {
+                "institution": "Interactive Brokers",
+                "statement": {"period_end": "2026-05-18", "currency": "USD"},
+                "positions": [{"symbol": "MSFT", "quantity": 2.5, "market_value": 860.0, "currency": "USD"}],
+            },
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert "float" in str(detail).lower()
+
+
+async def test_AC_brokerage_import_10_decimal_string_payload_still_accepted(client):
+    """AC-portfolio.brokerage-import.10 guard: the decimal-string wire shape keeps working."""
+    response = await client.post(
+        "/portfolio/brokerage/import",
+        json={
+            "filename": "ibkr.csv",
+            "payload": {
+                "institution": "Interactive Brokers",
+                "statement": {"period_end": "2026-05-18", "currency": "USD"},
+                "positions": [{"symbol": "MSFT", "quantity": "2", "market_value": "860.00", "currency": "USD"}],
+            },
+        },
+    )
+    assert response.status_code == 200

--- a/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
@@ -473,7 +473,7 @@ async def test_accept_match_already_accepted_is_idempotent(db: AsyncSession, tes
     await db.commit()
 
     # Second accept should be idempotent
-    result = await accept_match_service(db, str(match.id), user_id=test_user.id)
+    result = await accept_match_service(db, match.id, user_id=test_user.id)
 
     assert result.status == ReconciliationStatus.ACCEPTED
 
@@ -566,7 +566,7 @@ async def test_accept_match_amount_mismatch_raises(db: AsyncSession, test_user) 
     await db.commit()
 
     with pytest.raises(ValueError, match="Amount mismatch"):
-        await accept_match_service(db, str(match.id), user_id=test_user.id)
+        await accept_match_service(db, match.id, user_id=test_user.id)
 
 
 async def test_accept_match_amount_within_tolerance(db: AsyncSession, test_user) -> None:
@@ -612,7 +612,7 @@ async def test_accept_match_amount_within_tolerance(db: AsyncSession, test_user)
     db.add(match)
     await db.commit()
 
-    result = await accept_match_service(db, str(match.id), user_id=test_user.id)
+    result = await accept_match_service(db, match.id, user_id=test_user.id)
     assert result.status == ReconciliationStatus.ACCEPTED
 
 

--- a/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
@@ -616,8 +616,8 @@ async def test_accept_match_amount_within_tolerance(db: AsyncSession, test_user)
     assert result.status == ReconciliationStatus.ACCEPTED
 
 
-async def test_accept_match_skip_validation_bypasses_check(db: AsyncSession, test_user) -> None:
-    """Accept match with skip_amount_validation=True should bypass validation."""
+async def test_accept_match_amount_check_cannot_be_bypassed(db: AsyncSession, test_user) -> None:
+    """AC-reconciliation.review-hardening.2: mismatched amounts always raise (#1864)."""
     from src.reconciliation.extension.review_queue import accept_match as accept_match_service
 
     statement = await _create_statement(db, test_user.id)
@@ -637,7 +637,7 @@ async def test_accept_match_skip_validation_bypasses_check(db: AsyncSession, tes
     db.add(entry)
     await db.flush()
 
-    # Entry amount is $50, but we skip validation
+    # Entry amount is $50 vs a $100 transaction — a real mismatch
     db.add(
         JournalLine(
             journal_entry_id=entry.id,
@@ -659,9 +659,9 @@ async def test_accept_match_skip_validation_bypasses_check(db: AsyncSession, tes
     db.add(match)
     await db.commit()
 
-    # Should succeed with skip_amount_validation=True
-    result = await accept_match_service(db, str(match.id), user_id=test_user.id, skip_amount_validation=True)
-    assert result.status == ReconciliationStatus.ACCEPTED
+    # $50 entry vs $100 transaction: validation is unconditional, so this raises.
+    with pytest.raises(ValueError, match="Amount mismatch"):
+        await accept_match_service(db, match.id, user_id=test_user.id)
 
 
 async def test_batch_accept_skips_low_score_matches(db: AsyncSession, test_user) -> None:

--- a/apps/backend/tests/reconciliation/test_review_queue.py
+++ b/apps/backend/tests/reconciliation/test_review_queue.py
@@ -13,6 +13,7 @@ review-queue services can resolve the owning statement. Matches are keyed on
 source of truth).
 """
 
+import inspect
 from datetime import date
 from decimal import Decimal
 from unittest.mock import patch
@@ -174,7 +175,12 @@ async def test_accept_match_amount_mismatch_raises(db, test_user):
         await accept_match(db, str(match.id), user_id=test_user.id)
 
 
-async def test_accept_match_skip_amount_validation(db, test_user):
+async def test_AC_review_hardening_2_accept_match_validation_unconditional(db, test_user):
+    """AC-reconciliation.review-hardening.2: amount validation cannot be bypassed (#1864)."""
+    # The public signature carries no bypass flag — entry balance validation
+    # is never skippable (red line).
+    assert "skip_amount_validation" not in inspect.signature(accept_match).parameters
+
     stmt = await _make_statement(db, test_user.id)
     txn = await _make_txn(db, test_user.id, stmt, amount=Decimal("500.00"))
     entry, _, _ = await JournalEntryFactory.create_balanced_async(db, user_id=test_user.id, amount=Decimal("100.00"))
@@ -186,8 +192,8 @@ async def test_accept_match_skip_amount_validation(db, test_user):
     )
     await db.commit()
 
-    result = await accept_match(db, str(match.id), user_id=test_user.id, skip_amount_validation=True)
-    assert result.status == ReconciliationStatus.ACCEPTED
+    with pytest.raises(ValueError, match="Amount mismatch"):
+        await accept_match(db, match.id, user_id=test_user.id)
 
 
 async def test_accept_match_reconciles_journal_entries(db, test_user):
@@ -250,7 +256,7 @@ async def test_accept_match_does_not_reconcile_void_entries(db, test_user):
     )
     await db.commit()
 
-    await accept_match(db, str(match.id), user_id=test_user.id, skip_amount_validation=True)
+    await accept_match(db, match.id, user_id=test_user.id)
     await db.refresh(entry)
     assert entry.status == JournalEntryStatus.VOID
 

--- a/apps/backend/tests/reconciliation/test_review_queue.py
+++ b/apps/backend/tests/reconciliation/test_review_queue.py
@@ -132,14 +132,14 @@ async def test_accept_match_updates_status(db, test_user):
     )
     await db.commit()
 
-    result = await accept_match(db, str(match.id), user_id=test_user.id)
+    result = await accept_match(db, match.id, user_id=test_user.id)
     assert result.status == ReconciliationStatus.ACCEPTED
     assert result.version == 2
 
 
 async def test_accept_match_not_found_raises(db, test_user):
     with pytest.raises(ValueError, match="Match not found"):
-        await accept_match(db, str(uuid4()), user_id=test_user.id)
+        await accept_match(db, uuid4(), user_id=test_user.id)
 
 
 async def test_accept_match_already_accepted_returns_unchanged(db, test_user):
@@ -154,7 +154,7 @@ async def test_accept_match_already_accepted_returns_unchanged(db, test_user):
     )
     await db.commit()
 
-    result = await accept_match(db, str(match.id), user_id=test_user.id)
+    result = await accept_match(db, match.id, user_id=test_user.id)
     assert result.status == ReconciliationStatus.ACCEPTED
     assert result.version == 1
 
@@ -172,7 +172,7 @@ async def test_accept_match_amount_mismatch_raises(db, test_user):
     await db.commit()
 
     with pytest.raises(ValueError, match="Amount mismatch"):
-        await accept_match(db, str(match.id), user_id=test_user.id)
+        await accept_match(db, match.id, user_id=test_user.id)
 
 
 async def test_AC_review_hardening_2_accept_match_validation_unconditional(db, test_user):
@@ -208,7 +208,7 @@ async def test_accept_match_reconciles_journal_entries(db, test_user):
     )
     await db.commit()
 
-    await accept_match(db, str(match.id), user_id=test_user.id)
+    await accept_match(db, match.id, user_id=test_user.id)
     await db.refresh(entry)
     assert entry.status == JournalEntryStatus.RECONCILED
 
@@ -232,7 +232,7 @@ async def test_accept_match_creates_missing_journal_entry(db, test_user):
     )
     await db.commit()
 
-    result = await accept_match(db, str(match.id), user_id=test_user.id)
+    result = await accept_match(db, match.id, user_id=test_user.id)
 
     assert result.status == ReconciliationStatus.ACCEPTED
     assert len(result.journal_entry_ids) == 1

--- a/apps/backend/tests/review/test_consistency_checks.py
+++ b/apps/backend/tests/review/test_consistency_checks.py
@@ -629,3 +629,12 @@ class TestGetPendingChecksEdgeCases:
         result = await get_pending_checks(db, user_id, severity="high")
         assert len(result) == 1
         assert result[0].id == high_check.id
+
+
+async def test_AC_consistency_checks_10_list_endpoint_rejects_unbounded_limit(client):
+    """AC-reconciliation.consistency-checks.10: over-limit page size → 422 (#1864)."""
+    response = await client.get("/statements/consistency-checks/list", params={"limit": 10_000})
+    assert response.status_code == 422
+
+    response = await client.get("/statements/consistency-checks/list", params={"limit": 0})
+    assert response.status_code == 422

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -11484,11 +11484,15 @@
         "operationId": "list_ai_suggestions_ai_suggestions_get",
         "parameters": [
           {
+            "description": "Maximum items to return",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 50,
+              "description": "Maximum items to return",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -11499,6 +11503,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Offset",
               "type": "integer"
             }
@@ -24214,11 +24219,15 @@
             }
           },
           {
+            "description": "Maximum items to return",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 50,
+              "description": "Maximum items to return",
+              "maximum": 200,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -24229,6 +24238,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "minimum": 0,
               "title": "Offset",
               "type": "integer"
             }

--- a/common/audit/money/exchange_rate.py
+++ b/common/audit/money/exchange_rate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 
+from common.audit.decimal_scalar import coerce_decimal
 from common.audit.money.currency import Currency
 from common.audit.money.errors import FloatNotAllowedError, InvalidExchangeRateError
 
@@ -12,20 +13,8 @@ _RateInput = Decimal | int
 
 
 def _coerce_rate(value: object) -> Decimal:
-    if isinstance(value, bool):
-        raise FloatNotAllowedError("bool is not a valid FX rate")
-    if isinstance(value, float):
-        raise FloatNotAllowedError(
-            "float is not allowed for FX rates (IEEE-754 precision loss); use Decimal"
-        )
-    if isinstance(value, Decimal):
-        rate = value
-    elif isinstance(value, int):
-        rate = Decimal(value)
-    else:
-        raise FloatNotAllowedError(
-            f"FX rate must be Decimal or int, got {type(value).__name__}"
-        )
+    """Coerce via the shared codec (AC-audit.36.1); positivity stays FX-specific."""
+    rate = coerce_decimal(value, "FX rate", float_error=FloatNotAllowedError)
     if not rate.is_finite() or rate <= 0:
         raise InvalidExchangeRateError("FX rate must be finite and positive")
     return rate

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -223,6 +223,7 @@ CONTRACT = PackageContract(
         "record_correction",
         "register_fx_rate_provider",
         "register_position_reconciler",
+        "reject_json_floats",
         "reject_statement_workflow",
         "resolve_custody_account_id",
         "resolve_ingest_currency",

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -629,5 +629,21 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group ai-suggestions: the AiFeedback review surface (#1864 S1) ──
+        ACRecord(
+            id="AC-identity.ai-suggestions.1",
+            statement=(
+                "``GET /ai/suggestions`` enforces a bounded page "
+                "size: ``limit`` is declared with ``ge=1, le=200`` and an "
+                "over-limit request is rejected with 422 instead of being "
+                "accepted unbounded (#1864 S1)."
+            ),
+            test=(
+                "apps/backend/tests/api/test_ai_feedback_router.py"
+                "::test_AC_ai_suggestions_1_list_rejects_unbounded_limit"
+            ),
+            priority="P1",
+            status="done",
+        ),
     ],
 )

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -1196,6 +1196,41 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        # ── group safe-error-ssot: one PII-redacting error-text sanitizer
+        # (naive `[:500]` copies in routers/extraction bypassed redaction,
+        # signature review 2026-07-15, #1864 S1) ──
+        ACRecord(
+            id="AC-observability.safe-error-ssot.1",
+            statement=(
+                "Exactly one error-text sanitizer exists: "
+                "``safe_error_message`` in ``src/observability/audit.py``. No "
+                "module under ``apps/backend/src/`` defines a local "
+                "``_safe_error_message`` — the naive truncate-only copies "
+                "bypassed PII redaction on parse/match failure paths."
+            ),
+            test=(
+                "tests/tooling/test_safe_error_message_ssot.py"
+                "::test_AC_safe_error_ssot_1_single_sanitizer_definition"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-observability.safe-error-ssot.2",
+            statement=(
+                "Parse-failure text is PII-redacted and bounded before it is "
+                "persisted or logged: a failure message carrying an email or "
+                "account number reaches neither ``validation_error`` nor the "
+                "failure-log fields raw — both go through "
+                "``safe_error_message``."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_parse_failure_redaction.py"
+                "::test_AC_safe_error_ssot_2_handle_parse_failure_redacts_pii"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
     concepts=[
         ConceptRecord(

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -1789,6 +1789,23 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-portfolio.brokerage-import.10",
+            statement=(
+                "``POST /portfolio/brokerage/import`` validates the payload "
+                "at the wire boundary: a JSON float anywhere in the payload "
+                "tree is rejected with 422 (amounts travel as decimal "
+                "strings per the money wire policy), so float-precision "
+                "values can never launder into position quantities or market "
+                "values (#1864 S1)."
+            ),
+            test=(
+                "apps/backend/tests/portfolio/test_brokerage_position_parsing.py"
+                "::test_AC_brokerage_import_10_payload_rejects_json_floats"
+            ),
+            priority="P0",
+            status="done",
+        ),
         # ── Wave B (#1821): frontend-proof rows migrated from EPIC-016
         # (two-stage-review-ui) ──
         ACRecord(

--- a/common/reconciliation/contract.py
+++ b/common/reconciliation/contract.py
@@ -1321,6 +1321,22 @@ CONTRACT = PackageContract(
             priority="P0",
             status="done",
         ),
+        ACRecord(
+            id="AC-reconciliation.review-hardening.2",
+            statement=(
+                "``accept_match`` validates journal-entry amounts against the "
+                "transaction unconditionally: the public signature carries no "
+                "bypass flag, and accepting a match whose entry total "
+                "mismatches the transaction amount raises (entry balance "
+                "validation is never skippable — red line, #1864 S1)."
+            ),
+            test=(
+                "apps/backend/tests/reconciliation/test_review_queue.py"
+                "::test_AC_review_hardening_2_accept_match_validation_unconditional"
+            ),
+            priority="P0",
+            status="done",
+        ),
         # ── group audit-anchors: reconciliation-to-ledger anchor referential
         # integrity (was EPIC-018 AC18.11.1, migration closeout continuation,
         # #1663 / #1711) ──
@@ -1407,6 +1423,21 @@ CONTRACT = PackageContract(
             test=(
                 "apps/backend/tests/review/test_consistency_checks.py"
                 "::test_detect_transfer_pairs"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-reconciliation.consistency-checks.10",
+            statement=(
+                "``GET /statements/consistency-checks/list`` enforces a bounded "
+                "page size: ``limit`` is declared with ``ge=1, le=200`` and an "
+                "over-limit request is rejected with 422 instead of being "
+                "accepted unbounded (#1864 S1)."
+            ),
+            test=(
+                "apps/backend/tests/review/test_consistency_checks.py"
+                "::test_AC_consistency_checks_10_list_endpoint_rejects_unbounded_limit"
             ),
             priority="P1",
             status="done",

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,5 +15,5 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:154 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:525 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:805 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:541 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:689 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:537 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:685 |

--- a/tests/tooling/test_decimal_scalar_ssot.py
+++ b/tests/tooling/test_decimal_scalar_ssot.py
@@ -42,6 +42,10 @@ def _assert_layer_shares_one_codec(layer_root: str, import_prefix: str) -> None:
     }
     core_modules = {
         "money": f"{layer_root}/audit/money/money.py",
+        # exchange_rate escaped the original list and re-inlined the _coerce
+        # body (#1864 S1 backfill) — every construction-time coercion in the
+        # money package routes through the shared codec.
+        "money.exchange_rate": f"{layer_root}/audit/money/exchange_rate.py",
         "quantity": f"{layer_root}/audit/quantity/quantity.py",
         "ratio": f"{layer_root}/audit/ratio/ratio.py",
         "unit_price": f"{layer_root}/audit/unit_price/unit_price.py",

--- a/tests/tooling/test_safe_error_message_ssot.py
+++ b/tests/tooling/test_safe_error_message_ssot.py
@@ -10,6 +10,7 @@ telemetry — none redacted PII, so parse/match failure text reached logs and th
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from common.testing.ac_proof import ac_proof
@@ -17,6 +18,12 @@ from common.testing.ac_proof import ac_proof
 REPO = Path(__file__).resolve().parents[2]
 BACKEND_SRC = REPO / "apps" / "backend" / "src"
 CANONICAL = BACKEND_SRC / "observability" / "audit.py"
+
+# Line-anchored so comments/strings can't false-positive, and async-aware so a
+# coroutine copy can't slip through (Copilot review, PR #1871).
+_LOCAL_SANITIZER_DEF = re.compile(
+    r"^\s*(?:async\s+)?def _safe_error_message\(", re.MULTILINE
+)
 
 
 def _backend_source_files() -> list[Path]:
@@ -35,7 +42,7 @@ def test_AC_safe_error_ssot_1_single_sanitizer_definition():
     offenders = [
         str(path.relative_to(REPO))
         for path in _backend_source_files()
-        if "def _safe_error_message(" in path.read_text(encoding="utf-8")
+        if _LOCAL_SANITIZER_DEF.search(path.read_text(encoding="utf-8"))
     ]
     assert not offenders, (
         "local _safe_error_message copies bypass PII redaction; import "

--- a/tests/tooling/test_safe_error_message_ssot.py
+++ b/tests/tooling/test_safe_error_message_ssot.py
@@ -1,0 +1,48 @@
+"""One PII-redacting error-text sanitizer per backend (AC-observability.safe-error-ssot).
+
+The canonical sanitizer is ``src/observability/audit.py::safe_error_message``
+(whitespace collapse + PII redaction + length bound). The 2026-07-15 signature
+review (#1864) found three naive ``return message[:500]`` copies named
+``_safe_error_message`` in routers/extraction plus a truncate-only variant in
+telemetry — none redacted PII, so parse/match failure text reached logs and the
+``validation_error`` column raw. This gate keeps the copies from coming back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+BACKEND_SRC = REPO / "apps" / "backend" / "src"
+CANONICAL = BACKEND_SRC / "observability" / "audit.py"
+
+
+def _backend_source_files() -> list[Path]:
+    return [
+        path for path in BACKEND_SRC.rglob("*.py") if "__pycache__" not in path.parts
+    ]
+
+
+@ac_proof(
+    proof_id="test_safe_error_message_single_sanitizer",
+    ac_ids=["AC-observability.safe-error-ssot.1"],
+    ci_tier="pr_ci",
+)
+def test_AC_safe_error_ssot_1_single_sanitizer_definition():
+    """AC-observability.safe-error-ssot.1: no local ``_safe_error_message`` copies."""
+    offenders = [
+        str(path.relative_to(REPO))
+        for path in _backend_source_files()
+        if "def _safe_error_message(" in path.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        "local _safe_error_message copies bypass PII redaction; import "
+        f"src.observability.audit.safe_error_message instead: {offenders}"
+    )
+
+    canonical_src = CANONICAL.read_text(encoding="utf-8")
+    assert "def safe_error_message(" in canonical_src, (
+        "canonical sanitizer missing from src/observability/audit.py"
+    )


### PR DESCRIPTION
Closes #1864 (S1 of the #1863 signature-cleanup root).

## What & why

Five signature-level fixes where code bypassed stated red lines (all source-verified in the 2026-07-15 full-repo signature review):

| # | Fix | AC |
|---|-----|----|
| 1 | **One PII sanitizer.** Deleted the four naive `_safe_error_message` copies (`routers/statements.py`, `routers/reconciliation.py`, `extraction/extension/statement_parsing.py`, `observability/telemetry_metrics.py`); every parse/match failure path now routes through `observability.audit.safe_error_message` — including the previously **raw** `validation_error` DB write and `original_error`/`reason` log fields in `handle_parse_failure`. New tooling gate bans the copies from returning. | AC-observability.safe-error-ssot.1/.2 |
| 2 | **No validation bypass.** `accept_match` loses the never-used `skip_amount_validation` flag (entry balance validation is never skippable — red line); `match_id` typed `UUID`. The three tests that exercised the bypass now prove the opposite (mismatch always raises). | AC-reconciliation.review-hardening.2 |
| 3 | **Decimal-SSOT gate gap closed.** `_coerce_rate` in `money/exchange_rate.py` had re-inlined the canonical codec body on both layers; it now delegates to `coerce_decimal` (positivity check stays FX-specific, `InvalidExchangeRateError` semantics preserved — money conformance vectors + API-parity green). `exchange_rate.py` added to `test_decimal_scalar_ssot.py`'s module lists (test-gap backfill on AC-audit.36.1/36.2: the AC said "no base package re-defines the _coerce body" but the gate's file list missed this module). | AC-audit.36.1/36.2 backfill |
| 4 | **Bounded list endpoints.** `GET /statements/consistency-checks/list` and `GET /ai/suggestions` accepted `?limit=10000000`; both now declare `Query(50, ge=1, le=200)` (+ `offset ge=0`) and 422 over-limit requests. (Convention-wide `Pagination` adoption + route-walk gate stays in S2 #1865.) | AC-reconciliation.consistency-checks.10, AC-identity.ai-suggestions.1 |
| 5 | **Typed brokerage import boundary.** `BrokerageImportRequest.payload` recursively rejects JSON floats (422) — amounts travel as decimal strings per the money wire policy; a float would launder IEEE-754 precision into position quantities/market values via the importer's `str(value)` coercion. Decimal-string wire shape unchanged (guard test included); ints/bools stay allowed (exact). | AC-portfolio.brokerage-import.10 |

## Work order

MECE slice of #1864 (all 5 items, nothing from S2–S5) → 6 new ACs registered in owning package contracts (`observability`, `reconciliation` ×2, `identity`, `portfolio`) → failing tests first (SSOT gate red on all 4 copies; endpoint tests red) → minimal code → registry regenerated (`generate_ac_registry.py`, `check_ac_index`, `check_epic_package_dual` green).

## Gates

- Affected backend suites green locally: review_queue (35), router_additional + consistency + ai_feedback + parse-failure-redaction + telemetry (72), brokerage (31+2 new), audit/money both layers (73 + 45 tooling incl. conformance vectors & API parity).
- Changed-line coverage confirmed via scoped `--cov` (new `_coerce_rate` raise covered by a new backend test).
- Generated artifacts refreshed: `apps/frontend/openapi.json`, `docs/reference/router-contract-maturity.md` (new `le=200` bounds are in the FE contract).
- `preflight --tier=static`: **7/9 green**; `schema-validate` and `backend-format` fail **identically on main** (99 legacy missing `Field(description=...)`; system ruff 0.15 UP042×65 vs pinned 0.14 — version drift). Zero new violations from this diff (error counts identical on stashed baseline). Committed with the documented `SKIP=mypy,validate-schemas` local-hook recipe; mypy errors shown are pre-existing (`DbSession = None` implicit-Optional pile — owned by S2 #1865).

🤖 Generated with [Claude Code](https://claude.com/claude-code)