### PR TITLE
[finance_report_ui] S2: lock API-surface migration seams

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -989,6 +989,38 @@ CONTRACT = PackageContract(
             priority="P1",
             status="done",
         ),
+        ACRecord(
+            id="AC-meta.delivery.2",
+            statement=(
+                "The terminal HTTP API home is each owning package's "
+                "extension/api/ adapter. apps/backend/src/routers remains a "
+                "transitional delivery layer whose non-__init__.py file set "
+                "may only shrink relative to the committed baseline; a new "
+                "flat router fails CI and --update refuses to adopt it "
+                "(#1865 S2 G-one-home-decided)."
+            ),
+            test=(
+                "tests/tooling/test_api_surface_ratchet.py"
+                "::test_AC_meta_delivery_2_router_file_set_only_shrinks"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.delivery.3",
+            statement=(
+                "The total direct package-to-src.schemas import count may "
+                "only shrink relative to the committed baseline; a new "
+                "package dependency fails CI and --update refuses to raise "
+                "the baseline (#1865 S2 G-dependency-direction)."
+            ),
+            test=(
+                "tests/tooling/test_api_surface_ratchet.py"
+                "::test_AC_meta_delivery_3_package_schema_import_count_only_shrinks"
+            ),
+            priority="P1",
+            status="done",
+        ),
         # ── residue: the post-migration EPIC tables hold only explicitly
         # marked residue (#1719 "retire the center"; #1416 DoD addition
         # 2026-07-11 makes "genuinely EPIC-owned" machine-checkable). ──
@@ -2214,6 +2246,25 @@ CONTRACT = PackageContract(
         ),
     ],
     concepts=[
+        ConceptRecord(
+            key="api_surface_terminal_home",
+            owner="common/meta/contract.py",
+            description=(
+                "The terminal home for HTTP adapters is the owning package's "
+                "extension/api/ layer; src/routers is transitional and may only "
+                "shrink (#1865 S2)."
+            ),
+            cross_refs=[
+                "common/testing/api_surface_ratchet.py",
+                "common/testing/data/api-surface-ratchet-baseline.json",
+                "tests/tooling/test_api_surface_ratchet.py",
+            ],
+            proofs=["tests/tooling/test_api_surface_ratchet.py"],
+            family="platform",
+            kind="concept",
+            authority="documented_contract",
+            parent="package_model",
+        ),
         ConceptRecord(
             key="ac_tier_baseline",
             owner="common/meta/data/ac-tier-baseline.json",

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -1009,10 +1009,10 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-meta.delivery.3",
             statement=(
-                "The total direct package-to-src.schemas import count may "
-                "only shrink relative to the committed baseline; a new "
-                "package dependency fails CI and --update refuses to raise "
-                "the baseline (#1865 S2 G-dependency-direction)."
+                "The count of package files importing src.schemas may only "
+                "shrink relative to the committed baseline; a new package "
+                "dependency fails CI and --update refuses to raise the "
+                "baseline (#1865 S2 G-dependency-direction)."
             ),
             test=(
                 "tests/tooling/test_api_surface_ratchet.py"

--- a/common/testing/api_surface_ratchet.py
+++ b/common/testing/api_surface_ratchet.py
@@ -3,8 +3,9 @@
 The terminal home for an HTTP adapter is its owning package's
 ``extension/api/`` directory. ``src/routers`` remains only as a transitional
 delivery layer, so it must not gain new flat router modules. Domain packages
-also still have transitional ``src.schemas`` imports; their total may only
-decrease until the vocabulary is fully repatriated.
+also still have transitional ``src.schemas`` imports; the number of package
+files carrying that dependency may only decrease until the vocabulary is fully
+repatriated.
 """
 
 from __future__ import annotations
@@ -51,24 +52,24 @@ def _package_dirs() -> list[Path]:
     ]
 
 
-def _imports_schemas(path: Path) -> int:
+def _imports_schemas(path: Path) -> bool:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    count = 0
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             if node.module == "src.schemas" or (
                 node.module is not None and node.module.startswith("src.schemas.")
             ):
-                count += 1
+                return True
         elif isinstance(node, ast.Import):
-            count += sum(
+            if any(
                 alias.name == "src.schemas" or alias.name.startswith("src.schemas.")
                 for alias in node.names
-            )
-    return count
+            ):
+                return True
+    return False
 
 
-def package_schema_import_count() -> int:
+def package_schema_import_file_count() -> int:
     return sum(
         _imports_schemas(path)
         for package_dir in _package_dirs()
@@ -84,19 +85,19 @@ def _load_baseline() -> dict[str, object]:
         isinstance(path, str) for path in router_files
     ):
         raise ValueError("api-surface ratchet baseline requires router_files list")
-    if type(baseline.get("package_schema_imports")) is not int:
+    if type(baseline.get("package_schema_import_files")) is not int:
         raise ValueError(
-            "api-surface ratchet baseline requires package_schema_imports int"
+            "api-surface ratchet baseline requires package_schema_import_files int"
         )
     return baseline
 
 
-def _write_baseline(*, current_routers: set[str], current_imports: int) -> None:
+def _write_baseline(*, current_routers: set[str], current_import_files: int) -> None:
     BASELINE_PATH.write_text(
         json.dumps(
             {
                 "router_files": sorted(current_routers),
-                "package_schema_imports": current_imports,
+                "package_schema_import_files": current_import_files,
             },
             indent=2,
         )
@@ -113,21 +114,21 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     baseline = _load_baseline()
     current_routers = router_files()
-    current_imports = package_schema_import_count()
+    current_import_files = package_schema_import_file_count()
     baseline_routers = set(baseline["router_files"])
-    baseline_imports = baseline["package_schema_imports"]
-    assert isinstance(baseline_imports, int)
+    baseline_import_files = baseline["package_schema_import_files"]
+    assert isinstance(baseline_import_files, int)
 
     new_routers = sorted(current_routers - baseline_routers)
-    import_growth = current_imports > baseline_imports
+    import_growth = current_import_files > baseline_import_files
     if new_routers or import_growth:
         errors = []
         if new_routers:
             errors.append(f"new flat router files: {', '.join(new_routers)}")
         if import_growth:
             errors.append(
-                "package-to-src.schemas imports grew "
-                f"({baseline_imports} -> {current_imports})"
+                "package files importing src.schemas grew "
+                f"({baseline_import_files} -> {current_import_files})"
             )
         prefix = "REFUSED" if "--update" in args else "ERROR"
         print(f"{prefix}: {'; '.join(errors)}", file=sys.stderr)
@@ -136,7 +137,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if "--update" in args:
         _write_baseline(
             current_routers=current_routers,
-            current_imports=current_imports,
+            current_import_files=current_import_files,
         )
         print("api-surface ratchet baseline tightened")
         return 0
@@ -144,7 +145,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         "api-surface-ratchet: "
         f"routers {len(current_routers)} <= {len(baseline_routers)}, "
-        f"package schema imports {current_imports} <= {baseline_imports}"
+        "package files importing schemas "
+        f"{current_import_files} <= {baseline_import_files}"
     )
     return 0
 

--- a/common/testing/api_surface_ratchet.py
+++ b/common/testing/api_surface_ratchet.py
@@ -1,0 +1,153 @@
+"""Shrink-only API-surface migration locks (#1865 S2 PR-A).
+
+The terminal home for an HTTP adapter is its owning package's
+``extension/api/`` directory. ``src/routers`` remains only as a transitional
+delivery layer, so it must not gain new flat router modules. Domain packages
+also still have transitional ``src.schemas`` imports; their total may only
+decrease until the vocabulary is fully repatriated.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from common.meta.base.layering import PACKAGE_LAYER
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_SRC = REPO_ROOT / "apps" / "backend" / "src"
+ROUTERS_DIR = BACKEND_SRC / "routers"
+BASELINE_PATH = Path(__file__).parent / "data" / "api-surface-ratchet-baseline.json"
+
+TERMINAL_API_HOME = "extension/api"
+
+
+def _relative_to_root(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def router_files() -> set[str]:
+    if not ROUTERS_DIR.exists():
+        return set()
+    return {
+        _relative_to_root(path)
+        for path in ROUTERS_DIR.glob("*.py")
+        if path.name != "__init__.py"
+    }
+
+
+def _package_dirs() -> list[Path]:
+    return [
+        BACKEND_SRC / name
+        for name in sorted(PACKAGE_LAYER)
+        if name not in {"backend", "frontend", "meta", "testing"}
+        and (BACKEND_SRC / name).is_dir()
+    ]
+
+
+def _imports_schemas(path: Path) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "src.schemas" or (
+                node.module is not None and node.module.startswith("src.schemas.")
+            ):
+                count += 1
+        elif isinstance(node, ast.Import):
+            count += sum(
+                alias.name == "src.schemas" or alias.name.startswith("src.schemas.")
+                for alias in node.names
+            )
+    return count
+
+
+def package_schema_import_count() -> int:
+    return sum(
+        _imports_schemas(path)
+        for package_dir in _package_dirs()
+        for path in package_dir.rglob("*.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+def _load_baseline() -> dict[str, object]:
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    router_files = baseline.get("router_files")
+    if not isinstance(router_files, list) or not all(
+        isinstance(path, str) for path in router_files
+    ):
+        raise ValueError("api-surface ratchet baseline requires router_files list")
+    if type(baseline.get("package_schema_imports")) is not int:
+        raise ValueError(
+            "api-surface ratchet baseline requires package_schema_imports int"
+        )
+    return baseline
+
+
+def _write_baseline(*, current_routers: set[str], current_imports: int) -> None:
+    BASELINE_PATH.write_text(
+        json.dumps(
+            {
+                "router_files": sorted(current_routers),
+                "package_schema_imports": current_imports,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if set(args) - {"--update"}:
+        print("usage: api_surface_ratchet.py [--update]", file=sys.stderr)
+        return 2
+
+    baseline = _load_baseline()
+    current_routers = router_files()
+    current_imports = package_schema_import_count()
+    baseline_routers = set(baseline["router_files"])
+    baseline_imports = baseline["package_schema_imports"]
+    assert isinstance(baseline_imports, int)
+
+    new_routers = sorted(current_routers - baseline_routers)
+    import_growth = current_imports > baseline_imports
+    if new_routers or import_growth:
+        errors = []
+        if new_routers:
+            errors.append(f"new flat router files: {', '.join(new_routers)}")
+        if import_growth:
+            errors.append(
+                "package-to-src.schemas imports grew "
+                f"({baseline_imports} -> {current_imports})"
+            )
+        prefix = "REFUSED" if "--update" in args else "ERROR"
+        print(f"{prefix}: {'; '.join(errors)}", file=sys.stderr)
+        return 1
+
+    if "--update" in args:
+        _write_baseline(
+            current_routers=current_routers,
+            current_imports=current_imports,
+        )
+        print("api-surface ratchet baseline tightened")
+        return 0
+
+    print(
+        "api-surface-ratchet: "
+        f"routers {len(current_routers)} <= {len(baseline_routers)}, "
+        f"package schema imports {current_imports} <= {baseline_imports}"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -3940,6 +3940,23 @@ CONTRACT = PackageContract(
     ],
     concepts=[
         ConceptRecord(
+            key="api_surface_ratchet",
+            owner="common/testing/api_surface_ratchet.py",
+            description=(
+                "Shrink-only structural lock for the transitional flat router "
+                "directory and package-to-src.schemas dependency count during "
+                "the API-surface migration (#1865 S2)."
+            ),
+            cross_refs=[
+                "common/testing/data/api-surface-ratchet-baseline.json",
+                "common/meta/contract.py",
+                "tests/tooling/test_api_surface_ratchet.py",
+            ],
+            proofs=["tests/tooling/test_api_surface_ratchet.py"],
+            family="platform",
+            kind="baseline",
+        ),
+        ConceptRecord(
             key="ac_graph",
             owner="common/testing/ac_graph.py",
             description=(

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -3944,7 +3944,8 @@ CONTRACT = PackageContract(
             owner="common/testing/api_surface_ratchet.py",
             description=(
                 "Shrink-only structural lock for the transitional flat router "
-                "directory and package-to-src.schemas dependency count during "
+                "directory and the count of package files carrying a "
+                "src.schemas dependency during "
                 "the API-surface migration (#1865 S2)."
             ),
             cross_refs=[

--- a/common/testing/data/api-surface-ratchet-baseline.json
+++ b/common/testing/data/api-surface-ratchet-baseline.json
@@ -22,5 +22,5 @@
     "apps/backend/src/routers/user_settings.py",
     "apps/backend/src/routers/workflow.py"
   ],
-  "package_schema_imports": 22
+  "package_schema_import_files": 20
 }

--- a/common/testing/data/api-surface-ratchet-baseline.json
+++ b/common/testing/data/api-surface-ratchet-baseline.json
@@ -1,0 +1,26 @@
+{
+  "router_files": [
+    "apps/backend/src/routers/accounts.py",
+    "apps/backend/src/routers/ai_feedback.py",
+    "apps/backend/src/routers/app_config.py",
+    "apps/backend/src/routers/assets.py",
+    "apps/backend/src/routers/audit.py",
+    "apps/backend/src/routers/chat.py",
+    "apps/backend/src/routers/classifications.py",
+    "apps/backend/src/routers/corrections.py",
+    "apps/backend/src/routers/evidence.py",
+    "apps/backend/src/routers/income.py",
+    "apps/backend/src/routers/journal.py",
+    "apps/backend/src/routers/llm.py",
+    "apps/backend/src/routers/market_data.py",
+    "apps/backend/src/routers/metrics.py",
+    "apps/backend/src/routers/portfolio.py",
+    "apps/backend/src/routers/reconciliation.py",
+    "apps/backend/src/routers/reports.py",
+    "apps/backend/src/routers/review.py",
+    "apps/backend/src/routers/statements.py",
+    "apps/backend/src/routers/user_settings.py",
+    "apps/backend/src/routers/workflow.py"
+  ],
+  "package_schema_imports": 22
+}

--- a/tests/tooling/test_api_surface_ratchet.py
+++ b/tests/tooling/test_api_surface_ratchet.py
@@ -1,0 +1,131 @@
+"""Structural locks for the staged API-surface migration (#1865 S2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from common.testing import api_surface_ratchet
+
+
+def _write_baseline(path: Path, *, routers: list[str], schema_imports: int) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "router_files": routers,
+                "package_schema_imports": schema_imports,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_AC_meta_delivery_2_router_file_set_only_shrinks() -> None:
+    """AC-meta.delivery.2: the transitional router directory cannot grow."""
+    assert api_surface_ratchet.TERMINAL_API_HOME == "extension/api"
+    assert api_surface_ratchet.main([]) == 0
+
+
+def test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it(
+    tmp_path: Path, monkeypatch
+) -> None:
+    backend_src = tmp_path / "apps" / "backend" / "src"
+    routers_dir = backend_src / "routers"
+    routers_dir.mkdir(parents=True)
+    (routers_dir / "existing.py").write_text("", encoding="utf-8")
+    (routers_dir / "new.py").write_text("", encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(
+        baseline,
+        routers=["apps/backend/src/routers/existing.py"],
+        schema_imports=0,
+    )
+
+    monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(api_surface_ratchet, "BACKEND_SRC", backend_src)
+    monkeypatch.setattr(api_surface_ratchet, "ROUTERS_DIR", routers_dir)
+    monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
+
+    assert api_surface_ratchet.main([]) == 1
+    assert api_surface_ratchet.main(["--update"]) == 1
+    assert json.loads(baseline.read_text(encoding="utf-8"))["router_files"] == [
+        "apps/backend/src/routers/existing.py"
+    ]
+
+
+def test_AC_meta_delivery_3_package_schema_import_count_only_shrinks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """AC-meta.delivery.3: package dependencies cannot expand the DTO seam."""
+    backend_src = tmp_path / "apps" / "backend" / "src"
+    package_file = backend_src / "reporting" / "extension" / "service.py"
+    package_file.parent.mkdir(parents=True)
+    package_file.write_text(
+        "from src.schemas.reporting import ReportLineId\n",
+        encoding="utf-8",
+    )
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, routers=[], schema_imports=0)
+
+    monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(api_surface_ratchet, "BACKEND_SRC", backend_src)
+    monkeypatch.setattr(api_surface_ratchet, "ROUTERS_DIR", backend_src / "routers")
+    monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
+
+    assert api_surface_ratchet.main([]) == 1
+    assert api_surface_ratchet.main(["--update"]) == 1
+    assert (
+        json.loads(baseline.read_text(encoding="utf-8"))["package_schema_imports"] == 0
+    )
+
+
+def test_update_tightens_a_shrunk_baseline_and_validates_arguments(
+    tmp_path: Path, monkeypatch
+) -> None:
+    backend_src = tmp_path / "apps" / "backend" / "src"
+    backend_src.mkdir(parents=True)
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(
+        baseline,
+        routers=["apps/backend/src/routers/removed.py"],
+        schema_imports=1,
+    )
+
+    monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(api_surface_ratchet, "BACKEND_SRC", backend_src)
+    monkeypatch.setattr(api_surface_ratchet, "ROUTERS_DIR", backend_src / "routers")
+    monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
+
+    assert api_surface_ratchet.main(["--unknown"]) == 2
+    assert api_surface_ratchet.main(["--update"]) == 0
+    assert json.loads(baseline.read_text(encoding="utf-8")) == {
+        "router_files": [],
+        "package_schema_imports": 0,
+    }
+
+
+def test_baseline_requires_the_declared_shape_and_handles_external_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
+
+    baseline.write_text('{"package_schema_imports": 0}', encoding="utf-8")
+    with pytest.raises(ValueError, match="router_files"):
+        api_surface_ratchet._load_baseline()
+
+    baseline.write_text(
+        '{"router_files": [1], "package_schema_imports": 0}', encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="router_files"):
+        api_surface_ratchet._load_baseline()
+
+    baseline.write_text(
+        '{"router_files": [], "package_schema_imports": true}', encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="package_schema_imports"):
+        api_surface_ratchet._load_baseline()
+
+    assert api_surface_ratchet._relative_to_root(tmp_path) == str(tmp_path)

--- a/tests/tooling/test_api_surface_ratchet.py
+++ b/tests/tooling/test_api_surface_ratchet.py
@@ -10,12 +10,14 @@ import pytest
 from common.testing import api_surface_ratchet
 
 
-def _write_baseline(path: Path, *, routers: list[str], schema_imports: int) -> None:
+def _write_baseline(
+    path: Path, *, routers: list[str], schema_import_files: int
+) -> None:
     path.write_text(
         json.dumps(
             {
                 "router_files": routers,
-                "package_schema_imports": schema_imports,
+                "package_schema_import_files": schema_import_files,
             }
         ),
         encoding="utf-8",
@@ -29,7 +31,7 @@ def test_AC_meta_delivery_2_router_file_set_only_shrinks() -> None:
 
 
 def test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     backend_src = tmp_path / "apps" / "backend" / "src"
     routers_dir = backend_src / "routers"
@@ -40,7 +42,7 @@ def test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it(
     _write_baseline(
         baseline,
         routers=["apps/backend/src/routers/existing.py"],
-        schema_imports=0,
+        schema_import_files=0,
     )
 
     monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
@@ -56,33 +58,48 @@ def test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it(
 
 
 def test_AC_meta_delivery_3_package_schema_import_count_only_shrinks(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """AC-meta.delivery.3: package dependencies cannot expand the DTO seam."""
     backend_src = tmp_path / "apps" / "backend" / "src"
     package_file = backend_src / "reporting" / "extension" / "service.py"
     package_file.parent.mkdir(parents=True)
     package_file.write_text(
-        "from src.schemas.reporting import ReportLineId\n",
+        "from src.schemas.reporting import ReportLineId\n"
+        "from src.schemas.base import CurrencyCode\n"
+        "import src.schemas.workflow\n",
         encoding="utf-8",
     )
+    (package_file.parent / "plain.py").write_text(
+        "import src.schemas.workflow\n", encoding="utf-8"
+    )
     baseline = tmp_path / "baseline.json"
-    _write_baseline(baseline, routers=[], schema_imports=0)
+    _write_baseline(baseline, routers=[], schema_import_files=2)
 
     monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(api_surface_ratchet, "BACKEND_SRC", backend_src)
     monkeypatch.setattr(api_surface_ratchet, "ROUTERS_DIR", backend_src / "routers")
     monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
 
+    assert api_surface_ratchet.main([]) == 0
+
+    second_package_file = backend_src / "ledger" / "extension" / "service.py"
+    second_package_file.parent.mkdir(parents=True)
+    second_package_file.write_text(
+        "from src.schemas.account import AccountCreate\n",
+        encoding="utf-8",
+    )
+
     assert api_surface_ratchet.main([]) == 1
     assert api_surface_ratchet.main(["--update"]) == 1
     assert (
-        json.loads(baseline.read_text(encoding="utf-8"))["package_schema_imports"] == 0
+        json.loads(baseline.read_text(encoding="utf-8"))["package_schema_import_files"]
+        == 2
     )
 
 
 def test_update_tightens_a_shrunk_baseline_and_validates_arguments(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     backend_src = tmp_path / "apps" / "backend" / "src"
     backend_src.mkdir(parents=True)
@@ -90,7 +107,7 @@ def test_update_tightens_a_shrunk_baseline_and_validates_arguments(
     _write_baseline(
         baseline,
         routers=["apps/backend/src/routers/removed.py"],
-        schema_imports=1,
+        schema_import_files=1,
     )
 
     monkeypatch.setattr(api_surface_ratchet, "REPO_ROOT", tmp_path)
@@ -102,30 +119,32 @@ def test_update_tightens_a_shrunk_baseline_and_validates_arguments(
     assert api_surface_ratchet.main(["--update"]) == 0
     assert json.loads(baseline.read_text(encoding="utf-8")) == {
         "router_files": [],
-        "package_schema_imports": 0,
+        "package_schema_import_files": 0,
     }
 
 
 def test_baseline_requires_the_declared_shape_and_handles_external_paths(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     baseline = tmp_path / "baseline.json"
     monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
 
-    baseline.write_text('{"package_schema_imports": 0}', encoding="utf-8")
+    baseline.write_text('{"package_schema_import_files": 0}', encoding="utf-8")
     with pytest.raises(ValueError, match="router_files"):
         api_surface_ratchet._load_baseline()
 
     baseline.write_text(
-        '{"router_files": [1], "package_schema_imports": 0}', encoding="utf-8"
+        '{"router_files": [1], "package_schema_import_files": 0}',
+        encoding="utf-8",
     )
     with pytest.raises(ValueError, match="router_files"):
         api_surface_ratchet._load_baseline()
 
     baseline.write_text(
-        '{"router_files": [], "package_schema_imports": true}', encoding="utf-8"
+        '{"router_files": [], "package_schema_import_files": true}',
+        encoding="utf-8",
     )
-    with pytest.raises(ValueError, match="package_schema_imports"):
+    with pytest.raises(ValueError, match="package_schema_import_files"):
         api_surface_ratchet._load_baseline()
 
     assert api_surface_ratchet._relative_to_root(tmp_path) == str(tmp_path)


### PR DESCRIPTION
## Summary
- Record extension/api as the terminal home for package HTTP adapters.
- Add shrink-only ratchets for flat router files and package-to-src.schemas imports.
- Register AC-meta.delivery.2/.3 with test-backed SSOT ownership.

## Validation
- apps/backend/.venv/bin/python -m pytest -q --cov=common.testing.api_surface_ratchet --cov-report=term-missing tests/tooling/test_api_surface_ratchet.py
- apps/backend/.venv/bin/python tools/check_ac_index.py
- apps/backend/.venv/bin/python tools/check_epic_package_dual.py
- apps/backend/.venv/bin/python tools/check_package_contract.py
- apps/backend/.venv/bin/python tools/check_manifest.py
- moon run :lint
- moon run :test
- apps/backend/.venv/bin/python tools/preflight.py --tier=static --base origin/main