### PR TITLE
[finance_report_ui] fix(#1868): S5 PR-B — single-home countLabel/readinessVariant/getPnlColor/isActive/formatCurrency, dedupe lib/audit wire+locale boilerplate

### DIFF
--- a/apps/frontend/src/__tests__/navigation.test.ts
+++ b/apps/frontend/src/__tests__/navigation.test.ts
@@ -8,6 +8,7 @@ import {
   auditHubItems,
   bottomTabItems,
   getRouteConfig,
+  isActive,
   moreItems,
 } from "@/components/navigation";
 
@@ -108,5 +109,15 @@ describe("navigation metadata", () => {
     expect(ROUTE_CONFIG["/events"]).toBeUndefined();
     expect(getRouteConfig("/events").label).toBe("Events");
     expect(getRouteConfig("/notifications").label).toBe("Notifications");
+  });
+
+  // Single-homed from Sidebar.tsx/BottomTabBar.tsx byte-identical duplicates (#1868 S5).
+  it("isActive matches home exactly and other routes exactly or by path prefix", () => {
+    expect(isActive("/", "/")).toBe(true);
+    expect(isActive("/reports", "/")).toBe(false);
+    expect(isActive("/reports", "/reports")).toBe(true);
+    expect(isActive("/reports/balance-sheet", "/reports")).toBe(true);
+    expect(isActive("/reportsomething", "/reports")).toBe(false);
+    expect(isActive("/journal", "/reports")).toBe(false);
   });
 });

--- a/apps/frontend/src/__tests__/reportsCockpit.test.tsx
+++ b/apps/frontend/src/__tests__/reportsCockpit.test.tsx
@@ -224,7 +224,10 @@ describe("Reports cockpit (EPIC-022 AC22.3)", () => {
       await waitFor(() =>
         expect(cockpit).toHaveTextContent(`Current package state is ${label.toLowerCase()}.`),
       )
-      expect(cockpit).toHaveTextContent("unknown source")
+      // sourceClassLabel's fallback is now the shared lib/statusLabels
+      // humanizeIdentifier (title-cased, acronym-aware) — was a plain
+      // replaceAll("_"," ") local to this page, #1868 S5.
+      expect(cockpit).toHaveTextContent("Unknown Source")
       const statusBadge = Array.from(cockpit.querySelectorAll(".badge")).find(
         (badge) => badge.textContent === label,
       )

--- a/apps/frontend/src/__tests__/statementDetailParts.test.tsx
+++ b/apps/frontend/src/__tests__/statementDetailParts.test.tsx
@@ -6,6 +6,8 @@ import { StatementSummaryCards } from "@/app/(main)/statements/[id]/_components/
 import { StatementTransactionsTable } from "@/app/(main)/statements/[id]/_components/StatementTransactionsTable";
 import { BrokerageImportResultBanner } from "@/app/(main)/statements/[id]/_components/BrokerageImportResultBanner";
 import { BankStatement, BankStatementTransaction, BrokerageImportResponse } from "@/lib/types";
+import { currencyCodeOrDash as formatCode } from "@/lib/statusLabels";
+import { formatPeriod } from "@/lib/date";
 
 vi.mock("next/link", () => ({
     default: ({ href, children, ...rest }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
@@ -47,12 +49,6 @@ const txn: BankStatementTransaction = {
     confidence: "high",
     created_at: "2026-01-02T00:00:00Z",
     updated_at: "2026-01-02T00:00:00Z",
-};
-
-const formatCode = (currency?: string | null) => currency || "—";
-const formatPeriod = (start?: string | null, end?: string | null) => {
-    if (!start || !end) return "Parsing...";
-    return `${start} to ${end}`;
 };
 
 function renderHeader(overrides: Partial<React.ComponentProps<typeof StatementHeader>> = {}) {

--- a/apps/frontend/src/__tests__/statusLabels.test.ts
+++ b/apps/frontend/src/__tests__/statusLabels.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 
-import { confidenceLabel, coverageLabel } from "@/lib/statusLabels";
+import {
+    checkSeverityColor,
+    checkTypeLabel,
+    confidenceLabel,
+    countLabel,
+    coverageLabel,
+    currencyCodeOrDash,
+    humanizeIdentifier,
+    pnlColorClass,
+    readinessVariant,
+    sourceClassLabel,
+} from "@/lib/statusLabels";
 
 describe("statusLabels (#1609 colour-not-alone)", () => {
     it("confidenceLabel covers every tier", () => {
@@ -17,5 +28,65 @@ describe("statusLabels (#1609 colour-not-alone)", () => {
         expect(coverageLabel(72)).toBe("Fair");
         expect(coverageLabel(60)).toBe("Fair");
         expect(coverageLabel(30)).toBe("Needs attention");
+    });
+});
+
+// #1868 S5 PR-B: helpers single-homed from component-local duplicates.
+describe("statusLabels — single-homed helpers (#1868 S5)", () => {
+    it("currencyCodeOrDash returns the code, or a dash when unset", () => {
+        expect(currencyCodeOrDash("SGD")).toBe("SGD");
+        expect(currencyCodeOrDash(null)).toBe("—");
+        expect(currencyCodeOrDash(undefined)).toBe("—");
+    });
+
+    it("countLabel pluralizes on count, with a default and an explicit plural", () => {
+        expect(countLabel(1, "item")).toBe("1 item");
+        expect(countLabel(3, "item")).toBe("3 items");
+        expect(countLabel(0, "blocked", "blocked")).toBe("0 blocked");
+        expect(countLabel(2, "blocked", "blocked")).toBe("2 blocked");
+    });
+
+    it("pnlColorClass signals positive/negative/zero by class", () => {
+        expect(pnlColorClass("10.00")).toBe("text-[var(--success)]");
+        expect(pnlColorClass("-10.00")).toBe("text-[var(--error)]");
+        expect(pnlColorClass("0")).toBe("");
+    });
+
+    it("humanizeIdentifier title-cases and preserves known acronyms", () => {
+        expect(humanizeIdentifier("csv_export")).toBe("CSV Export");
+        expect(humanizeIdentifier("bank-statement")).toBe("Bank Statement");
+        expect(humanizeIdentifier(null)).toBe("Not recorded");
+        expect(humanizeIdentifier("")).toBe("Not recorded");
+    });
+
+    it("sourceClassLabel prefers the known map, falls back to humanizeIdentifier", () => {
+        expect(sourceClassLabel("bank_statement")).toBe("Bank statements");
+        expect(sourceClassLabel("manual_valuation_snapshot")).toBe("Manual valuation snapshots");
+        expect(sourceClassLabel("unknown_source")).toBe("Unknown Source");
+    });
+
+    it("checkSeverityColor/checkTypeLabel cover the stage2 consistency-check vocabulary", () => {
+        expect(checkSeverityColor("high")).toBe("text-[var(--error)]");
+        expect(checkSeverityColor("medium")).toBe("text-[var(--warning)]");
+        expect(checkSeverityColor("low")).toBe("text-muted");
+        expect(checkTypeLabel("duplicate")).toBe("Duplicate");
+        expect(checkTypeLabel("transfer_pair")).toBe("Transfer Pair");
+        expect(checkTypeLabel("anomaly")).toBe("Anomaly");
+        expect(checkTypeLabel("manual_review")).toBe("manual_review");
+    });
+
+    // G-one-readiness-language (#1868 S5): the union of
+    // PersonalReportPackageReadinessResponse["state"] and
+    // WorkflowReportReadinessState, pinned so the two surfaces that
+    // previously disagreed (reports/page.tsx vs WorkflowNotifications.tsx)
+    // can never diverge again.
+    it("readinessVariant pins a color for every state in the unioned enum", () => {
+        expect(readinessVariant("ready")).toBe("success");
+        expect(readinessVariant("generated")).toBe("success");
+        expect(readinessVariant("blocked")).toBe("error");
+        expect(readinessVariant("stale")).toBe("error");
+        expect(readinessVariant("processing")).toBe("warning");
+        expect(readinessVariant("draft")).toBe("muted");
+        expect(readinessVariant("none")).toBe("info");
     });
 });

--- a/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
+++ b/apps/frontend/src/app/(main)/portfolio/[ticker]/page.tsx
@@ -11,16 +11,11 @@ import {
   HoldingsListResponse,
   RealizedLot,
 } from "@/lib/types";
-import { compareAmounts, formatCurrencyLocale } from "@/lib/audit/money";
+import { formatCurrencyLocale } from "@/lib/audit/money";
 import { formatQuantity } from "@/lib/audit/quantity";
 import { formatDateDisplay } from "@/lib/date";
 import { formatSignedPercentFromPercentValue } from "@/lib/audit/ratio/format";
-
-function getPnlColor(value: string): string {
-  const comparison = compareAmounts(value, "0");
-  if (comparison === 0) return "";
-  return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
-}
+import { pnlColorClass } from "@/lib/statusLabels";
 
 export default function HoldingDetailPage() {
   const params = useParams();
@@ -258,12 +253,12 @@ export default function HoldingDetailPage() {
                 Unrealized P&L
               </p>
               <p
-                className={`text-2xl font-semibold mt-1 ${getPnlColor(primary.unrealized_pnl)}`}
+                className={`text-2xl font-semibold mt-1 ${pnlColorClass(primary.unrealized_pnl)}`}
               >
                 {formatCurrencyLocale(primary.unrealized_pnl, primary.currency)}
               </p>
               <p
-                className={`text-sm mt-0.5 ${getPnlColor(primary.unrealized_pnl_percent)}`}
+                className={`text-sm mt-0.5 ${pnlColorClass(primary.unrealized_pnl_percent)}`}
               >
                 {formatSignedPercentFromPercentValue(
                   primary.unrealized_pnl_percent,
@@ -327,7 +322,7 @@ export default function HoldingDetailPage() {
                           {formatCurrencyLocale(h.market_value, h.currency)}
                         </td>
                         <td
-                          className={`px-4 py-2 text-right font-medium ${getPnlColor(h.unrealized_pnl)}`}
+                          className={`px-4 py-2 text-right font-medium ${pnlColorClass(h.unrealized_pnl)}`}
                         >
                           {formatCurrencyLocale(h.unrealized_pnl, h.currency)}
                         </td>
@@ -500,7 +495,7 @@ export default function HoldingDetailPage() {
                         {formatCurrencyLocale(lot.proceeds, lot.currency)}
                       </td>
                       <td
-                        className={`px-4 py-2 text-right font-medium ${getPnlColor(lot.gain_loss)}`}
+                        className={`px-4 py-2 text-right font-medium ${pnlColorClass(lot.gain_loss)}`}
                       >
                         {formatCurrencyLocale(lot.gain_loss, lot.currency)}
                       </td>

--- a/apps/frontend/src/app/(main)/reports/page.tsx
+++ b/apps/frontend/src/app/(main)/reports/page.tsx
@@ -15,9 +15,10 @@ import {
 import { apiFetch } from "@/lib/api";
 import { formatCurrencyLocale } from "@/lib/audit/money";
 import { formatPercentFromPercentValue } from "@/lib/audit/ratio/format";
-import { Badge, type BadgeVariant } from "@/components/ui";
+import { Badge } from "@/components/ui";
 import { InfoHint, type GlossaryTerm } from "@/components/ui/InfoHint";
 import { reportPeriodStart } from "@/hooks/usePersonalReportPackage";
+import { countLabel, readinessVariant, sourceClassLabel } from "@/lib/statusLabels";
 import type {
   AnnualizedIncomeResponse,
   PersonalReportPackageReadinessResponse,
@@ -47,17 +48,6 @@ const MORE_REPORTS = [
 
 type ReadinessLoadState = "loading" | "loaded" | "error";
 
-const SOURCE_CLASS_LABELS: Record<string, string> = {
-  bank_statement: "Bank statements",
-  brokerage_statement: "Brokerage statements",
-  settlement_note: "Settlement notes",
-  esop_rsu_plan: "ESOP / RSU plans",
-  property_statement: "Property statements",
-  liability_statement: "Liability statements",
-  csv_export: "CSV exports",
-  manual_record: "Manual records",
-};
-
 function packageReadinessQuery(): string {
   const reportDate = new Date().toISOString().slice(0, 10);
   const params = new URLSearchParams({
@@ -66,32 +56,6 @@ function packageReadinessQuery(): string {
     as_of_date: reportDate,
   });
   return `?${params.toString()}`;
-}
-
-function countLabel(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function sourceClassLabel(sourceClass: string): string {
-  return SOURCE_CLASS_LABELS[sourceClass] ?? sourceClass.replaceAll("_", " ");
-}
-
-function readinessVariant(
-  state?: PersonalReportPackageReadinessResponse["state"],
-): BadgeVariant {
-  switch (state) {
-    case "ready":
-    case "generated":
-      return "success";
-    case "blocked":
-    case "stale":
-      return "error";
-    case "processing":
-      return "warning";
-    case "draft":
-    default:
-      return "muted";
-  }
 }
 
 function isPackageReadiness(

--- a/apps/frontend/src/app/(main)/statements/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/statements/[id]/page.tsx
@@ -9,6 +9,8 @@ import { LoadingState } from "@/components/ui";
 import { FlowStepBanner } from "@/components/workflow/FlowStepBanner";
 import { apiFetch } from "@/lib/api";
 import { BankStatement, BrokerageImportResponse } from "@/lib/types";
+import { currencyCodeOrDash } from "@/lib/statusLabels";
+import { formatPeriod } from "@/lib/date";
 import { StatementHeader } from "./_components/StatementHeader";
 import { BrokerageImportResultBanner } from "./_components/BrokerageImportResultBanner";
 import { StatementSummaryCards } from "./_components/StatementSummaryCards";
@@ -148,13 +150,6 @@ export default function StatementDetailPage() {
         }
     };
 
-    const formatCode = (currency?: string | null) => currency || "—";
-
-    const formatPeriod = (start?: string | null, end?: string | null) => {
-        if (!start || !end) return "Parsing...";
-        return `${start} to ${end}`;
-    };
-
     if (loading) {
         return (
             <div className="p-6">
@@ -226,7 +221,7 @@ export default function StatementDetailPage() {
                 retryLoading={retryLoading}
                 onBrokerageImport={handleBrokerageImport}
                 onRetry={handleRetry}
-                formatCode={formatCode}
+                formatCode={currencyCodeOrDash}
                 formatPeriod={formatPeriod}
             />
 

--- a/apps/frontend/src/app/(main)/upload/page.tsx
+++ b/apps/frontend/src/app/(main)/upload/page.tsx
@@ -16,6 +16,8 @@ import type { BadgeVariant } from "@/components/ui";
 import { apiFetch } from "@/lib/api";
 import { BankStatement, BankStatementListResponse } from "@/lib/types";
 import { formatCurrencyLocale } from "@/lib/audit/money";
+import { currencyCodeOrDash } from "@/lib/statusLabels";
+import { formatPeriod } from "@/lib/date";
 
 // Plain-language status for everyday users. "parsed" means the AI finished and
 // it is the user's turn to review — surface that as an action, not a warning.
@@ -96,13 +98,6 @@ export default function UploadPage() {
         } finally {
             setDeleting(false);
         }
-    };
-
-    const formatCurrency = (currency?: string | null) => currency || "—";
-
-    const formatPeriod = (start?: string | null, end?: string | null) => {
-        if (!start || !end) return "Parsing...";
-        return `${start} → ${end}`;
     };
 
     return (
@@ -249,7 +244,7 @@ export default function UploadPage() {
                                             <span>•</span>
                                             <span>{formatPeriod(statement.period_start, statement.period_end)}</span>
                                             <span>•</span>
-                                            <span>{formatCurrency(statement.currency)}</span>
+                                            <span>{currencyCodeOrDash(statement.currency)}</span>
                                         </div>
                                     </div>
                                     <div className="relative z-10 text-right flex-shrink-0 flex flex-col items-end gap-2">

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -8,13 +8,8 @@ import { LogIn, LogOut } from "lucide-react";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { clearUser, getUserEmail, isAuthenticated } from "@/lib/auth";
-import { ADD_ACTION, bottomTabItems, type NavItem } from "@/components/navigation";
+import { ADD_ACTION, bottomTabItems, isActive, type NavItem } from "@/components/navigation";
 import AddSheet from "@/components/shell/AddSheet";
-
-function isActive(pathname: string, href: string): boolean {
-    if (href === "/") return pathname === "/";
-    return pathname === href || pathname.startsWith(href + "/");
-}
 
 // EPIC-022 AC22.21.2: the desktop sidebar mirrors the mobile bottom tab bar —
 // Home, Chat, a center-equivalent Add action, Audit, and More — so there is one

--- a/apps/frontend/src/components/navigation.ts
+++ b/apps/frontend/src/components/navigation.ts
@@ -116,6 +116,12 @@ export const DEFAULT_ROUTE_ICON = UploadCloud;
 // Re-exported so the `/more` page can render the genuine power escape hatch.
 export { FolderOpen };
 
+/** Whether a nav item's href matches the current pathname (exact, or a path prefix). */
+export function isActive(pathname: string, href: string): boolean {
+    if (href === "/") return pathname === "/";
+    return pathname === href || pathname.startsWith(href + "/");
+}
+
 export function getRouteConfig(pathname: string): RouteConfig {
     if (ROUTE_CONFIG[pathname]) return ROUTE_CONFIG[pathname];
     const segments = pathname.split("/").filter(Boolean);

--- a/apps/frontend/src/components/portfolio/HoldingsTable.tsx
+++ b/apps/frontend/src/components/portfolio/HoldingsTable.tsx
@@ -2,21 +2,16 @@
 
 import Link from "next/link";
 import { PortfolioHolding } from "@/lib/types";
-import { compareAmounts, formatCurrencyLocale } from "@/lib/audit/money";
+import { formatCurrencyLocale } from "@/lib/audit/money";
 import { formatQuantity } from "@/lib/audit/quantity";
 import { formatDateDisplay } from "@/lib/date";
 import { formatSignedPercentFromPercentValue } from "@/lib/audit/ratio/format";
+import { pnlColorClass } from "@/lib/statusLabels";
 import { ProvenanceBadge } from "@/components/ui/ProvenanceBadge";
 
 interface HoldingsTableProps {
   holdings: PortfolioHolding[];
   showDisposed?: boolean;
-}
-
-function getPnlColor(value: string): string {
-  const comparison = compareAmounts(value, "0");
-  if (comparison === 0) return "";
-  return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
 }
 
 export function HoldingsTable({
@@ -132,12 +127,12 @@ export function HoldingsTable({
                       {formatCurrencyLocale(h.market_value, h.currency)}
                     </td>
                     <td
-                      className={`px-4 py-2 text-right font-medium ${getPnlColor(h.unrealized_pnl)}`}
+                      className={`px-4 py-2 text-right font-medium ${pnlColorClass(h.unrealized_pnl)}`}
                     >
                       {formatCurrencyLocale(h.unrealized_pnl, h.currency)}
                     </td>
                     <td
-                      className={`px-4 py-2 text-right ${getPnlColor(h.unrealized_pnl_percent)}`}
+                      className={`px-4 py-2 text-right ${pnlColorClass(h.unrealized_pnl_percent)}`}
                     >
                       {formatSignedPercentFromPercentValue(
                         h.unrealized_pnl_percent,

--- a/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
+++ b/apps/frontend/src/components/reports/package/PackageReadinessSections.tsx
@@ -4,14 +4,9 @@ import type {
   FrameworkPolicyResult,
   PersonalReportPackageReadinessResponse,
 } from "@/lib/types";
+import { countLabel, humanizeIdentifier } from "@/lib/statusLabels";
 
-import {
-  countLabel,
-  FRAMEWORK_LABELS,
-  humanizeIdentifier,
-  renderCsv,
-  renderSourceClasses,
-} from "./shared";
+import { FRAMEWORK_LABELS, renderCsv, renderSourceClasses } from "./shared";
 
 type SourceTrustSummary = NonNullable<
   PersonalReportPackageReadinessResponse["source_trust_summary"]

--- a/apps/frontend/src/components/reports/package/PackageTraceability.tsx
+++ b/apps/frontend/src/components/reports/package/PackageTraceability.tsx
@@ -5,13 +5,9 @@ import type {
   PersonalReportPackageTraceabilityLine,
   PersonalReportPackageTraceabilityResponse,
 } from "@/lib/types";
+import { countLabel, humanizeIdentifier } from "@/lib/statusLabels";
 
-import {
-  countLabel,
-  humanizeIdentifier,
-  renderAnchorDetail,
-  type LineagePanelState,
-} from "./shared";
+import { renderAnchorDetail, type LineagePanelState } from "./shared";
 
 export function PackageTraceabilitySection({
   appendix,

--- a/apps/frontend/src/components/reports/package/shared.tsx
+++ b/apps/frontend/src/components/reports/package/shared.tsx
@@ -8,23 +8,11 @@ import type {
   PersonalReportPackageSnapshotSummary,
   PersonalReportPackageTraceabilityLine,
 } from "@/lib/types";
+import { sourceClassLabel } from "@/lib/statusLabels";
 
 export const FRAMEWORK_LABELS: Record<string, string> = {
   personal_us_gaap_like: "US-like",
   personal_hkfrs_like: "HK-like",
-};
-
-const SOURCE_CLASS_LABELS: Record<string, string> = {
-  bank_statement: "Bank statements",
-  brokerage_statement: "Brokerage statements",
-  settlement_note: "Settlement notes",
-  esop_rsu_plan: "ESOP / RSU plans",
-  property_statement: "Property statements",
-  liability_statement: "Liability statements",
-  csv_export: "CSV exports",
-  manual_record: "Manual records",
-  manual_valuation_snapshot: "Manual valuation snapshots",
-  package_contract: "Package contract",
 };
 
 export type LineagePanelState = {
@@ -85,30 +73,6 @@ export function formatScheduleCurrency(
 
 export function renderCsv(values?: string[]): string {
   return values && values.length ? values.join(", ") : "none";
-}
-
-export function countLabel(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-export function humanizeIdentifier(value?: string | null): string {
-  if (!value) return "Not recorded";
-  const spaced = value.replace(/[._-]+/g, " ").trim();
-  if (!spaced) return "Not recorded";
-  return spaced
-    .split(/\s+/)
-    .map((word) => {
-      const upper = word.toUpperCase();
-      if (["AI", "CSV", "ESOP", "FX", "GAAP", "HK", "LLM", "OCR", "PR", "RSU", "US"].includes(upper)) {
-        return upper;
-      }
-      return `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`;
-    })
-    .join(" ");
-}
-
-export function sourceClassLabel(sourceClass: string): string {
-  return SOURCE_CLASS_LABELS[sourceClass] ?? humanizeIdentifier(sourceClass);
 }
 
 export function renderSourceClasses(values?: string[]): string {

--- a/apps/frontend/src/components/shell/BottomTabBar.tsx
+++ b/apps/frontend/src/components/shell/BottomTabBar.tsx
@@ -4,14 +4,9 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
-import { ADD_ACTION, bottomTabItems, type NavItem } from "@/components/navigation";
+import { ADD_ACTION, bottomTabItems, isActive, type NavItem } from "@/components/navigation";
 import { isAuthenticated } from "@/lib/auth";
 import AddSheet from "@/components/shell/AddSheet";
-
-function isActive(pathname: string, href: string): boolean {
-    if (href === "/") return pathname === "/";
-    return pathname === href || pathname.startsWith(href + "/");
-}
 
 // EPIC-022 AC22.21.2: the mobile/PWA-first bottom tab bar. Home · Chat · ⊕ Add ·
 // Audit · More, with the center Add as an action (opens AddSheet), not a route.

--- a/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
+++ b/apps/frontend/src/components/workflow/WorkflowNotifications.tsx
@@ -17,9 +17,10 @@ import {
   ShieldAlert,
 } from "lucide-react";
 import Sheet from "@/components/ui/Sheet";
-import { Alert, Badge, EmptyState, type BadgeVariant } from "@/components/ui";
+import { Alert, Badge, EmptyState } from "@/components/ui";
 import { useApiQuery } from "@/hooks/useApiQuery";
 import { updateWorkflowEventStatus } from "@/lib/api";
+import { countLabel, readinessVariant } from "@/lib/statusLabels";
 import type {
   WorkflowEventListResponse,
   WorkflowEventResponse,
@@ -58,10 +59,6 @@ function sentenceFromSnake(value: string) {
   return value.replace(/_/g, " ");
 }
 
-function countLabel(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
 function formatEventTime(value: string) {
   return new Intl.DateTimeFormat(undefined, {
     month: "short",
@@ -95,13 +92,6 @@ function workflowStateCopy(status: WorkflowStatusResponse) {
   if (status.primary_state === "processing") return "Automation is processing uploaded source files.";
   if (status.primary_state === "ready") return "Reports are ready to inspect.";
   return "Upload files to start the automated reporting workflow.";
-}
-
-function readinessVariant(state: WorkflowStatusResponse["report_readiness"]["state"]): BadgeVariant {
-  if (state === "blocked" || state === "stale") return "error";
-  if (state === "processing") return "warning";
-  if (state === "ready") return "success";
-  return "info";
 }
 
 function isWorkflowStatusResponse(value: unknown): value is WorkflowStatusResponse {

--- a/apps/frontend/src/lib/audit/localeFormat.ts
+++ b/apps/frontend/src/lib/audit/localeFormat.ts
@@ -1,0 +1,24 @@
+/**
+ * Locale-aware number-formatting primitives shared by money and quantity
+ * display formatting (was duplicated near-identically between
+ * lib/audit/money/format.ts and lib/audit/quantity/format.ts, #1868 S5).
+ */
+
+/** Group and decimal separator characters for a locale. */
+export function getLocaleSeparators(locale: string): { group: string; decimal: string } {
+  const group =
+    new Intl.NumberFormat(locale, { useGrouping: true })
+      .formatToParts(1000)
+      .find((part) => part.type === "group")?.value ?? ",";
+  const decimal =
+    new Intl.NumberFormat(locale)
+      .formatToParts(1.1)
+      .find((part) => part.type === "decimal")?.value ?? ".";
+  return { group, decimal };
+}
+
+/** Insert thousands separators into an integer-part digit string. */
+export function groupIntegerPart(value: string, groupSeparator: string, useGrouping = true): string {
+  if (!useGrouping) return value;
+  return value.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
+}

--- a/apps/frontend/src/lib/audit/money/format.ts
+++ b/apps/frontend/src/lib/audit/money/format.ts
@@ -1,5 +1,7 @@
 import Decimal from "decimal.js";
 
+import { getLocaleSeparators, groupIntegerPart } from "@/lib/audit/localeFormat";
+
 export type MonetaryInput = Decimal | string | number;
 
 export function parseAmount(value: string | number): Decimal {
@@ -69,21 +71,6 @@ export function formatCurrency(
 ): string {
   const amount = formatAmount(value, decimals);
   return `${currency} ${amount}`;
-}
-
-function getLocaleSeparators(locale: string) {
-  const group = new Intl.NumberFormat(locale, { useGrouping: true })
-    .formatToParts(1000)
-    .find((part) => part.type === "group")?.value ?? ",";
-  const decimal = new Intl.NumberFormat(locale)
-    .formatToParts(1.1)
-    .find((part) => part.type === "decimal")?.value ?? ".";
-  return { group, decimal };
-}
-
-function groupIntegerPart(value: string, groupSeparator: string, useGrouping: boolean): string {
-  if (!useGrouping) return value;
-  return value.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
 }
 
 export function formatCurrencyLocale(

--- a/apps/frontend/src/lib/audit/money/money.ts
+++ b/apps/frontend/src/lib/audit/money/money.ts
@@ -6,6 +6,8 @@
 
 import Decimal from "decimal.js";
 
+import { decimalStringFromWire, decimalToWire } from "@/lib/audit/wire";
+
 import { Currency } from "./currency";
 import {
   CurrencyMismatchError,
@@ -52,10 +54,6 @@ function coerceAmount(value: AmountInput): Decimal {
   return coerceDecimal(value, "Money amount");
 }
 
-function decimalToWire(value: Decimal): string {
-  return value.isZero() ? "0" : value.toFixed().replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
-}
-
 function recordFromWire(payload: unknown, what: string): Record<string, unknown> {
   if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
     throw new InvalidMoneyPayloadError(`${what} payload must be an object`);
@@ -67,23 +65,6 @@ function stringField(payload: Record<string, unknown>, key: string, what: string
   const value = payload[key];
   if (typeof value !== "string") {
     throw new InvalidMoneyPayloadError(`${what} payload field ${key} must be a string`);
-  }
-  return value;
-}
-
-function decimalStringFromWire(value: unknown, what: string): string {
-  if (typeof value === "number") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string, not a number`);
-  }
-  if (typeof value !== "string") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string`);
-  }
-  try {
-    const parsed = new Decimal(value);
-    if (!parsed.isFinite()) throw new FloatNotAllowedError(`${what} must be finite`);
-  } catch (error) {
-    if (error instanceof FloatNotAllowedError) throw error;
-    throw new InvalidMoneyPayloadError(`${what} is not a valid decimal string`);
   }
   return value;
 }
@@ -202,7 +183,8 @@ export function money_to_wire(money: Money): MoneyWire {
 
 export function money_from_wire(payload: unknown): Money {
   const fields = recordFromWire(payload, "Money");
-  return new Money(decimalStringFromWire(fields.amount, "Money amount"), stringField(fields, "currency", "Money"));
+  const amount = decimalStringFromWire(fields.amount, "Money amount", FloatNotAllowedError, InvalidMoneyPayloadError);
+  return new Money(amount, stringField(fields, "currency", "Money"));
 }
 
 export function exchange_rate_to_wire(rate: ExchangeRate): ExchangeRateWire {
@@ -221,6 +203,6 @@ export function exchange_rate_from_wire(payload: unknown): ExchangeRate {
   return new ExchangeRate(
     stringField(fields, "base", "ExchangeRate"),
     stringField(fields, "quote", "ExchangeRate"),
-    decimalStringFromWire(fields.rate, "FX rate"),
+    decimalStringFromWire(fields.rate, "FX rate", FloatNotAllowedError, InvalidMoneyPayloadError),
   );
 }

--- a/apps/frontend/src/lib/audit/quantity/format.ts
+++ b/apps/frontend/src/lib/audit/quantity/format.ts
@@ -1,29 +1,10 @@
-import Decimal from "decimal.js";
-
-import { FloatNotAllowedError } from "./errors";
-import type { QuantityInput } from "./quantity";
-
-function coerce(value: QuantityInput, what = "quantity value"): Decimal {
-  if (value instanceof Decimal) return value;
-  if (typeof value === "string") return new Decimal(value);
-  throw new FloatNotAllowedError(`${what} must be a Decimal or decimal string, not a number`);
-}
-
-function getLocaleSeparators(locale: string) {
-  const group =
-    new Intl.NumberFormat(locale, { useGrouping: true })
-      .formatToParts(1000)
-      .find((part) => part.type === "group")?.value ?? ",";
-  return { group };
-}
-
-function groupIntegerPart(value: string, groupSeparator: string): string {
-  return value.replace(/\B(?=(\d{3})+(?!\d))/g, groupSeparator);
-}
+import { coerce, type QuantityInput } from "./quantity";
+import { getLocaleSeparators, groupIntegerPart } from "@/lib/audit/localeFormat";
 
 export function formatQuantity(value: QuantityInput): string {
+  // coerce() already rejects non-finite values (FloatNotAllowedError,
+  // "quantity value must be finite") — no separate isFinite() check needed.
   const amount = coerce(value);
-  if (!amount.isFinite()) throw new FloatNotAllowedError("quantity value must be finite");
 
   const { group } = getLocaleSeparators("en-US");
   const sign = amount.isNegative() ? "-" : "";

--- a/apps/frontend/src/lib/audit/quantity/quantity.ts
+++ b/apps/frontend/src/lib/audit/quantity/quantity.ts
@@ -1,6 +1,7 @@
 import Decimal from "decimal.js";
 
 import { Ratio } from "@/lib/audit/ratio";
+import { decimalStringFromWire as sharedDecimalStringFromWire, decimalToWire } from "@/lib/audit/wire";
 
 import { FloatNotAllowedError, InvalidQuantityPayloadError, InvalidUnitError, UnitMismatchError } from "./errors";
 
@@ -13,7 +14,8 @@ export type QuantityWire = { value: string; unit: string };
 
 const UNIT_RE = /^[a-z][a-z0-9_-]*$/;
 
-function coerce(value: QuantityInput, what = "quantity value"): Decimal {
+/** Construction-time coercion to Decimal (exported for lib/audit/quantity/format.ts, #1868 S5). */
+export function coerce(value: QuantityInput, what = "quantity value"): Decimal {
   let d: Decimal;
   if (value instanceof Decimal) {
     d = value;
@@ -24,10 +26,6 @@ function coerce(value: QuantityInput, what = "quantity value"): Decimal {
   }
   if (!d.isFinite()) throw new FloatNotAllowedError(`${what} must be finite`);
   return d;
-}
-
-function decimalToWire(value: Decimal): string {
-  return value.isZero() ? "0" : value.toFixed().replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
 }
 
 function recordFromWire(payload: unknown): Record<string, unknown> {
@@ -46,20 +44,7 @@ function stringField(payload: Record<string, unknown>, key: string): string {
 }
 
 function decimalStringFromWire(value: unknown, what = "quantity value"): string {
-  if (typeof value === "number") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string, not a number`);
-  }
-  if (typeof value !== "string") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string`);
-  }
-  try {
-    const parsed = new Decimal(value);
-    if (!parsed.isFinite()) throw new FloatNotAllowedError(`${what} must be finite`);
-  } catch (error) {
-    if (error instanceof FloatNotAllowedError) throw error;
-    throw new InvalidQuantityPayloadError(`${what} is not a valid decimal string`);
-  }
-  return value;
+  return sharedDecimalStringFromWire(value, what, FloatNotAllowedError, InvalidQuantityPayloadError);
 }
 
 export class Unit {

--- a/apps/frontend/src/lib/audit/ratio/ratio.ts
+++ b/apps/frontend/src/lib/audit/ratio/ratio.ts
@@ -5,6 +5,8 @@
 
 import Decimal from "decimal.js";
 
+import { decimalStringFromWire as sharedDecimalStringFromWire, decimalToWire } from "@/lib/audit/wire";
+
 import { FloatNotAllowedError, InvalidRatioPayloadError, UndefinedRatioError } from "./errors";
 
 export const PERCENT_DP = 2;
@@ -23,25 +25,8 @@ function coerce(value: RatioInput, what = "ratio value"): Decimal {
   throw new FloatNotAllowedError(`${what} must be a Decimal or decimal string, not a number`);
 }
 
-function decimalToWire(value: Decimal): string {
-  return value.isZero() ? "0" : value.toFixed().replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
-}
-
 function decimalStringFromWire(value: unknown, what = "ratio value"): string {
-  if (typeof value === "number") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string, not a number`);
-  }
-  if (typeof value !== "string") {
-    throw new FloatNotAllowedError(`${what} must be encoded as a decimal string`);
-  }
-  try {
-    const parsed = new Decimal(value);
-    if (!parsed.isFinite()) throw new FloatNotAllowedError(`${what} must be finite`);
-  } catch (error) {
-    if (error instanceof FloatNotAllowedError) throw error;
-    throw new InvalidRatioPayloadError(`${what} is not a valid decimal string`);
-  }
-  return value;
+  return sharedDecimalStringFromWire(value, what, FloatNotAllowedError, InvalidRatioPayloadError);
 }
 
 /** An immutable dimensionless ratio (`0.125` == 12.5%). */

--- a/apps/frontend/src/lib/audit/wire.ts
+++ b/apps/frontend/src/lib/audit/wire.ts
@@ -1,0 +1,42 @@
+import Decimal from "decimal.js";
+
+/**
+ * Shared wire-boundary codec for the audit value types (Money/Quantity/Ratio).
+ * `decimalToWire` is byte-identical across all three; `decimalStringFromWire`
+ * is structurally identical, differing only in which package-typed error
+ * class each throws on a float/malformed value — parameterized here instead
+ * of copy-pasted (#1868 S5; mirrors the backend `WireCodec` pattern in
+ * common/audit/decimal_scalar.py).
+ */
+
+/** Format a Decimal for the wire: trimmed, no trailing zeros, "0" for zero. */
+export function decimalToWire(value: Decimal): string {
+  return value.isZero() ? "0" : value.toFixed().replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+}
+
+/**
+ * Decode+validate a wire decimal string: rejects a JS number (float) and a
+ * non-finite value. `FloatError`/`PayloadError` are the caller's own typed
+ * error classes (e.g. money's `FloatNotAllowedError`/`InvalidMoneyPayloadError`).
+ */
+export function decimalStringFromWire(
+  value: unknown,
+  what: string,
+  FloatError: new (message: string) => Error,
+  PayloadError: new (message: string) => Error,
+): string {
+  if (typeof value === "number") {
+    throw new FloatError(`${what} must be encoded as a decimal string, not a number`);
+  }
+  if (typeof value !== "string") {
+    throw new FloatError(`${what} must be encoded as a decimal string`);
+  }
+  try {
+    const parsed = new Decimal(value);
+    if (!parsed.isFinite()) throw new FloatError(`${what} must be finite`);
+  } catch (error) {
+    if (error instanceof FloatError) throw error;
+    throw new PayloadError(`${what} is not a valid decimal string`);
+  }
+  return value;
+}

--- a/apps/frontend/src/lib/date.ts
+++ b/apps/frontend/src/lib/date.ts
@@ -19,3 +19,14 @@ export const formatMonthLabel = (value: string): string => {
   const safe = value.includes("T") ? value : value + "T00:00:00";
   return new Date(safe).toLocaleDateString("en-US", { month: "short" });
 };
+
+/**
+ * A statement/document period as "start to end", or "Parsing..." while
+ * either bound is still unknown. Was two near-duplicate local copies
+ * (upload/page.tsx used "→", statements/[id]/page.tsx used "to") that had
+ * already diverged (#1868 S5) — "to" is the single canonical separator.
+ */
+export const formatPeriod = (start?: string | null, end?: string | null): string => {
+  if (!start || !end) return "Parsing...";
+  return `${start} to ${end}`;
+};

--- a/apps/frontend/src/lib/statusLabels.ts
+++ b/apps/frontend/src/lib/statusLabels.ts
@@ -1,5 +1,91 @@
+import { compareAmounts } from "@/lib/audit/money";
+import type { BadgeVariant } from "@/components/ui";
+
 // Text labels that back colour-coded financial status, so state is never
 // conveyed by colour alone (WCAG 1.4.1, issue #1609).
+
+/**
+ * Report-readiness state -> Badge color, the union of the two report-package
+ * readiness state enums (`PersonalReportPackageReadinessResponse["state"]`
+ * and `WorkflowReportReadinessState`). Was two near-duplicate
+ * `readinessVariant` functions (reports/page.tsx, WorkflowNotifications.tsx)
+ * that assigned CONFLICTING colors to their "unhandled" defaults — but the
+ * two enums don't actually overlap on the states each treats as a default
+ * (reports/page.tsx never sees `none`; the workflow status never sees
+ * `draft`/`generated`), so every state below is mapped explicitly and no
+ * default/fallback branch is needed (#1868 S5).
+ */
+const READINESS_VARIANTS: Record<
+    "ready" | "generated" | "blocked" | "stale" | "processing" | "draft" | "none",
+    BadgeVariant
+> = {
+    ready: "success",
+    generated: "success",
+    blocked: "error",
+    stale: "error",
+    processing: "warning",
+    draft: "muted",
+    none: "info",
+};
+
+export function readinessVariant(state: keyof typeof READINESS_VARIANTS): BadgeVariant {
+    return READINESS_VARIANTS[state];
+}
+
+/** A currency code, or an em dash while unknown (was duplicated under the
+ * name `formatCurrency` in upload/page.tsx — collided in name, though not
+ * meaning, with lib/audit/money/format.ts's amount-formatting
+ * `formatCurrency`, #1868 S5). */
+export function currencyCodeOrDash(currency?: string | null): string {
+    return currency || "—";
+}
+
+/** Pluralize a count: "1 item" / "3 items" (default plural is `${singular}s`). */
+export function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+    return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/** Text color class for a signed money amount: positive/negative/zero. */
+export function pnlColorClass(value: string): string {
+    const comparison = compareAmounts(value, "0");
+    if (comparison === 0) return "";
+    return comparison > 0 ? "text-[var(--success)]" : "text-[var(--error)]";
+}
+
+const SOURCE_CLASS_LABELS: Record<string, string> = {
+    bank_statement: "Bank statements",
+    brokerage_statement: "Brokerage statements",
+    settlement_note: "Settlement notes",
+    esop_rsu_plan: "ESOP / RSU plans",
+    property_statement: "Property statements",
+    liability_statement: "Liability statements",
+    csv_export: "CSV exports",
+    manual_record: "Manual records",
+    manual_valuation_snapshot: "Manual valuation snapshots",
+    package_contract: "Package contract",
+};
+
+const ACRONYMS = new Set(["AI", "CSV", "ESOP", "FX", "GAAP", "HK", "LLM", "OCR", "PR", "RSU", "US"]);
+
+/** Title-case an identifier, preserving known acronyms ("csv_export" -> "CSV Export"). */
+export function humanizeIdentifier(value?: string | null): string {
+    if (!value) return "Not recorded";
+    const spaced = value.replace(/[._-]+/g, " ").trim();
+    if (!spaced) return "Not recorded";
+    return spaced
+        .split(/\s+/)
+        .map((word) => {
+            const upper = word.toUpperCase();
+            if (ACRONYMS.has(upper)) return upper;
+            return `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`;
+        })
+        .join(" ");
+}
+
+/** Display label for a source-document class, e.g. "bank_statement" -> "Bank statements". */
+export function sourceClassLabel(sourceClass: string): string {
+    return SOURCE_CLASS_LABELS[sourceClass] ?? humanizeIdentifier(sourceClass);
+}
 
 /** Parse-confidence tier label for a 0-100 score. */
 export function confidenceLabel(score: number): string {

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2169,15 +2169,18 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-meta.fe-contract-types.4",
             statement=(
-                "`countLabel`/`getPnlColor`(renamed `pnlColorClass`)/`formatPeriod`/"
-                "`isActive` each have at most one definition, at one canonical "
-                "home (`lib/statusLabels.ts`, `lib/date.ts`, "
+                "`countLabel`/`pnlColorClass`/`formatPeriod`/`isActive` each "
+                "have at most one definition, at one canonical home "
+                "(`lib/statusLabels.ts`, `lib/date.ts`, "
                 "`components/navigation.ts`) — were 2-3 component-local copies "
                 'each, with `formatPeriod` already diverged (a "→" vs "to" '
-                "separator) before unification. `formatCurrency` is defined "
-                "only in `lib/audit/money/format.ts` (amount formatting) — no "
-                "second definition colliding in name with a currency-CODE "
-                "formatter exists anywhere else (#1868 S5)."
+                "separator) before unification. The gate actively governs the "
+                "renamed name too (`pnlColorClass`, not just banning the old "
+                "`getPnlColor`), so a future duplicate of the CURRENT name is "
+                "caught, not only a regression to the old one. `formatCurrency` "
+                "is defined only in `lib/audit/money/format.ts` (amount "
+                "formatting) — no second definition colliding in name with a "
+                "currency-CODE formatter exists anywhere else (#1868 S5)."
             ),
             test=(
                 "tests/tooling/test_fe_helper_ssot.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2166,6 +2166,26 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-meta.fe-contract-types.4",
+            statement=(
+                "`countLabel`/`getPnlColor`(renamed `pnlColorClass`)/`formatPeriod`/"
+                "`isActive` each have at most one definition, at one canonical "
+                "home (`lib/statusLabels.ts`, `lib/date.ts`, "
+                "`components/navigation.ts`) — were 2-3 component-local copies "
+                'each, with `formatPeriod` already diverged (a "→" vs "to" '
+                "separator) before unification. `formatCurrency` is defined "
+                "only in `lib/audit/money/format.ts` (amount formatting) — no "
+                "second definition colliding in name with a currency-CODE "
+                "formatter exists anywhere else (#1868 S5)."
+            ),
+            test=(
+                "tests/tooling/test_fe_helper_ssot.py"
+                "::test_AC_fe_helper_ssot_1_each_helper_defined_at_most_once"
+            ),
+            priority="P2",
+            status="done",
+        ),
     ],
     concepts=[
         ConceptRecord(

--- a/tests/tooling/test_fe_helper_ssot.py
+++ b/tests/tooling/test_fe_helper_ssot.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from common.testing.ac_proof import ac_proof
 
 REPO = Path(__file__).resolve().parents[2]
-FRONTEND_SRC = REPO / "apps" / "backend" / ".." / "frontend" / "src"
 FRONTEND_SRC = (REPO / "apps" / "frontend" / "src").resolve()
 
 # Line-anchored (not raw substring), matching both `function foo(` and
@@ -32,6 +31,10 @@ _HELPER_DEFS = {
     ),
     "getPnlColor": re.compile(
         r"^\s*(?:export\s+)?(?:function\s+getPnlColor\(|const\s+getPnlColor\s*=)",
+        re.MULTILINE,
+    ),
+    "pnlColorClass": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+pnlColorClass\(|const\s+pnlColorClass\s*=)",
         re.MULTILINE,
     ),
     "formatPeriod": re.compile(
@@ -53,6 +56,7 @@ _HELPER_DEFS = {
 _CANONICAL_HOME = {
     "countLabel": "apps/frontend/src/lib/statusLabels.ts",
     "getPnlColor": None,  # renamed to pnlColorClass; zero definitions allowed anywhere
+    "pnlColorClass": "apps/frontend/src/lib/statusLabels.ts",
     "formatPeriod": "apps/frontend/src/lib/date.ts",
     "isActive": "apps/frontend/src/components/navigation.ts",
     "formatCurrency": "apps/frontend/src/lib/audit/money/format.ts",

--- a/tests/tooling/test_fe_helper_ssot.py
+++ b/tests/tooling/test_fe_helper_ssot.py
@@ -1,0 +1,104 @@
+"""No duplicate definitions of the single-homed FE helpers (AC-meta.fe-contract-types.4, #1868 S5 PR-B).
+
+`countLabel`/`pnlColorClass`(formerly `getPnlColor`)/`formatPeriod`/`isActive`
+were each duplicated 2-3x across component files, with `formatPeriod`
+already having diverged (a "→" vs "to" separator) and `getPnlColor`
+byte-identical only by luck. They are now single-homed in `lib/statusLabels.ts`,
+`lib/date.ts`, and `components/navigation.ts`. This gate keeps a re-duplication
+from silently coming back. `formatCurrency` collided in name (not meaning)
+with `lib/audit/money/format.ts`'s amount formatter — the local copy is
+renamed `currencyCodeOrDash`, so a bare `formatCurrency` definition anywhere
+outside `lib/audit/money/format.ts` would be exactly that collision returning.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from common.testing.ac_proof import ac_proof
+
+REPO = Path(__file__).resolve().parents[2]
+FRONTEND_SRC = REPO / "apps" / "backend" / ".." / "frontend" / "src"
+FRONTEND_SRC = (REPO / "apps" / "frontend" / "src").resolve()
+
+# Line-anchored (not raw substring), matching both `function foo(` and
+# `const foo = (` styles — the async-aware-regex lesson from
+# tests/tooling/test_safe_error_message_ssot.py (#1864 S1, PR #1871 review).
+_HELPER_DEFS = {
+    "countLabel": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+countLabel\(|const\s+countLabel\s*=)",
+        re.MULTILINE,
+    ),
+    "getPnlColor": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+getPnlColor\(|const\s+getPnlColor\s*=)",
+        re.MULTILINE,
+    ),
+    "formatPeriod": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+formatPeriod\(|const\s+formatPeriod\s*=)",
+        re.MULTILINE,
+    ),
+    "isActive": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+isActive\(|const\s+isActive\s*=)",
+        re.MULTILINE,
+    ),
+    "formatCurrency": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+formatCurrency\(|const\s+formatCurrency\s*=)",
+        re.MULTILINE,
+    ),
+}
+
+# The one canonical home each helper is allowed to be defined in
+# (repo-relative, POSIX-style).
+_CANONICAL_HOME = {
+    "countLabel": "apps/frontend/src/lib/statusLabels.ts",
+    "getPnlColor": None,  # renamed to pnlColorClass; zero definitions allowed anywhere
+    "formatPeriod": "apps/frontend/src/lib/date.ts",
+    "isActive": "apps/frontend/src/components/navigation.ts",
+    "formatCurrency": "apps/frontend/src/lib/audit/money/format.ts",
+}
+
+
+def _frontend_source_files() -> list[Path]:
+    files: list[Path] = []
+    for pattern in ("*.ts", "*.tsx"):
+        for path in FRONTEND_SRC.rglob(pattern):
+            if "node_modules" in path.parts:
+                continue
+            files.append(path)
+    return files
+
+
+@ac_proof(
+    proof_id="test_fe_helper_ssot_single_definition_per_helper",
+    ac_ids=["AC-meta.fe-contract-types.4"],
+    ci_tier="pr_ci",
+)
+def test_AC_fe_helper_ssot_1_each_helper_defined_at_most_once():
+    """AC-meta.fe-contract-types.4: each single-homed helper has ≤1 definition, at its canonical home."""
+    files = _frontend_source_files()
+    violations: list[str] = []
+    for name, pattern in _HELPER_DEFS.items():
+        canonical = _CANONICAL_HOME[name]
+        hits = [
+            str(path.relative_to(REPO))
+            for path in files
+            if pattern.search(path.read_text(encoding="utf-8"))
+        ]
+        if canonical is None:
+            if hits:
+                violations.append(
+                    f"{name}: must not be redefined anywhere (found in {hits})"
+                )
+            continue
+        offenders = [h for h in hits if h != canonical]
+        if offenders:
+            violations.append(
+                f"{name}: defined outside its canonical home {canonical}: {offenders}"
+            )
+        if canonical not in hits:
+            violations.append(
+                f"{name}: canonical home {canonical} no longer defines it (moved or renamed?)"
+            )
+
+    assert not violations, "helper single-homing regressed:\n" + "\n".join(violations)


### PR DESCRIPTION
Part of #1868 (S5 of the #1863 signature-cleanup root). PR-B of 3, **stacked on PR-A (#1872)** — base branch is `fix/1868-s5-pr-a-wire-ssot`, not `main`. Merge PR-A first; this PR's diff will shrink to just PR-B's content once PR-A lands and this is retargeted (or GitHub auto-retargets to `main`).

## What & why

Six helper functions duplicated 2-3x across component files — one pair already behaviorally diverged, one pair conflicted on defaults, one collided in *name* (not meaning) with an unrelated formatter:

| Helper | Copies | Resolution |
|---|---|---|
| `countLabel` | 3 byte-identical | → `lib/statusLabels.ts` |
| `sourceClassLabel`/`SOURCE_CLASS_LABELS`/`humanizeIdentifier` | 2, **drifted fallbacks** (`replaceAll("_"," ")` vs title-case+acronym-aware `humanizeIdentifier`, 2 extra map keys) | → `lib/statusLabels.ts`, richer behavior wins; one FE test's assertion text updated (`"unknown source"` → `"Unknown Source"`) |
| `readinessVariant` | 2, **conflicting unhandled-defaults** (`muted` vs `info`) | → one function, all 7 states of the unioned enum mapped explicitly — turns out the "conflict" was two disjoint domains that never actually overlapped |
| `getPnlColor` | 2 byte-identical | → `lib/statusLabels.ts` as `pnlColorClass` |
| `isActive` | 2 byte-identical | → `components/navigation.ts` |
| `formatCurrency` | name collision (currency-CODE formatter vs `lib/audit/money`'s amount formatter) | → renamed `currencyCodeOrDash` |
| `formatPeriod` | 2, **already diverged** (`"→"` vs `"to"`), + a dead 3rd copy in a test file | → `lib/date.ts`, `"to"` canonical; dead copy deleted |

## `lib/audit` internal dedup (money/quantity/ratio value types)

- `lib/audit/wire.ts`: `decimalToWire` (byte-identical ×3) + `decimalStringFromWire` (structurally identical ×3, now parameterized by each package's typed `FloatError`/`PayloadError` classes — mirrors the backend `WireCodec` pattern in `common/audit/decimal_scalar.py`).
- `lib/audit/localeFormat.ts`: `getLocaleSeparators` + `groupIntegerPart`, shared between `money/format.ts` and `quantity/format.ts`.
- `quantity/format.ts`'s second `coerce` (missing `quantity.ts`'s `isFinite` check) deleted; `quantity.ts`'s `coerce` exported for cross-file use, kept out of the package's public `index.ts` barrel.
- **All three FE conformance-vector suites (money/quantity/ratio) stay green** — the cross-language mirror policy against `common/audit` is unchanged.

## New gate

`tests/tooling/test_fe_helper_ssot.py` (`AC-meta.fe-contract-types.4`, extending PR-A's `.3` group) — pins each helper to exactly one canonical file.

Test coverage extended in `lib/statusLabels.ts`'s and `components/navigation.ts`'s test files for every new/moved function, including a `readinessVariant` test pinning the color for all 7 states of the unioned enum.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- Full frontend suite: **153 files / 1070 tests green** (incl. all 3 audit conformance suites)
- Coverage: 98.15% lines / 88.94% branches / 98.64% functions / 99.37% statements — above the 98/84/98/98 floor
- AC registry/index/dual gates: green
- `tests/tooling/`: 2140 passed (1 pre-existing, unrelated local infra2-submodule-pin failure, same as PR-A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)