### PR TITLE
[finance_report_ui] fix(#1868): lock readinessVariant single-definition — S5 closure review follow-up

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2174,9 +2174,12 @@ CONTRACT = PackageContract(
                 "canonical home (`lib/statusLabels.ts`, `lib/date.ts`, "
                 "`components/navigation.ts`) — were 2-3 component-local copies "
                 'each, with `formatPeriod` already diverged (a "→" vs "to" '
-                "separator) and `readinessVariant` already diverged (conflicting "
-                "Badge colors for overlapping states) before unification. The "
-                "gate actively governs the renamed name too (`pnlColorClass`, "
+                "separator) and `readinessVariant` already diverged (its two "
+                'definitions\' "unhandled"/default branches assigned '
+                "conflicting Badge colors — the two source enums don't "
+                "actually overlap on which states hit that default) before "
+                "unification. The gate actively governs the renamed name too "
+                "(`pnlColorClass`, "
                 "not just banning the old `getPnlColor`), so a future duplicate "
                 "of the CURRENT name is caught, not only a regression to the "
                 "old one. `formatCurrency` is defined only in "

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2169,18 +2169,20 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-meta.fe-contract-types.4",
             statement=(
-                "`countLabel`/`pnlColorClass`/`formatPeriod`/`isActive` each "
-                "have at most one definition, at one canonical home "
-                "(`lib/statusLabels.ts`, `lib/date.ts`, "
+                "`countLabel`/`pnlColorClass`/`formatPeriod`/`isActive`/"
+                "`readinessVariant` each have at most one definition, at one "
+                "canonical home (`lib/statusLabels.ts`, `lib/date.ts`, "
                 "`components/navigation.ts`) — were 2-3 component-local copies "
                 'each, with `formatPeriod` already diverged (a "→" vs "to" '
-                "separator) before unification. The gate actively governs the "
-                "renamed name too (`pnlColorClass`, not just banning the old "
-                "`getPnlColor`), so a future duplicate of the CURRENT name is "
-                "caught, not only a regression to the old one. `formatCurrency` "
-                "is defined only in `lib/audit/money/format.ts` (amount "
-                "formatting) — no second definition colliding in name with a "
-                "currency-CODE formatter exists anywhere else (#1868 S5)."
+                "separator) and `readinessVariant` already diverged (conflicting "
+                "Badge colors for overlapping states) before unification. The "
+                "gate actively governs the renamed name too (`pnlColorClass`, "
+                "not just banning the old `getPnlColor`), so a future duplicate "
+                "of the CURRENT name is caught, not only a regression to the "
+                "old one. `formatCurrency` is defined only in "
+                "`lib/audit/money/format.ts` (amount formatting) — no second "
+                "definition colliding in name with a currency-CODE formatter "
+                "exists anywhere else (#1868 S5)."
             ),
             test=(
                 "tests/tooling/test_fe_helper_ssot.py"

--- a/tests/tooling/test_fe_helper_ssot.py
+++ b/tests/tooling/test_fe_helper_ssot.py
@@ -9,11 +9,13 @@ from silently coming back. `formatCurrency` collided in name (not meaning)
 with `lib/audit/money/format.ts`'s amount formatter — the local copy is
 renamed `currencyCodeOrDash`, so a bare `formatCurrency` definition anywhere
 outside `lib/audit/money/format.ts` would be exactly that collision returning.
-`readinessVariant` (also unified in PR-B, from two conflicting definitions
-with different Badge colors for the same states) was covered by a
-color-pinning test but never by a single-definition gate — added here on
-#1868 root-issue closure review so G-one-readiness-language's "grep gate"
-half of its guarantee is actually locked, not just true by inspection.
+`readinessVariant` (also unified in PR-B, from two near-duplicate
+definitions whose "unhandled"/default branches assigned conflicting Badge
+colors — the two source enums don't actually overlap on which states hit
+that default, see `lib/statusLabels.ts`) was covered by a color-pinning
+test but never by a single-definition gate — added here on #1868
+root-issue closure review so G-one-readiness-language's "grep gate" half
+of its guarantee is actually locked, not just true by inspection.
 """
 
 from __future__ import annotations

--- a/tests/tooling/test_fe_helper_ssot.py
+++ b/tests/tooling/test_fe_helper_ssot.py
@@ -9,6 +9,11 @@ from silently coming back. `formatCurrency` collided in name (not meaning)
 with `lib/audit/money/format.ts`'s amount formatter — the local copy is
 renamed `currencyCodeOrDash`, so a bare `formatCurrency` definition anywhere
 outside `lib/audit/money/format.ts` would be exactly that collision returning.
+`readinessVariant` (also unified in PR-B, from two conflicting definitions
+with different Badge colors for the same states) was covered by a
+color-pinning test but never by a single-definition gate — added here on
+#1868 root-issue closure review so G-one-readiness-language's "grep gate"
+half of its guarantee is actually locked, not just true by inspection.
 """
 
 from __future__ import annotations
@@ -49,6 +54,10 @@ _HELPER_DEFS = {
         r"^\s*(?:export\s+)?(?:function\s+formatCurrency\(|const\s+formatCurrency\s*=)",
         re.MULTILINE,
     ),
+    "readinessVariant": re.compile(
+        r"^\s*(?:export\s+)?(?:function\s+readinessVariant\(|const\s+readinessVariant\s*=)",
+        re.MULTILINE,
+    ),
 }
 
 # The one canonical home each helper is allowed to be defined in
@@ -60,6 +69,7 @@ _CANONICAL_HOME = {
     "formatPeriod": "apps/frontend/src/lib/date.ts",
     "isActive": "apps/frontend/src/components/navigation.ts",
     "formatCurrency": "apps/frontend/src/lib/audit/money/format.ts",
+    "readinessVariant": "apps/frontend/src/lib/statusLabels.ts",
 }
 
 


### PR DESCRIPTION
Small follow-up found while closing out #1868 (S5)/root #1863.

## What

#1868's G-one-readiness-language acceptance criterion reads:

> one `readinessVariant` definition (**grep gate**: exactly one `function readinessVariant` in the tree); a test pins the Badge color for every state literal in the unioned set

PR #1874 shipped the color-pinning test (`statusLabels.test.ts`) but never actually added `readinessVariant` to the single-definition gate — it was true by inspection, not locked in CI. Found during closure review: `grep -rln readinessVariant tests/tooling/ common/testing/` returned nothing before this PR.

## Fix

Extends the existing `tests/tooling/test_fe_helper_ssot.py` mechanism (`_HELPER_DEFS`/`_CANONICAL_HOME`, already governing `countLabel`/`pnlColorClass`/`formatPeriod`/`isActive`/`formatCurrency`) with a `readinessVariant` entry, canonical home `lib/statusLabels.ts`. No behavior change — this only tightens the gate.

## Test plan

- [x] `tests/tooling/test_fe_helper_ssot.py` passes locally
- [x] `tools/generate_ac_registry.py` / `tools/check_ac_index.py` pass
- [x] `apps/backend/.venv/bin/python tools/preflight.py --tier=static` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>