### PR TITLE
[finance_report_audit_1866_b] Type extraction orchestration seams

### DIFF
--- a/apps/backend/src/extraction/__init__.py
+++ b/apps/backend/src/extraction/__init__.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 # monkeypatch its functions (``validation.validate_balance = …``) and need one
 # canonical module object to patch.
 from src.extraction.base import validation
+from src.extraction.base.types import DocumentSource, ExtractedTransactionRow, ParseJob
 from src.extraction.base.validation import (
     compute_confidence_score,
     detect_balance_chain_break,
@@ -173,6 +174,7 @@ __all__ = [
     "CurrencyUnresolvedError",
     "DEFAULT_MAX_DEPTH",
     "DeduplicationService",
+    "DocumentSource",
     "DocumentStatus",
     "DocumentType",
     "EvidenceEdge",
@@ -183,12 +185,14 @@ __all__ = [
     "EvidenceTraversalStep",
     "ExtractionError",
     "ExtractionService",
+    "ExtractedTransactionRow",
     "ManagedPosition",
     "ManualValuationBasis",
     "ManualValuationComponentType",
     "ManualValuationLiquidityClass",
     "ManualValuationSnapshot",
     "PositionStatus",
+    "ParseJob",
     "ReportSnapshot",
     "ReportType",
     "SYSTEM_PROMPT",

--- a/apps/backend/src/extraction/base/__init__.py
+++ b/apps/backend/src/extraction/base/__init__.py
@@ -1,4 +1,4 @@
-"""``extraction.base`` — the pure core: validation + confidence calculus.
+"""``extraction.base`` — pure extraction values and validation calculus.
 
 Pure functions over parsed payloads (dicts/Decimals): per-currency balance
 closure, balance-chain continuity, confidence scoring and threshold routing.
@@ -6,3 +6,7 @@ No ORM, no network, no LLM — the extension pipeline calls DOWN into these.
 """
 
 from __future__ import annotations
+
+from src.extraction.base.types import DocumentSource, ExtractedTransactionRow, ParseJob
+
+__all__ = ["DocumentSource", "ExtractedTransactionRow", "ParseJob"]

--- a/apps/backend/src/extraction/base/types.py
+++ b/apps/backend/src/extraction/base/types.py
@@ -1,0 +1,125 @@
+"""Pure value objects carried across extraction orchestration boundaries."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import TypedDict
+from uuid import UUID
+
+
+class PrefectParseParams(TypedDict):
+    """JSON-safe wire representation of :class:`ParseJob`."""
+
+    statement_id: str
+    filename: str
+    institution: str | None
+    user_id: str
+    account_id: str | None
+    file_hash: str
+    storage_key: str
+    model: str | None
+    request_id: str | None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ParseJob:
+    """Immutable identity and routing context for one statement parse."""
+
+    statement_id: UUID
+    filename: str
+    institution: str | None
+    user_id: UUID
+    account_id: UUID | None
+    file_hash: str
+    storage_key: str
+    model: str | None
+    request_id: str | None = None
+
+    def to_prefect_params(self) -> PrefectParseParams:
+        """Return the explicit JSON-safe contract accepted by the Prefect flow."""
+        return {
+            "statement_id": str(self.statement_id),
+            "filename": self.filename,
+            "institution": self.institution,
+            "user_id": str(self.user_id),
+            "account_id": str(self.account_id) if self.account_id is not None else None,
+            "file_hash": self.file_hash,
+            "storage_key": self.storage_key,
+            "model": self.model,
+            "request_id": self.request_id,
+        }
+
+    @classmethod
+    def from_prefect_params(cls, params: Mapping[str, str | None]) -> ParseJob:
+        """Rehydrate a job at the durable-worker boundary."""
+
+        def required(key: str) -> str:
+            value = params.get(key)
+            if value is None:
+                raise ValueError(f"Missing Prefect parse parameter: {key}")
+            return value
+
+        account_id = params.get("account_id")
+        return cls(
+            statement_id=UUID(required("statement_id")),
+            filename=required("filename"),
+            institution=params.get("institution"),
+            user_id=UUID(required("user_id")),
+            account_id=UUID(account_id) if account_id else None,
+            file_hash=required("file_hash"),
+            storage_key=required("storage_key"),
+            model=params.get("model"),
+            request_id=params.get("request_id"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentSource:
+    """One normalized address and identity for a document being parsed."""
+
+    path: Path
+    content: bytes | None
+    url: str | None
+    content_hash: str
+    filename: str
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        path: Path,
+        content: bytes | None = None,
+        url: str | None = None,
+        content_hash: str | None = None,
+        filename: str | None = None,
+    ) -> DocumentSource:
+        """Resolve all legacy source aliases exactly once at the call boundary."""
+        return cls(
+            path=path,
+            content=content,
+            url=url,
+            content_hash=content_hash or hashlib.sha256(content or b"").hexdigest(),
+            filename=filename or path.name,
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ExtractedTransactionRow:
+    """Typed pre-persistence transaction row produced by document extraction."""
+
+    user_id: UUID
+    txn_date: date
+    amount: Decimal
+    direction: str
+    description: str
+    reference: str | None
+    currency: str
+    currency_unresolved: bool
+    balance_after: Decimal | None
+    occurrence_index: int
+    dedup_hash: str

--- a/apps/backend/src/extraction/extension/deduplication.py
+++ b/apps/backend/src/extraction/extension/deduplication.py
@@ -2,13 +2,13 @@ import hashlib
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.extraction.extension.currency_resolution import resolve_ingest_currency
+from src.extraction.base.types import ExtractedTransactionRow
 from src.extraction.orm.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.extraction.orm.layer2 import (
     AtomicPosition,
@@ -122,33 +122,80 @@ class DeduplicationService:
 
     async def upsert_atomic_transaction(
         self,
+        *,
         db: AsyncSession,
-        user_id: UUID,
-        txn_date: date,
-        amount: Decimal,
-        direction: TransactionDirection,
-        description: str,
-        currency: str,
+        row: ExtractedTransactionRow | None = None,
         source_doc_id: UUID,
         source_doc_type: DocumentType,
-        reference: str | None = None,
-        balance_after: Decimal | None = None,
-        occurrence_index: int = 0,
-        currency_unresolved: bool = False,
+        **legacy_fields: object,
     ) -> AtomicTransaction:
         """Upsert atomic transaction with deduplication.
 
         If dedup_hash exists -> Append to source_documents array
         If dedup_hash new -> Insert new record
 
-        ``currency_unresolved`` (EPIC-012 AC12.40.2) flags a new row whose currency
+        ``row.currency_unresolved`` (EPIC-012 AC12.40.2) flags a new row whose currency
         could not be determined at the ingest boundary; ``currency`` then holds a
         non-authoritative placeholder and the row is blocked from promotion until a
         reviewer specifies the currency.
         """
+        if row is None:
+            user_id = cast(UUID, legacy_fields.pop("user_id"))
+            txn_date = cast(date, legacy_fields.pop("txn_date"))
+            amount = cast(Decimal, legacy_fields.pop("amount"))
+            direction = TransactionDirection(cast(str, legacy_fields.pop("direction")))
+            description = str(legacy_fields.pop("description"))
+            reference = cast(str | None, legacy_fields.pop("reference", None))
+            balance_after = cast(Decimal | None, legacy_fields.pop("balance_after", None))
+            occurrence_index = int(legacy_fields.pop("occurrence_index", 0))
+            currency = str(legacy_fields.pop("currency"))
+            row = ExtractedTransactionRow(
+                user_id=user_id,
+                txn_date=txn_date,
+                amount=amount,
+                direction=direction.value,
+                description=description,
+                reference=reference,
+                currency=currency,
+                currency_unresolved=bool(legacy_fields.pop("currency_unresolved", False)),
+                balance_after=balance_after,
+                occurrence_index=occurrence_index,
+                dedup_hash=self.calculate_transaction_hash(
+                    user_id,
+                    txn_date,
+                    amount,
+                    direction,
+                    description,
+                    reference=reference,
+                    balance_after=balance_after,
+                    occurrence_index=occurrence_index,
+                ),
+            )
+        if legacy_fields:
+            names = ", ".join(sorted(legacy_fields))
+            raise TypeError(f"Unexpected atomic transaction fields: {names}")
+
+        user_id = row.user_id
+        txn_date = row.txn_date
+        amount = row.amount
+        direction = TransactionDirection(row.direction)
+        description = row.description
+        reference = row.reference
+        currency = row.currency
+        currency_unresolved = row.currency_unresolved
+        balance_after = row.balance_after
         dedup_hash = self.calculate_transaction_hash(
-            user_id, txn_date, amount, direction, description, reference, balance_after, occurrence_index
+            user_id,
+            txn_date,
+            amount,
+            direction,
+            description,
+            reference,
+            balance_after,
+            row.occurrence_index,
         )
+        if dedup_hash != row.dedup_hash:
+            raise ValueError("Extracted transaction dedup hash does not match its typed fields")
 
         stmt = select(AtomicTransaction).where(
             AtomicTransaction.user_id == user_id,
@@ -420,7 +467,7 @@ class DeduplicationService:
         return doc
 
 
-async def _detach_document_from_atomic_transactions(db: Any, user_id: UUID, doc_id: UUID) -> None:
+async def _detach_document_from_atomic_transactions(db: AsyncSession, user_id: UUID, doc_id: UUID) -> None:
     """Remove a document's contribution to Layer 2 before a reparse re-ingests it.
 
     Atomic transactions sourced *solely* from this document are deleted (the reparse
@@ -458,10 +505,11 @@ async def _detach_document_from_atomic_transactions(db: Any, user_id: UUID, doc_
 
 
 async def dual_write_layer2(
-    db: Any,
+    db: AsyncSession,
     user_id: UUID,
     statement: StatementSummary,
-    transactions: list[AtomicTransaction],
+    transactions: list[ExtractedTransactionRow],
+    *,
     file_path: Path | None = None,
     original_filename: str | None = None,
     document_type: DocumentType | None = None,
@@ -471,18 +519,18 @@ async def dual_write_layer2(
     """Persist the DWD ingestion result: ODS document, Layer-2 facts, conform summary.
 
     Single source of truth for an ingested statement. Given the parsed
-    ``StatementSummary`` envelope and its ``AtomicTransaction`` rows (produced by
+    ``StatementSummary`` envelope and its typed extracted rows (produced by
     ``ExtractionService.parse_document``), this:
 
     1. creates the Layer-1 ``UploadedDocument`` (ODS),
-    2. upserts each ``AtomicTransaction`` (dedup by hash; the extracted running
-       ``balance_after`` stashed on ``txn._extracted_balance_after`` is threaded back
-       into the upsert hash so it matches the precomputed ``dedup_hash``),
+    2. upserts each ``AtomicTransaction`` using the DTO's explicit running
+       ``balance_after`` and occurrence index so its hash matches the precomputed
+       ``dedup_hash``,
     3. links ``StatementSummary.uploaded_document_id`` to the ODS document and
        persists the summary (DWD conform).
 
-    Precondition: each transaction carries a precomputed ``dedup_hash`` and an
-    optional transient ``_extracted_balance_after`` attribute.
+    Precondition: each immutable row carries its precomputed ``dedup_hash`` and
+    every value needed by persistence; no transient ORM attributes are accepted.
 
     Raises RuntimeError on non-IntegrityError failures. IntegrityError (duplicate
     upload) is silently ignored.
@@ -545,33 +593,25 @@ async def dual_write_layer2(
 
         layer2_count = 0
         for txn in transactions:
-            # EPIC-012 AC12.40.1/.2: the currency is decided once at the ingest boundary
-            # in ``ExtractionService.parse_document`` via ``resolve_ingest_currency`` and
-            # stashed on ``txn._currency_unresolved`` (alongside the resolved/placeholder
-            # code already on ``txn.currency``). Callers that build transactions outside
-            # that path fall back to a fresh resolution over the model + statement fields
-            # so this stays the single DB-write boundary and never silent-defaults.
-            if hasattr(txn, "_currency_unresolved"):
-                resolved_code = txn.currency
-                currency_unresolved = bool(txn._currency_unresolved)
-            else:
-                resolved = resolve_ingest_currency(txn.currency, statement.currency)
-                resolved_code = resolved.code
-                currency_unresolved = resolved.unresolved
+            if not isinstance(txn, ExtractedTransactionRow):
+                txn = ExtractedTransactionRow(
+                    user_id=txn.user_id,
+                    txn_date=txn.txn_date,
+                    amount=txn.amount,
+                    direction=TransactionDirection(txn.direction).value,
+                    description=txn.description,
+                    reference=txn.reference,
+                    currency=txn.currency,
+                    currency_unresolved=bool(txn.currency_unresolved),
+                    balance_after=txn.balance_after,
+                    occurrence_index=0,
+                    dedup_hash=txn.dedup_hash,
+                )
             upserted_txn = await dedup_service.upsert_atomic_transaction(
                 db=db,
-                user_id=user_id,
-                txn_date=txn.txn_date,
-                amount=txn.amount,
-                direction=txn.direction,
-                description=txn.description,
-                currency=resolved_code,
-                currency_unresolved=currency_unresolved,
+                row=txn,
                 source_doc_id=uploaded_doc.id,
                 source_doc_type=doc_type,
-                reference=txn.reference,
-                balance_after=getattr(txn, "_extracted_balance_after", None),
-                occurrence_index=getattr(txn, "_occurrence_index", 0),
             )
             layer2_count += 1
 

--- a/apps/backend/src/extraction/extension/deduplication.py
+++ b/apps/backend/src/extraction/extension/deduplication.py
@@ -537,6 +537,12 @@ async def dual_write_layer2(
     """
     from sqlalchemy.exc import IntegrityError
 
+    if any(not isinstance(txn, ExtractedTransactionRow) for txn in transactions):
+        raise TypeError(
+            "dual_write_layer2 requires ExtractedTransactionRow values; "
+            "ORM rows do not carry a reproducible occurrence_index"
+        )
+
     dedup_service = DeduplicationService()
 
     doc_type_map = {
@@ -593,30 +599,6 @@ async def dual_write_layer2(
 
         layer2_count = 0
         for txn in transactions:
-            if not isinstance(txn, ExtractedTransactionRow):
-                direction = TransactionDirection(txn.direction)
-                txn = ExtractedTransactionRow(
-                    user_id=txn.user_id,
-                    txn_date=txn.txn_date,
-                    amount=txn.amount,
-                    direction=direction.value,
-                    description=txn.description,
-                    reference=txn.reference,
-                    currency=txn.currency,
-                    currency_unresolved=bool(txn.currency_unresolved),
-                    balance_after=txn.balance_after,
-                    occurrence_index=0,
-                    dedup_hash=dedup_service.calculate_transaction_hash(
-                        txn.user_id,
-                        txn.txn_date,
-                        txn.amount,
-                        direction,
-                        txn.description,
-                        txn.reference,
-                        txn.balance_after,
-                        0,
-                    ),
-                )
             upserted_txn = await dedup_service.upsert_atomic_transaction(
                 db=db,
                 row=txn,

--- a/apps/backend/src/extraction/extension/deduplication.py
+++ b/apps/backend/src/extraction/extension/deduplication.py
@@ -594,18 +594,28 @@ async def dual_write_layer2(
         layer2_count = 0
         for txn in transactions:
             if not isinstance(txn, ExtractedTransactionRow):
+                direction = TransactionDirection(txn.direction)
                 txn = ExtractedTransactionRow(
                     user_id=txn.user_id,
                     txn_date=txn.txn_date,
                     amount=txn.amount,
-                    direction=TransactionDirection(txn.direction).value,
+                    direction=direction.value,
                     description=txn.description,
                     reference=txn.reference,
                     currency=txn.currency,
                     currency_unresolved=bool(txn.currency_unresolved),
                     balance_after=txn.balance_after,
                     occurrence_index=0,
-                    dedup_hash=txn.dedup_hash,
+                    dedup_hash=dedup_service.calculate_transaction_hash(
+                        txn.user_id,
+                        txn.txn_date,
+                        txn.amount,
+                        direction,
+                        txn.description,
+                        txn.reference,
+                        txn.balance_after,
+                        0,
+                    ),
                 )
             upserted_txn = await dedup_service.upsert_atomic_transaction(
                 db=db,

--- a/apps/backend/src/extraction/extension/service.py
+++ b/apps/backend/src/extraction/extension/service.py
@@ -1,7 +1,6 @@
 """ExtractionService: core LLM parse path + mixin composition."""
 
 import asyncio
-import hashlib
 import json
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -10,10 +9,12 @@ from uuid import UUID
 
 import httpx
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import src.config
 from src.audit.money.currency import normalize_currency_code
 from src.extraction.base.paged_extraction import build_paged_prompt, merge_paged_extractions
+from src.extraction.base.types import DocumentSource, ExtractedTransactionRow
 from src.extraction.base.validation import (
     bank_currency_balances,
     compute_confidence_score,
@@ -49,7 +50,7 @@ from src.extraction.extension.currency_resolution import resolve_ingest_currency
 from src.extraction.extension.deduplication import DeduplicationService, _decimal_key, dual_write_layer2
 from src.extraction.extension.prompts.statement import get_parsing_prompt
 from src.extraction.orm.layer1 import DocumentType
-from src.extraction.orm.layer2 import AtomicTransaction, TransactionDirection
+from src.extraction.orm.layer2 import TransactionDirection
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Account, AccountType, JournalLine
@@ -177,62 +178,107 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         await db.delete(account)
         await db.flush()
 
+    async def _extract_csv_source(
+        self,
+        source: DocumentSource,
+        *,
+        institution: str | None,
+    ) -> dict[str, Any]:
+        if not source.content:
+            raise ExtractionError("File content is required for CSV parsing")
+        if not institution:
+            raise ExtractionError("Institution is required for CSV parsing")
+        return await self._parse_csv_content(source.content, institution)
+
+    async def _extract_vision_source(
+        self,
+        source: DocumentSource,
+        *,
+        institution: str | None,
+        file_type: str,
+        force_model: str | None,
+        user_id: UUID,
+    ) -> dict[str, Any]:
+        extracted = await self._extract_with_balance_retry(
+            file_content=source.content,
+            institution=institution,
+            file_type=file_type,
+            file_url=source.url,
+            force_model=force_model,
+            filename=source.filename,
+            user_id=user_id,
+        )
+        return self._backfill_generated_brokerage_positions(
+            extracted,
+            file_content=source.content,
+            file_type=file_type,
+            filename=source.filename,
+            institution=institution,
+        )
+
     async def parse_document(
         self,
-        file_path: Path,
-        institution: str | None,
+        source: DocumentSource | Path | None = None,
+        institution: str | None = None,
+        *,
         user_id: UUID,
         file_type: str = "pdf",
         account_id: UUID | None = None,
-        file_content: bytes | None = None,
-        file_hash: str | None = None,
-        file_url: str | None = None,
-        original_filename: str | None = None,
         force_model: str | None = None,
-        db: Any | None = None,
-    ) -> tuple[StatementSummary, list[AtomicTransaction]]:
+        db: AsyncSession | None = None,
+        **legacy_source: object,
+    ) -> tuple[StatementSummary, list[ExtractedTransactionRow]]:
         """Parse document using AI vision models or CSV parser.
 
         Builds a DWD ``StatementSummary`` envelope and a list of Layer-2
-        ``AtomicTransaction`` rows. The atomic rows carry a precomputed
+        typed extracted transaction rows. The rows carry a precomputed
         ``dedup_hash`` (with the extracted running ``balance_after`` threaded in so
-        otherwise-identical transactions stay distinct) and an empty
-        ``source_documents`` placeholder; ``dual_write_layer2`` creates the
-        ``UploadedDocument``, fills ``source_documents``/upserts the rows, links the
-        summary's ``uploaded_document_id`` and persists the summary.
+        otherwise-identical transactions stay distinct). ``dual_write_layer2``
+        creates the ``UploadedDocument``, upserts the rows with their source link,
+        links the summary's ``uploaded_document_id``, and persists the summary.
         """
+        legacy_path = legacy_source.pop("file_path", None)
+        if source is None:
+            source = legacy_path if isinstance(legacy_path, Path) else None
+        if isinstance(source, Path):
+            content = legacy_source.pop("file_content", None)
+            file_url = legacy_source.pop("file_url", None)
+            file_hash = legacy_source.pop("file_hash", None)
+            original_filename = legacy_source.pop("original_filename", None)
+            source = DocumentSource.resolve(
+                path=source,
+                content=content if isinstance(content, bytes) else None,
+                url=file_url if isinstance(file_url, str) else None,
+                content_hash=file_hash if isinstance(file_hash, str) else None,
+                filename=original_filename if isinstance(original_filename, str) else None,
+            )
+        if not isinstance(source, DocumentSource):
+            raise TypeError("parse_document requires a DocumentSource or Path")
+        if legacy_source:
+            names = ", ".join(sorted(legacy_source))
+            raise TypeError(f"Unexpected document source arguments: {names}")
+
+        file_path = source.path
+        original_filename = source.filename
         model = force_model or self.ocr_model
         logger.info(
             "Parsing document",
             institution=institution or "(auto-detect)",
             file_type=file_type,
             model=model,
-            filename=original_filename or (file_path.name if file_path else "unknown"),
+            filename=source.filename,
         )
 
         try:
             if file_type == "csv":
-                if not file_content:
-                    raise ExtractionError("File content is required for CSV parsing")
-                if not institution:
-                    raise ExtractionError("Institution is required for CSV parsing")
-                extracted = await self._parse_csv_content(file_content, institution)
+                extracted = await self._extract_csv_source(source, institution=institution)
             elif file_type in ("pdf", "png", "jpg", "jpeg"):
-                extracted = await self._extract_with_balance_retry(
-                    file_content=file_content,
+                extracted = await self._extract_vision_source(
+                    source,
                     institution=institution,
                     file_type=file_type,
-                    file_url=file_url,
                     force_model=force_model,
-                    filename=original_filename or (file_path.name if file_path else None),
                     user_id=user_id,
-                )
-                extracted = self._backfill_generated_brokerage_positions(
-                    extracted,
-                    file_content=file_content,
-                    file_type=file_type,
-                    filename=original_filename or (file_path.name if file_path else None),
-                    institution=institution,
                 )
             else:
                 raise ExtractionError(f"Unsupported file type: {file_type}")
@@ -245,7 +291,7 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                 institution=final_institution,
             )
 
-            resolved_file_hash = file_hash or hashlib.sha256(file_content or b"").hexdigest()
+            resolved_file_hash = source.content_hash
             # Raw extracted statement currency (no fallback) — feeds the per-transaction
             # ingest-boundary resolution (AC12.40) so a genuinely-missing currency is
             # flagged for review rather than masked by the StatementSummary default.
@@ -427,7 +473,7 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                         )
                     statement.currency_balances = bank_balances
 
-            transactions: list[AtomicTransaction] = []
+            transactions: list[ExtractedTransactionRow] = []
             net_transactions = Decimal("0.00")
             # Per-document occurrence ordinal among rows that would otherwise hash
             # identically (same date/amount/direction/description/reference/balance): lets
@@ -541,21 +587,19 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
                     occurrence_index=occurrence_index,
                 )
 
-                transaction = AtomicTransaction(
+                transaction = ExtractedTransactionRow(
                     user_id=user_id,
                     txn_date=parsed_date,
                     amount=amount,
-                    direction=txn_direction,
+                    direction=txn_direction.value,
                     description=txn_description,
                     reference=txn_reference,
                     currency=txn_currency,
+                    currency_unresolved=resolved_currency.unresolved,
+                    balance_after=txn_balance_after,
+                    occurrence_index=occurrence_index,
                     dedup_hash=dedup_hash,
-                    source_documents=[],
                 )
-                transaction._extracted_balance_after = txn_balance_after
-                transaction._occurrence_index = occurrence_index
-                # AC12.40.2: carry the ingest-boundary resolution decision to dual_write_layer2.
-                transaction._currency_unresolved = resolved_currency.unresolved
                 transactions.append(transaction)
 
             # Within-document dedup-collapse signal (EPIC-026 AC26.8.1; #1254 class).

--- a/apps/backend/src/extraction/extension/service.py
+++ b/apps/backend/src/extraction/extension/service.py
@@ -238,15 +238,30 @@ class ExtractionService(_MediaMixin, _CoerceMixin, _OcrMixin, _BrokerageMixin, _
         links the summary's ``uploaded_document_id``, and persists the summary.
         """
         legacy_path = legacy_source.pop("file_path", None)
-        if source is None:
-            source = legacy_path if isinstance(legacy_path, Path) else None
-        if isinstance(source, Path):
+        if source is None and isinstance(legacy_path, Path):
+            source = legacy_path
+        legacy_content = legacy_source.get("file_content")
+        legacy_url = legacy_source.get("file_url")
+        if isinstance(source, Path) or (
+            source is None and (isinstance(legacy_content, bytes) or isinstance(legacy_url, str))
+        ):
             content = legacy_source.pop("file_content", None)
             file_url = legacy_source.pop("file_url", None)
             file_hash = legacy_source.pop("file_hash", None)
             original_filename = legacy_source.pop("original_filename", None)
+            path = (
+                source
+                if isinstance(source, Path)
+                else Path(
+                    original_filename
+                    if isinstance(original_filename, str)
+                    else file_hash
+                    if isinstance(file_hash, str)
+                    else "in-memory-document"
+                )
+            )
             source = DocumentSource.resolve(
-                path=source,
+                path=path,
                 content=content if isinstance(content, bytes) else None,
                 url=file_url if isinstance(file_url, str) else None,
                 content_hash=file_hash if isinstance(file_hash, str) else None,

--- a/apps/backend/src/extraction/extension/statement_flow.py
+++ b/apps/backend/src/extraction/extension/statement_flow.py
@@ -9,12 +9,11 @@ in ``statement_pipeline.py``.
 
 from __future__ import annotations
 
-from uuid import UUID
-
 from fastapi.concurrency import run_in_threadpool
 from prefect import flow
 
 from src.database import async_session_maker
+from src.extraction.base.types import ParseJob
 from src.extraction.extension.statement_parsing import parse_statement_background
 from src.observability import get_logger, run_with_async_parse_tracking
 from src.runtime import StorageService
@@ -25,15 +24,7 @@ logger = get_logger(__name__)
 @flow(name="parse-statement", retries=2, retry_delay_seconds=30)
 async def parse_statement_flow(
     *,
-    statement_id: str,
-    filename: str,
-    institution: str | None,
-    user_id: str,
-    account_id: str | None,
-    file_hash: str,
-    storage_key: str,
-    model: str | None,
-    request_id: str | None = None,
+    job: dict[str, str | None],
 ) -> None:
     """Durable, retriable statement parse.
 
@@ -41,27 +32,20 @@ async def parse_statement_flow(
     then runs the existing parse logic. Idempotency is keyed on ``statement_id``
     (the underlying parse persists by statement id), so retries/re-runs are safe.
     """
+    parse_job = ParseJob.from_prefect_params(job)
     logger.info(
         "statement.parse.flow_started",
-        statement_id=statement_id,
-        request_id=request_id,
+        statement_id=str(parse_job.statement_id),
+        request_id=parse_job.request_id,
     )
     storage = StorageService()
-    content = await run_in_threadpool(storage.get_object, storage_key)
+    content = await run_in_threadpool(storage.get_object, parse_job.storage_key)
     await run_with_async_parse_tracking(
         parse_statement_background(
-            statement_id=UUID(statement_id),
-            filename=filename,
-            institution=institution,
-            user_id=UUID(user_id),
-            account_id=UUID(account_id) if account_id else None,
-            file_hash=file_hash,
-            storage_key=storage_key,
+            job=parse_job,
             content=content,
-            model=model,
             session_maker=async_session_maker,
-            request_id=request_id,
         ),
-        statement_id=statement_id,
-        request_id=request_id,
+        statement_id=parse_job.statement_id,
+        request_id=parse_job.request_id,
     )

--- a/apps/backend/src/extraction/extension/statement_parsing.py
+++ b/apps/backend/src/extraction/extension/statement_parsing.py
@@ -1,7 +1,7 @@
 """Background task functions for statement parsing."""
 
 import time
-from inspect import Parameter, signature
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from src.extraction.base.types import DocumentSource, ParseJob
 from src.extraction.extension.brokerage_positions import looks_like_brokerage_payload
 from src.extraction.extension.service import ExtractionError, ExtractionService
 from src.extraction.extension.statement_posting import try_auto_approve_high_confidence_statement
@@ -228,16 +229,12 @@ async def handle_parse_failure(
     statement: StatementSummary,
     db: AsyncSession,
     *,
+    job: ParseJob | None = None,
     message: str | None,
     phase: str = "unknown",
     progress: int | None = None,
     model_to_use: str | None = None,
     error_type: str | None = None,
-    request_id: str | None = None,
-    statement_id: UUID | None = None,
-    file_hash: str | None = None,
-    storage_key: str | None = None,
-    original_filename: str | None = None,
 ) -> None:
     """Handle parse failure by marking statement as REJECTED.
 
@@ -250,14 +247,15 @@ async def handle_parse_failure(
         statement: The StatementSummary envelope (may have expired session)
         db: AsyncSession for database operations
         message: Error message to store in validation_error
-        statement_id: Plain statement UUID captured before any failing operation.
-            Preferred over reading ``statement.id`` (#1256, AC13.23.3): on an
-            already-failed session, touching an expired ORM attribute raises
-            ``PendingRollbackError`` and masks the original error. We roll back
-            FIRST, then only fall back to reading the ORM attribute once the
-            session is clean.
+        job: Parse identity captured before any failing operation. Its plain
+            statement UUID is preferred over reading ``statement.id`` (#1256,
+            AC13.23.3): on an already-failed session, touching an expired ORM
+            attribute raises ``PendingRollbackError`` and masks the original
+            error. We roll back FIRST, then only fall back to reading the ORM
+            attribute once the session is clean.
     """
-    request_id = request_id or str(uuid4())
+    request_id = job.request_id if job is not None and job.request_id else str(uuid4())
+    statement_id = job.statement_id if job is not None else None
     # Resolve the statement id WITHOUT ever letting an expired/failed-session ORM
     # read mask the original error (#1256, AC13.23.3). Prefer the plain id the
     # caller captured before any failing operation; otherwise read ``statement.id``
@@ -305,13 +303,13 @@ async def handle_parse_failure(
         refreshed.validation_error = _redacted(message)
         refreshed.confidence_score = 0
         refreshed.balance_validated = False
-        if file_hash and storage_key:
+        if job is not None:
             await _ensure_failed_document_lineage(
                 db,
                 refreshed,
-                file_hash=file_hash,
-                storage_key=storage_key,
-                original_filename=original_filename or file_hash,
+                file_hash=job.file_hash,
+                storage_key=job.storage_key,
+                original_filename=job.filename,
             )
         await db.commit()
         logger.warning(
@@ -336,66 +334,11 @@ async def handle_parse_failure(
         )
 
 
-def _filter_failure_handler_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
-    try:
-        parameters = signature(handle_parse_failure).parameters
-    except (TypeError, ValueError):
-        return kwargs
-    if any(parameter.kind == Parameter.VAR_KEYWORD for parameter in parameters.values()):
-        return kwargs
-    return {key: value for key, value in kwargs.items() if key in parameters}
-
-
-async def _handle_parse_failure(
-    statement: StatementSummary,
-    db: AsyncSession,
-    *,
-    message: str | None,
-    phase: str,
-    progress: int | None,
-    model_to_use: str | None,
-    error_type: str | None,
-    request_id: str,
-    statement_id: UUID | None = None,
-    file_hash: str | None = None,
-    storage_key: str | None = None,
-    original_filename: str | None = None,
-) -> None:
-    await handle_parse_failure(
-        statement,
-        db,
-        **_filter_failure_handler_kwargs(
-            {
-                "message": message,
-                "phase": phase,
-                "progress": progress,
-                "model_to_use": model_to_use,
-                "error_type": error_type,
-                "request_id": request_id,
-                # Plain UUID captured at task start — safe to read even if the
-                # ORM `statement` row's session is in a failed state (#1256).
-                "statement_id": statement_id,
-                "file_hash": file_hash,
-                "storage_key": storage_key,
-                "original_filename": original_filename,
-            }
-        ),
-    )
-
-
 async def parse_statement_background(
+    job: ParseJob,
     *,
-    statement_id: UUID,
-    filename: str,
-    institution: str | None,
-    user_id: UUID,
-    account_id: UUID | None,
-    file_hash: str,
-    storage_key: str,
     content: bytes,
-    model: str | None,
     session_maker: async_sessionmaker[AsyncSession],
-    request_id: str | None = None,
 ) -> None:
     """Background task to parse a bank statement document.
 
@@ -406,19 +349,21 @@ async def parse_statement_background(
     4. Handle errors and mark statement appropriately
 
     Args:
-        statement_id: UUID of the StatementSummary envelope to parse
-        filename: Original filename of uploaded file
-        institution: Bank institution name (or None for auto-detect)
-        user_id: User ID who uploaded the statement
-        account_id: Optional account ID to associate with statement
-        file_hash: SHA256 hash of file content
-        storage_key: Storage key for the uploaded file
+        job: Immutable identity and routing context for this parse.
         content: Raw file content bytes
-        model: AI model to use for parsing (or None for default)
         session_maker: AsyncSession maker for background DB operations
-        request_id: Optional request ID for tracing
     """
-    request_id = request_id or str(uuid4())
+    statement_id = job.statement_id
+    filename = job.filename
+    institution = job.institution
+    user_id = job.user_id
+    account_id = job.account_id
+    file_hash = job.file_hash
+    storage_key = job.storage_key
+    model = job.model
+    request_id = job.request_id or str(uuid4())
+    if job.request_id is None:
+        job = replace(job, request_id=request_id)
     # Bind request_id to context for this background task
     structlog.contextvars.bind_contextvars(
         request_id=request_id, statement_id=str(statement_id), task="parse_statement"
@@ -492,15 +437,17 @@ async def parse_statement_background(
             # (caught by the #1520 real-storage pipeline test). The display
             # name travels separately as original_filename.
             parsed_statement, transactions = await service.parse_document(
-                file_path=Path(storage_key),
+                DocumentSource.resolve(
+                    path=Path(storage_key),
+                    content=content,
+                    url=file_url,
+                    content_hash=file_hash,
+                    filename=filename,
+                ),
                 institution=institution,
                 user_id=user_id,
                 file_type=file_type,
                 account_id=account_id,
-                file_content=content,
-                file_hash=file_hash,
-                file_url=file_url,
-                original_filename=filename,
                 force_model=model,
                 db=session,
             )
@@ -515,19 +462,15 @@ async def parse_statement_background(
             )
             checkpoint("extraction_completed")
         except ExtractionError as exc:
-            await _handle_parse_failure(
+            await handle_parse_failure(
                 statement,
                 session,
+                job=job,
                 message=str(exc),
                 phase=current_phase,
                 progress=None,
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
-                request_id=request_id,
-                statement_id=statement_id,
-                file_hash=file_hash,
-                storage_key=storage_key,
-                original_filename=filename,
             )
             return
         except Exception as exc:
@@ -539,19 +482,15 @@ async def parse_statement_background(
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
             )
-            await _handle_parse_failure(
+            await handle_parse_failure(
                 statement,
                 session,
+                job=job,
                 message=f"Parsing failed: {exc}",
                 phase=current_phase,
                 progress=None,
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
-                request_id=request_id,
-                statement_id=statement_id,
-                file_hash=file_hash,
-                storage_key=storage_key,
-                original_filename=filename,
             )
             return
 
@@ -603,17 +542,13 @@ async def parse_statement_background(
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
             )
-            await _handle_parse_failure(
+            await handle_parse_failure(
                 statement,
                 session,
+                job=job,
                 message=f"Finalize failed: {exc}",
                 phase=current_phase,
                 progress=None,
                 model_to_use=model_to_use,
                 error_type=type(exc).__name__,
-                request_id=request_id,
-                statement_id=statement_id,
-                file_hash=file_hash,
-                storage_key=storage_key,
-                original_filename=filename,
             )

--- a/apps/backend/src/extraction/extension/statement_pipeline.py
+++ b/apps/backend/src/extraction/extension/statement_pipeline.py
@@ -19,12 +19,12 @@ everywhere), so the fallback path never pays an import cost it doesn't need.
 from __future__ import annotations
 
 import asyncio
-from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import src.config
 from src.database import create_session_maker_from_db
+from src.extraction.base.types import ParseJob
 from src.extraction.extension.statement_parsing import parse_statement_background
 from src.observability import get_logger, run_with_async_parse_tracking
 
@@ -45,17 +45,9 @@ def _consume_background_task_exception(task: asyncio.Task[None]) -> None:
 
 async def submit_parse_pipeline(
     *,
-    statement_id: UUID,
-    filename: str,
-    institution: str | None,
-    user_id: UUID,
-    account_id: UUID | None,
-    file_hash: str,
-    storage_key: str,
+    job: ParseJob,
     content: bytes,
-    model: str | None,
     db: AsyncSession,
-    request_id: str | None,
 ) -> asyncio.Task[None] | None:
     """Dispatch statement parsing.
 
@@ -72,20 +64,12 @@ async def submit_parse_pipeline(
         task = asyncio.create_task(
             run_with_async_parse_tracking(
                 parse_statement_background(
-                    statement_id=statement_id,
-                    filename=filename,
-                    institution=institution,
-                    user_id=user_id,
-                    account_id=account_id,
-                    file_hash=file_hash,
-                    storage_key=storage_key,
+                    job=job,
                     content=content,
-                    model=model,
                     session_maker=create_session_maker_from_db(db),
-                    request_id=request_id,
                 ),
-                statement_id=statement_id,
-                request_id=request_id,
+                statement_id=job.statement_id,
+                request_id=job.request_id,
             )
         )
         task.add_done_callback(_consume_background_task_exception)
@@ -100,24 +84,14 @@ async def submit_parse_pipeline(
 
             await run_deployment(
                 name=PARSE_DEPLOYMENT,
-                parameters={
-                    "statement_id": str(statement_id),
-                    "filename": filename,
-                    "institution": institution,
-                    "user_id": str(user_id),
-                    "account_id": str(account_id) if account_id is not None else None,
-                    "file_hash": file_hash,
-                    "storage_key": storage_key,
-                    "model": model,
-                    "request_id": request_id,
-                },
+                parameters={"job": job.to_prefect_params()},
                 timeout=0,  # fire-and-submit: do not block the upload request on completion
             )
             logger.info(
                 "statement.parse.submitted_to_prefect",
-                statement_id=str(statement_id),
+                statement_id=str(job.statement_id),
                 deployment=PARSE_DEPLOYMENT,
-                request_id=request_id,
+                request_id=job.request_id,
             )
             return None
         except Exception as exc:  # noqa: BLE001
@@ -128,9 +102,9 @@ async def submit_parse_pipeline(
             # runs; only the durable-handoff is skipped (logged loudly for ops).
             logger.warning(
                 "statement.parse.prefect_unavailable_fallback_in_process",
-                statement_id=str(statement_id),
+                statement_id=str(job.statement_id),
                 error=str(exc),
-                request_id=request_id,
+                request_id=job.request_id,
             )
             return _run_in_process()
 

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -18,6 +18,7 @@ from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.extraction import (
     BrokeragePositionImportService,
+    ParseJob,
     UploadedDocument,
     _brokerage_import_not_ready_reason,
     _brokerage_payload_from_persisted_extraction,
@@ -151,17 +152,19 @@ async def _queue_statement_reparse(
     request_id = _current_request_id()
     model_to_use = None if model == settings.ocr_model else model
     task = await submit_parse_pipeline(
-        statement_id=statement.id,
-        filename=filename,
-        institution=statement.institution,
-        user_id=user_id,
-        account_id=statement.account_id,
-        file_hash=statement.file_hash,
-        storage_key=storage_key,
+        job=ParseJob(
+            statement_id=statement.id,
+            filename=filename,
+            institution=statement.institution,
+            user_id=user_id,
+            account_id=statement.account_id,
+            file_hash=statement.file_hash,
+            storage_key=storage_key,
+            model=model_to_use,
+            request_id=request_id,
+        ),
         content=content,
-        model=model_to_use,
         db=db,
-        request_id=request_id,
     )
     if task is not None:
         _track_task(task)
@@ -403,17 +406,19 @@ async def upload_statement(
         raise_internal_error("Failed to persist statement metadata", cause=exc)
 
     task = await submit_parse_pipeline(
-        statement_id=statement_id,
-        filename=filename,
-        institution=institution,
-        user_id=user_id,
-        account_id=account_id,
-        file_hash=file_hash,
-        storage_key=storage_key,
+        job=ParseJob(
+            statement_id=statement_id,
+            filename=filename,
+            institution=institution,
+            user_id=user_id,
+            account_id=account_id,
+            file_hash=file_hash,
+            storage_key=storage_key,
+            model=model_to_use,
+            request_id=request_id,
+        ),
         content=content,
-        model=model_to_use,
         db=db,
-        request_id=request_id,
     )
     if task is not None:
         _track_task(task)

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -15,8 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit import JournalEntrySourceType
 from src.deps import PaginationParams
-from src.extraction import DocumentType, ReportSnapshot, UploadedDocument
-from src.extraction.extension.deduplication import dual_write_layer2
+from src.extraction import DocumentType, ExtractedTransactionRow, ReportSnapshot, UploadedDocument
+from src.extraction.extension.deduplication import DeduplicationService, dual_write_layer2
 from src.extraction.extension.evidence_graph_integration import EvidenceGraphIntegrationService
 from src.extraction.extension.review_queue import create_entry_from_txn
 from src.extraction.orm.layer2 import AssetType, AtomicPosition, AtomicTransaction, TransactionDirection
@@ -1644,16 +1644,29 @@ async def test_AC18_8_4_AC18_8_7_package_traceability_resolves_report_line_to_so
         balance_validated=True,
         stage1_status=Stage1Status.APPROVED,
     )
-    txn = AtomicTransaction(
+    amount = Decimal("120.00")
+    direction = TransactionDirection.IN
+    description = "Evidence graph income"
+    reference = "EG-INC"
+    txn = ExtractedTransactionRow(
         user_id=test_user.id,
         txn_date=report_date,
-        description="Evidence graph income",
-        amount=Decimal("120.00"),
-        direction=TransactionDirection.IN,
+        description=description,
+        amount=amount,
+        direction=direction.value,
         currency="SGD",
-        reference="EG-INC",
-        dedup_hash=uuid4().hex + uuid4().hex,
-        source_documents=[],
+        reference=reference,
+        currency_unresolved=False,
+        balance_after=None,
+        occurrence_index=0,
+        dedup_hash=DeduplicationService.calculate_transaction_hash(
+            test_user.id,
+            report_date,
+            amount,
+            direction,
+            description,
+            reference,
+        ),
     )
 
     await dual_write_layer2(

--- a/apps/backend/tests/api/test_statement_pipeline.py
+++ b/apps/backend/tests/api/test_statement_pipeline.py
@@ -15,24 +15,27 @@ from uuid import uuid4
 
 import pytest
 
-from src.extraction.extension import statement_pipeline
+from src.extraction import ParseJob
+from src.extraction.extension import statement_flow, statement_pipeline
 
 pytestmark = pytest.mark.no_db
 
 
 def _dispatch_kwargs() -> dict:
     return {
-        "statement_id": uuid4(),
-        "filename": "stmt.pdf",
-        "institution": None,
-        "user_id": uuid4(),
-        "account_id": None,
-        "file_hash": "hash",
-        "storage_key": "uploads/stmt.pdf",
+        "job": ParseJob(
+            statement_id=uuid4(),
+            filename="stmt.pdf",
+            institution=None,
+            user_id=uuid4(),
+            account_id=None,
+            file_hash="hash",
+            storage_key="uploads/stmt.pdf",
+            model=None,
+            request_id="req-1",
+        ),
         "content": b"file-bytes",
-        "model": None,
         "db": object(),
-        "request_id": "req-1",
     }
 
 
@@ -52,7 +55,7 @@ async def test_AC19_13_1_dispatch_falls_back_to_asyncio_when_prefect_unset(monke
     assert isinstance(task, asyncio.Task)
     await task
     # In-process path keeps the raw content + a session maker.
-    assert seen["filename"] == "stmt.pdf"
+    assert seen["job"].filename == "stmt.pdf"
     assert seen["content"] == b"file-bytes"
     assert seen["session_maker"] == "session-maker"
 
@@ -116,8 +119,8 @@ async def test_AC19_13_2_dispatch_submits_serializable_params_to_prefect(monkeyp
     assert "content" not in params
     assert "db" not in params
     assert "session_maker" not in params
-    assert params["statement_id"] == str(kwargs["statement_id"])
-    assert params["storage_key"] == "uploads/stmt.pdf"
+    assert params["job"] == kwargs["job"].to_prefect_params()
+    assert params["job"]["storage_key"] == "uploads/stmt.pdf"
 
 
 async def test_AC19_13_1_dispatch_falls_back_when_prefect_client_absent(monkeypatch):
@@ -165,3 +168,29 @@ async def test_AC19_13_1_dispatch_falls_back_when_prefect_submit_fails(monkeypat
     await task
     run_deployment.assert_awaited_once()  # it tried Prefect first, then fell back
     assert seen["content"] == b"file-bytes"
+
+
+async def test_AC_extraction_signature_seams_1_prefect_worker_rehydrates_parse_job(monkeypatch):
+    """AC-extraction.signature-seams.1: the worker reconstructs the same typed job."""
+    job = _dispatch_kwargs()["job"]
+    seen: dict = {}
+
+    async def fake_background(**kwargs):
+        seen.update(kwargs)
+
+    async def fake_run_in_threadpool(function, *args, **kwargs):
+        return b"stored-content"
+
+    monkeypatch.setattr(statement_flow, "parse_statement_background", fake_background)
+    monkeypatch.setattr(statement_flow, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(
+        statement_flow,
+        "run_with_async_parse_tracking",
+        lambda awaitable, **_context: awaitable,
+    )
+
+    await statement_flow.parse_statement_flow.fn(job=job.to_prefect_params())
+
+    assert seen["job"] == job
+    assert seen["content"] == b"stored-content"
+    assert seen["session_maker"] is statement_flow.async_session_maker

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -28,7 +28,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from src.audit import STATEMENT_SOURCE_TYPES, JournalEntrySourceType
-from src.extraction import DocumentSource, DocumentType, ExtractionError, ParseJob, UploadedDocument
+from src.extraction import (
+    DocumentSource,
+    DocumentType,
+    ExtractedTransactionRow,
+    ExtractionError,
+    ParseJob,
+    UploadedDocument,
+)
 from src.extraction.extension import (
     statement_parsing as statement_parsing_mod,
     statement_pipeline,
@@ -599,7 +606,7 @@ async def test_list_and_transactions_flow(db, monkeypatch, storage_stub, model_c
 
     content = b"statement-flow"
 
-    from src.extraction.extension.deduplication import dual_write_layer2
+    from src.extraction.extension.deduplication import DeduplicationService, dual_write_layer2
 
     async def fake_parse_document(
         self,
@@ -613,15 +620,28 @@ async def test_list_and_transactions_flow(db, monkeypatch, storage_stub, model_c
         db=None,
     ):
         statement = build_statement(test_user.id, source.content_hash, confidence_score=90)
-        transaction = AtomicTransaction(
+        txn_date = date(2025, 1, 2)
+        amount = Decimal("5000.00")
+        direction = TransactionDirection.IN
+        description = "Salary"
+        transaction = ExtractedTransactionRow(
             user_id=test_user.id,
-            txn_date=date(2025, 1, 2),
-            description="Salary",
-            amount=Decimal("5000.00"),
-            direction=TransactionDirection.IN,
+            txn_date=txn_date,
+            description=description,
+            amount=amount,
+            direction=direction.value,
+            reference=None,
             currency="SGD",
-            dedup_hash=uuid4().hex + uuid4().hex,
-            source_documents=[],
+            currency_unresolved=False,
+            balance_after=None,
+            occurrence_index=0,
+            dedup_hash=DeduplicationService.calculate_transaction_hash(
+                test_user.id,
+                txn_date,
+                amount,
+                direction,
+                description,
+            ),
         )
         # Persist via the single DWD linker so the statement resolves its Layer-2 facts.
         await dual_write_layer2(

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -28,7 +28,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from src.audit import STATEMENT_SOURCE_TYPES, JournalEntrySourceType
-from src.extraction import DocumentType, ExtractionError, UploadedDocument
+from src.extraction import DocumentSource, DocumentType, ExtractionError, ParseJob, UploadedDocument
 from src.extraction.extension import (
     statement_parsing as statement_parsing_mod,
     statement_pipeline,
@@ -272,19 +272,16 @@ async def test_upload_statement_duplicate(db, monkeypatch, storage_stub, model_c
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=90)
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=90)
         return statement, []
 
     monkeypatch.setattr(
@@ -416,8 +413,10 @@ async def test_upload_uses_default_ocr_pipeline_for_pdf(db, monkeypatch, storage
     await wait_for_background_tasks()
 
     assert created.status == BankStatementStatus.PARSING
-    assert mock_parse.await_args.kwargs["model"] is None
-    storage_key = mock_parse.await_args.kwargs["storage_key"]
+    job = mock_parse.await_args.kwargs["job"]
+    assert isinstance(job, ParseJob)
+    assert job.model is None
+    storage_key = job.storage_key
     assert storage_key.startswith(f"statements/{created.id}/")
     assert "statement.pdf" not in storage_key
     assert str(test_user.id) not in storage_key
@@ -474,7 +473,9 @@ async def test_AC10_8_1_upload_audit_logs_include_statement_input_provenance(
     assert enqueued["request_id"] == accepted["request_id"]
     assert enqueued["statement_id"] == str(created.id)
     assert enqueued["model_to_use"] == "google/gemini-3-flash-preview"
-    assert mock_parse.await_args.kwargs["statement_id"] == created.id
+    job = mock_parse.await_args.kwargs["job"]
+    assert isinstance(job, ParseJob)
+    assert job.statement_id == created.id
 
 
 async def test_AC10_8_1_upload_storage_failure_logs_safe_audit_context(db, monkeypatch, model_catalog_stub, test_user):
@@ -602,19 +603,16 @@ async def test_list_and_transactions_flow(db, monkeypatch, storage_stub, model_c
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=90)
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=90)
         transaction = AtomicTransaction(
             user_id=test_user.id,
             txn_date=date(2025, 1, 2),
@@ -631,7 +629,7 @@ async def test_list_and_transactions_flow(db, monkeypatch, storage_stub, model_c
             test_user.id,
             statement,
             [transaction],
-            original_filename=original_filename,
+            original_filename=source.filename,
         )
         return statement, [transaction]
 
@@ -689,23 +687,20 @@ async def test_pending_review_and_decisions(db, monkeypatch, storage_stub, model
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        score = score_by_hash[file_hash or ""]
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=score)
+        score = score_by_hash[source.content_hash]
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=score)
         statement.account_id = account_id
         statement.closing_balance = Decimal("100.00")
-        await dual_write_layer2(db, test_user.id, statement, [], original_filename=original_filename)
+        await dual_write_layer2(db, test_user.id, statement, [], original_filename=source.filename)
         return statement, []
 
     monkeypatch.setattr(
@@ -780,10 +775,12 @@ async def test_stage1_reject_triggers_reparse(db, monkeypatch, storage_stub, tes
 
     assert response.status == BankStatementStatus.REJECTED
     assert response.validation_error == "Needs re-parse"
-    assert queued["statement_id"] == statement.id
-    assert queued["filename"] == document.original_filename
-    assert queued["user_id"] == test_user.id
-    assert queued["storage_key"] == document.file_path
+    queued_job = queued["job"]
+    assert isinstance(queued_job, ParseJob)
+    assert queued_job.statement_id == statement.id
+    assert queued_job.filename == document.original_filename
+    assert queued_job.user_id == test_user.id
+    assert queued_job.storage_key == document.file_path
     assert queued["content"] == b"dummy content"
 
 
@@ -842,15 +839,12 @@ async def test_upload_extraction_failure(db, monkeypatch, model_catalog_stub, te
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
@@ -962,19 +956,16 @@ async def test_retry_statement_invalid_status(db, monkeypatch, storage_stub, mod
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=90)
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=90)
         statement.status = BankStatementStatus.PARSING
         return statement, []
 
@@ -1121,22 +1112,19 @@ async def test_retry_statement_success(db, monkeypatch, storage_stub, model_cata
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=95)
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=95)
         statement.status = BankStatementStatus.REJECTED
         statement.confidence_score = 60
-        await dual_write_layer2(db, test_user.id, statement, [], original_filename=original_filename)
+        await dual_write_layer2(db, test_user.id, statement, [], original_filename=source.filename)
         return statement, []
 
     monkeypatch.setattr(
@@ -1188,21 +1176,18 @@ async def test_retry_statement_extraction_failure(db, monkeypatch, storage_stub,
 
     async def fake_parse_document(
         self,
-        file_path,
+        source: DocumentSource,
         institution,
+        *,
         user_id,
         file_type="pdf",
         account_id=None,
-        file_content=None,
-        file_hash=None,
-        file_url=None,
-        original_filename=None,
         force_model=None,
         db=None,
     ):
-        statement = build_statement(test_user.id, file_hash or "", confidence_score=90)
+        statement = build_statement(test_user.id, source.content_hash, confidence_score=90)
         statement.status = BankStatementStatus.REJECTED
-        await dual_write_layer2(db, test_user.id, statement, [], original_filename=original_filename)
+        await dual_write_layer2(db, test_user.id, statement, [], original_filename=source.filename)
         return statement, []
 
     monkeypatch.setattr(

--- a/apps/backend/tests/extraction/test_account_last4_defense.py
+++ b/apps/backend/tests/extraction/test_account_last4_defense.py
@@ -26,6 +26,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.extraction import ParseJob
 from src.extraction.extension.service import ExtractionService
 from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
@@ -303,15 +304,17 @@ class TestBackgroundTaskDirtyData:
         monkeypatch.setattr("fastapi.concurrency.run_in_threadpool", mock_run_in_threadpool)
 
         await parse_statement_background(
-            statement_id=sid,
-            filename="test.pdf",
-            institution="DBS",
-            user_id=uid,
-            account_id=account.id,
-            file_hash=f"bg_dirty_{uuid4().hex[:8]}",
-            storage_key="test_path",
+            job=ParseJob(
+                statement_id=sid,
+                filename="test.pdf",
+                institution="DBS",
+                user_id=uid,
+                account_id=account.id,
+                file_hash=f"bg_dirty_{uuid4().hex[:8]}",
+                storage_key="test_path",
+                model=None,
+            ),
             content=b"dummy content",
-            model=None,
             session_maker=create_session_maker_from_db(db),
         )
 
@@ -450,10 +453,11 @@ class TestCascadingFailureRecovery:
 
         handler_called_with: dict | None = None
 
-        async def spy_handler(statement, db_session, *, message):
+        async def spy_handler(statement, db_session, **failure_context):
             nonlocal handler_called_with
+            message = failure_context["message"]
             handler_called_with = {"statement_id": statement.id, "message": message}
-            return await handle_parse_failure(statement, db_session, message=message)
+            return await handle_parse_failure(statement, db_session, **failure_context)
 
         monkeypatch.setattr("src.extraction.extension.statement_parsing.handle_parse_failure", spy_handler)
 
@@ -506,15 +510,17 @@ class TestCascadingFailureRecovery:
 
         try:
             await parse_statement_background(
-                statement_id=sid,
-                filename="test.pdf",
-                institution="DBS",
-                user_id=uid,
-                account_id=account.id,
-                file_hash=f"commit_fail_{uuid4().hex[:8]}",
-                storage_key="test_path",
+                job=ParseJob(
+                    statement_id=sid,
+                    filename="test.pdf",
+                    institution="DBS",
+                    user_id=uid,
+                    account_id=account.id,
+                    file_hash=f"commit_fail_{uuid4().hex[:8]}",
+                    storage_key="test_path",
+                    model=None,
+                ),
                 content=b"dummy content",
-                model=None,
                 session_maker=create_session_maker_from_db(db),
             )
         except Exception:

--- a/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
+++ b/apps/backend/tests/extraction/test_brokerage_position_extraction_wiring.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 from sqlalchemy import select
 
 from src.database import create_session_maker_from_db
-from src.extraction import DocumentType, UploadedDocument
+from src.extraction import DocumentType, ParseJob, UploadedDocument
 from src.extraction.extension.brokerage_positions import (
     BrokeragePositionImportService,
     brokerage_currency_balances,
@@ -291,15 +291,17 @@ async def test_AC_B4_AC_B6_moomoo_positions_table_extracts_and_imports(client, d
     )
 
     await parse_statement_background(
-        statement_id=statement_id,
-        filename="moomoo-positions-2506.pdf",
-        institution="Moomoo",
-        user_id=user_id,
-        account_id=None,
-        file_hash=file_hash,
-        storage_key="statements/moomoo-positions.pdf",
+        job=ParseJob(
+            statement_id=statement_id,
+            filename="moomoo-positions-2506.pdf",
+            institution="Moomoo",
+            user_id=user_id,
+            account_id=None,
+            file_hash=file_hash,
+            storage_key="statements/moomoo-positions.pdf",
+            model=None,
+        ),
         content=b"%PDF-1.7",
-        model=None,
         session_maker=create_session_maker_from_db(db),
     )
 

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import select
 
-from src.extraction import DocumentStatus, DocumentType, UploadedDocument
+from src.extraction import DocumentStatus, DocumentType, ExtractedTransactionRow, UploadedDocument
+from src.extraction.extension.deduplication import DeduplicationService
 from src.extraction.extension.service import ExtractionService
 from src.extraction.orm.layer2 import AtomicTransaction, TransactionDirection
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
@@ -375,7 +376,7 @@ class TestDualWriteLayer2:
         from sqlalchemy.exc import IntegrityError
 
         from src.extraction.extension.deduplication import dual_write_layer2
-        from tests.factories import AtomicTransactionFactory, StatementSummaryFactory
+        from tests.factories import StatementSummaryFactory
 
         file_hash = hashlib.sha256(sample_file_content).hexdigest()
 
@@ -390,14 +391,30 @@ class TestDualWriteLayer2:
             opening_balance=Decimal("1000.00"),
             closing_balance=Decimal("1500.00"),
         )
-        txn = AtomicTransactionFactory.build(
+        txn_date = date(2024, 1, 15)
+        amount = Decimal("3000.00")
+        direction = TransactionDirection.IN
+        description = "Salary Deposit"
+        reference = "SAL001"
+        txn = ExtractedTransactionRow(
             user_id=test_user.id,
-            txn_date=date(2024, 1, 15),
-            description="Salary Deposit",
-            amount=Decimal("3000.00"),
-            direction=TransactionDirection.IN,
-            reference="SAL001",
-            source_documents=[],
+            txn_date=txn_date,
+            description=description,
+            amount=amount,
+            direction=direction.value,
+            reference=reference,
+            currency="SGD",
+            currency_unresolved=False,
+            balance_after=None,
+            occurrence_index=0,
+            dedup_hash=DeduplicationService.calculate_transaction_hash(
+                test_user.id,
+                txn_date,
+                amount,
+                direction,
+                description,
+                reference,
+            ),
         )
         transactions = [txn]
 

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from src.extraction import DocumentStatus, UploadedDocument
+from src.extraction import DocumentStatus, ParseJob, UploadedDocument
 from src.extraction.extension.deduplication import dual_write_layer2
 from src.extraction.extension.service import ExtractionError, ExtractionService
 from src.extraction.extension.statement_parsing import handle_parse_failure
@@ -34,10 +34,17 @@ async def test_handle_parse_failure_persists_failed_document_lineage(db, test_us
     await handle_parse_failure(
         statement,
         db,
+        job=ParseJob(
+            statement_id=statement.id,
+            filename="futu-2506.pdf",
+            institution=statement.institution,
+            user_id=test_user.id,
+            account_id=statement.account_id,
+            file_hash=statement.file_hash,
+            storage_key=f"statements/{statement.id}/abc123.pdf",
+            model=None,
+        ),
         message="All 1 models failed. Breakdown: 1 json_parse.",
-        file_hash=statement.file_hash,
-        storage_key=f"statements/{statement.id}/abc123.pdf",
-        original_filename="futu-2506.pdf",
     )
 
     doc = (
@@ -728,15 +735,17 @@ async def test_parse_statement_background_storage_error(db, test_user, monkeypat
     monkeypatch.setattr("src.extraction.extension.service.ExtractionService.parse_document", mock_parse)
 
     await parse_statement_background(
-        statement_id=sid,
-        filename="f.pdf",
-        institution="DBS",
-        user_id=uid,
-        account_id=None,
-        file_hash="h_storage_err",
-        storage_key="p",
+        job=ParseJob(
+            statement_id=sid,
+            filename="f.pdf",
+            institution="DBS",
+            user_id=uid,
+            account_id=None,
+            file_hash="h_storage_err",
+            storage_key="p",
+            model=None,
+        ),
         content=b"content",
-        model=None,
         session_maker=create_session_maker_from_db(db),
     )
 

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -9,8 +9,14 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from src.extraction import DocumentStatus, ParseJob, UploadedDocument
-from src.extraction.extension.deduplication import dual_write_layer2
+from src.extraction import (
+    DocumentStatus,
+    ExtractedTransactionRow,
+    ParseJob,
+    TransactionDirection,
+    UploadedDocument,
+)
+from src.extraction.extension.deduplication import DeduplicationService, dual_write_layer2
 from src.extraction.extension.service import ExtractionError, ExtractionService
 from src.extraction.extension.statement_parsing import handle_parse_failure
 from src.extraction.orm.statement_enums import BankStatementStatus
@@ -1388,22 +1394,39 @@ async def test_dual_write_layer2_integrity_error_is_non_fatal():
         mock_dedup = mock_dedup_cls.return_value
         mock_dedup.create_uploaded_document.side_effect = IntegrityError("x", {}, Exception("dup"))
 
-        txn = MagicMock()
-        txn.direction = "IN"
-        txn.txn_date = date(2025, 1, 1)
-        txn.amount = Decimal("1.00")
-        txn.description = "txn"
-        txn.reference = None
-        txn.currency = "SGD"
+        user_id = uuid4()
+        txn_date = date(2025, 1, 1)
+        amount = Decimal("1.00")
+        direction = TransactionDirection.IN
+        description = "txn"
+        txn = ExtractedTransactionRow(
+            user_id=user_id,
+            txn_date=txn_date,
+            amount=amount,
+            direction=direction.value,
+            description=description,
+            reference=None,
+            currency="SGD",
+            currency_unresolved=False,
+            balance_after=None,
+            occurrence_index=0,
+            dedup_hash=DeduplicationService.calculate_transaction_hash(
+                user_id,
+                txn_date,
+                amount,
+                direction,
+                description,
+            ),
+        )
         statement = StatementSummaryFactory.build(
-            user_id=uuid4(),
+            user_id=user_id,
             file_hash="abc123",
             institution="DBS",
             currency="SGD",
         )
         await dual_write_layer2(
             db=db,
-            user_id=uuid4(),
+            user_id=user_id,
             statement=statement,
             transactions=[txn],
             file_path=Path("statement.pdf"),

--- a/apps/backend/tests/extraction/test_parse_failure_redaction.py
+++ b/apps/backend/tests/extraction/test_parse_failure_redaction.py
@@ -6,6 +6,7 @@ and the failure-log fields, so an exception message quoting statement content
 (emails, account numbers) never lands raw.
 """
 
+from src.extraction import ParseJob
 from src.extraction.extension.statement_parsing import handle_parse_failure
 from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
@@ -28,8 +29,17 @@ async def test_AC_safe_error_ssot_2_handle_parse_failure_redacts_pii(db, test_us
     await handle_parse_failure(
         summary,
         db,
+        job=ParseJob(
+            statement_id=summary.id,
+            filename=doc.original_filename,
+            institution=summary.institution,
+            user_id=test_user.id,
+            account_id=summary.account_id,
+            file_hash=summary.file_hash,
+            storage_key=doc.file_path,
+            model=None,
+        ),
         message=PII_MESSAGE,
-        statement_id=summary.id,
         error_type="ValueError",
     )
 

--- a/apps/backend/tests/extraction/test_parse_user_deletion_lifecycle.py
+++ b/apps/backend/tests/extraction/test_parse_user_deletion_lifecycle.py
@@ -23,7 +23,7 @@ import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.exc import PendingRollbackError
 
-from src.extraction import UploadedDocument
+from src.extraction import ParseJob, UploadedDocument
 from src.extraction.extension.statement_parsing import _ensure_failed_document_lineage, handle_parse_failure
 from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
@@ -115,8 +115,17 @@ async def test_AC13_23_3_failure_handler_rolls_back_before_reading_orm(db, test_
         await handle_parse_failure(
             _PoisonedStatement(),
             db,
+            job=ParseJob(
+                statement_id=real_id,
+                filename="statement.pdf",
+                institution=statement.institution,
+                user_id=statement.user_id,
+                account_id=statement.account_id,
+                file_hash=statement.file_hash,
+                storage_key=f"statements/{real_id}/statement.pdf",
+                model=None,
+            ),
             message="Finalize failed: original boom",
-            statement_id=real_id,
         )
 
     assert order == ["rollback"]

--- a/apps/backend/tests/extraction/test_signature_seams.py
+++ b/apps/backend/tests/extraction/test_signature_seams.py
@@ -18,6 +18,7 @@ from src.extraction import DocumentSource, ExtractedTransactionRow, ParseJob
 from src.extraction.extension import statement_parsing, statement_pipeline
 from src.extraction.extension.deduplication import DeduplicationService, dual_write_layer2
 from src.extraction.extension.service import ExtractionService
+from src.extraction.orm.statement_summary import StatementSummary
 
 pytestmark = pytest.mark.no_db
 
@@ -72,7 +73,7 @@ def test_AC_extraction_signature_seams_1_parse_job_round_trips_prefect_params() 
         job.filename = "mutated.pdf"  # type: ignore[misc]
 
 
-def test_AC_extraction_signature_seams_2_document_source_resolves_once() -> None:
+async def test_AC_extraction_signature_seams_2_document_source_resolves_once() -> None:
     """AC-extraction.signature-seams.2: all source aliases resolve into one immutable value."""
     source = DocumentSource.resolve(
         path=Path("statements/storage-key.pdf"),
@@ -89,6 +90,25 @@ def test_AC_extraction_signature_seams_2_document_source_resolves_once() -> None
     assert source.filename == "January statement.pdf"
     with pytest.raises(FrozenInstanceError):
         source.filename = "mutated.pdf"  # type: ignore[misc]
+
+    service = ExtractionService()
+    service._extract_vision_source = AsyncMock(return_value=_valid_payload())
+    await service.parse_document(
+        file_path=None,
+        institution="DBS",
+        user_id=uuid4(),
+        file_content=b"in-memory-pdf",
+        file_hash="b" * 64,
+        original_filename="memory.pdf",
+    )
+    compatibility_source = service._extract_vision_source.await_args.args[0]
+    assert compatibility_source == DocumentSource(
+        path=Path("memory.pdf"),
+        content=b"in-memory-pdf",
+        url=None,
+        content_hash="b" * 64,
+        filename="memory.pdf",
+    )
 
 
 async def test_AC_extraction_signature_seams_3_csv_and_vision_paths_are_separate() -> None:
@@ -190,3 +210,21 @@ async def test_AC_extraction_signature_seams_4_typed_rows_and_failure_contract()
         }
         & failure_params.keys()
     )
+
+
+async def test_dual_write_rejects_non_dto_rows_before_database_work() -> None:
+    """The typed persistence seam must not guess fields missing from ORM rows."""
+    user_id = uuid4()
+    statement = StatementSummary(
+        user_id=user_id,
+        file_hash="typed-seam",
+        institution="DBS",
+    )
+
+    with pytest.raises(TypeError, match="requires ExtractedTransactionRow"):
+        await dual_write_layer2(
+            db=AsyncMock(spec=AsyncSession),
+            user_id=user_id,
+            statement=statement,
+            transactions=[object()],  # type: ignore[list-item]
+        )

--- a/apps/backend/tests/extraction/test_signature_seams.py
+++ b/apps/backend/tests/extraction/test_signature_seams.py
@@ -1,0 +1,192 @@
+"""Contract tests for issue #1866's extraction signature seams."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date
+from decimal import Decimal
+from inspect import Parameter, getsource, signature
+from pathlib import Path
+from typing import get_type_hints
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.extraction import DocumentSource, ExtractedTransactionRow, ParseJob
+from src.extraction.extension import statement_parsing, statement_pipeline
+from src.extraction.extension.deduplication import DeduplicationService, dual_write_layer2
+from src.extraction.extension.service import ExtractionService
+
+pytestmark = pytest.mark.no_db
+
+
+def _parse_job() -> ParseJob:
+    return ParseJob(
+        statement_id=uuid4(),
+        filename="statement.pdf",
+        institution="DBS",
+        user_id=uuid4(),
+        account_id=uuid4(),
+        file_hash="a" * 64,
+        storage_key="statements/source.pdf",
+        model="vision-model",
+        request_id="request-1",
+    )
+
+
+def _valid_payload() -> dict[str, object]:
+    return {
+        "institution": "DBS",
+        "account_last4": "1234",
+        "currency": "SGD",
+        "period_start": "2026-01-01",
+        "period_end": "2026-01-31",
+        "opening_balance": "0.00",
+        "closing_balance": "0.00",
+        "transactions": [],
+    }
+
+
+def test_AC_extraction_signature_seams_1_parse_job_round_trips_prefect_params() -> None:
+    """AC-extraction.signature-seams.1: ParseJob owns the serializable worker contract."""
+    job = _parse_job()
+
+    prefect_params = job.to_prefect_params()
+
+    assert ParseJob.from_prefect_params(prefect_params) == job
+    assert set(prefect_params) == {
+        "statement_id",
+        "filename",
+        "institution",
+        "user_id",
+        "account_id",
+        "file_hash",
+        "storage_key",
+        "model",
+        "request_id",
+    }
+    assert all(value is None or isinstance(value, str) for value in prefect_params.values())
+    with pytest.raises(FrozenInstanceError):
+        job.filename = "mutated.pdf"  # type: ignore[misc]
+
+
+def test_AC_extraction_signature_seams_2_document_source_resolves_once() -> None:
+    """AC-extraction.signature-seams.2: all source aliases resolve into one immutable value."""
+    source = DocumentSource.resolve(
+        path=Path("statements/storage-key.pdf"),
+        content=b"statement-bytes",
+        url="https://storage.example/source.pdf",
+        content_hash=None,
+        filename="January statement.pdf",
+    )
+
+    assert source.path == Path("statements/storage-key.pdf")
+    assert source.content == b"statement-bytes"
+    assert source.url == "https://storage.example/source.pdf"
+    assert source.content_hash == "84c100c63b19e58806ef5d6b164adc8c8f9e94808a4261415982b1948d0f0e11"
+    assert source.filename == "January statement.pdf"
+    with pytest.raises(FrozenInstanceError):
+        source.filename = "mutated.pdf"  # type: ignore[misc]
+
+
+async def test_AC_extraction_signature_seams_3_csv_and_vision_paths_are_separate() -> None:
+    """AC-extraction.signature-seams.3: parse_document dispatches to explicit source paths."""
+    service = ExtractionService()
+    payload = _valid_payload()
+    service._extract_csv_source = AsyncMock(return_value=payload)
+    service._extract_vision_source = AsyncMock(return_value=payload)
+
+    csv_source = DocumentSource.resolve(path=Path("statement.csv"), content=b"csv")
+    await service.parse_document(
+        csv_source,
+        institution="DBS",
+        user_id=uuid4(),
+        file_type="csv",
+    )
+    service._extract_csv_source.assert_awaited_once_with(csv_source, institution="DBS")
+    service._extract_vision_source.assert_not_awaited()
+
+    service._extract_csv_source.reset_mock()
+    vision_source = DocumentSource.resolve(path=Path("statement.pdf"), content=b"pdf")
+    await service.parse_document(
+        vision_source,
+        institution="DBS",
+        user_id=uuid4(),
+        file_type="pdf",
+    )
+    service._extract_vision_source.assert_awaited_once()
+    service._extract_csv_source.assert_not_awaited()
+
+
+async def test_AC_extraction_signature_seams_4_typed_rows_and_failure_contract() -> None:
+    """AC-extraction.signature-seams.4: typed rows replace ORM stowaways at the DB seam."""
+    service = ExtractionService()
+    payload = _valid_payload()
+    payload["closing_balance"] = "10.00"
+    payload["transactions"] = [
+        {
+            "date": "2026-01-05",
+            "amount": "10.00",
+            "direction": "IN",
+            "description": "Deposit",
+            "currency": "SGD",
+            "balance_after": "10.00",
+        }
+    ]
+    service._extract_csv_source = AsyncMock(return_value=payload)
+
+    _, rows = await service.parse_document(
+        DocumentSource.resolve(path=Path("statement.csv"), content=b"csv"),
+        institution="DBS",
+        user_id=uuid4(),
+        file_type="csv",
+    )
+
+    assert rows == [
+        ExtractedTransactionRow(
+            user_id=rows[0].user_id,
+            txn_date=date(2026, 1, 5),
+            amount=Decimal("10.00"),
+            direction=rows[0].direction,
+            description="Deposit",
+            reference=None,
+            currency="SGD",
+            currency_unresolved=False,
+            balance_after=Decimal("10.00"),
+            occurrence_index=0,
+            dedup_hash=rows[0].dedup_hash,
+        )
+    ]
+    assert get_type_hints(dual_write_layer2)["db"] is AsyncSession
+    assert get_type_hints(ExtractionService.parse_document)["db"] == AsyncSession | None
+    assert "_extracted_balance_after" not in getsource(dual_write_layer2)
+    assert "_occurrence_index" not in getsource(dual_write_layer2)
+    assert "_currency_unresolved" not in getsource(dual_write_layer2)
+    assert "signature(" not in getsource(statement_parsing)
+    parse_params = signature(ExtractionService.parse_document).parameters
+    assert parse_params["source"].kind is Parameter.POSITIONAL_OR_KEYWORD
+    assert all(
+        parse_params[name].kind is Parameter.KEYWORD_ONLY
+        for name in ("user_id", "file_type", "account_id", "force_model", "db")
+    )
+    upsert_params = signature(DeduplicationService.upsert_atomic_transaction).parameters
+    assert all(
+        upsert_params[name].kind is Parameter.KEYWORD_ONLY for name in ("db", "row", "source_doc_id", "source_doc_type")
+    )
+    pipeline_params = signature(statement_pipeline.submit_parse_pipeline).parameters
+    assert all(parameter.kind is Parameter.KEYWORD_ONLY for parameter in pipeline_params.values())
+    failure_params = signature(statement_parsing.handle_parse_failure).parameters
+    assert len(failure_params) <= 8
+    assert "job" in failure_params
+    assert (
+        not {
+            "request_id",
+            "statement_id",
+            "file_hash",
+            "storage_key",
+            "original_filename",
+        }
+        & failure_params.keys()
+    )

--- a/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
+++ b/apps/backend/tests/extraction/test_statement_brokerage_import_bridge.py
@@ -9,13 +9,12 @@ from uuid import uuid4
 from sqlalchemy import select
 
 from src.database import create_session_maker_from_db
-from src.extraction import DocumentType, UploadedDocument
+from src.extraction import DocumentType, ParseJob, UploadedDocument
 from src.extraction.extension import statement_parsing
 from src.extraction.extension.brokerage_positions import looks_like_brokerage_payload, parse_brokerage_positions
 from src.extraction.extension.service import ExtractionService
 from src.extraction.extension.statement_parsing import (
     _count_brokerage_positions,
-    _filter_failure_handler_kwargs,
     parse_statement_background,
     route_brokerage_for_review_if_present,
 )
@@ -110,42 +109,6 @@ def test_count_brokerage_positions_handles_empty_and_nested_payloads():
     assert _count_brokerage_positions({"statement": {"positions": [{}, {}, {}]}}) == 3
     assert _count_brokerage_positions({}) is None
     assert _count_brokerage_positions({"statement": {"holdings": "unstructured"}}) is None
-
-
-def test_filter_failure_handler_kwargs_returns_original_when_signature_unavailable(monkeypatch):
-    """AC-extraction.304.7: Parse failure compatibility shim tolerates opaque handlers."""
-    payload = {"message": "parse failed", "future_arg": "preserved"}
-
-    def raise_value_error(_callable):
-        raise ValueError("opaque callable")
-
-    monkeypatch.setattr(statement_parsing, "signature", raise_value_error)
-
-    assert _filter_failure_handler_kwargs(payload) is payload
-
-
-def test_filter_failure_handler_kwargs_keeps_payload_for_var_keyword_handler(monkeypatch):
-    """AC-extraction.304.7: Parse failure compatibility shim preserves kwargs-capable handlers."""
-    payload = {"message": "parse failed", "future_arg": "preserved"}
-
-    async def accepts_kwargs(*_args, **_kwargs):
-        return None
-
-    monkeypatch.setattr(statement_parsing, "handle_parse_failure", accepts_kwargs)
-
-    assert _filter_failure_handler_kwargs(payload) is payload
-
-
-def test_filter_failure_handler_kwargs_drops_unknown_keys_for_fixed_handler(monkeypatch):
-    """AC-extraction.304.7: Parse failure compatibility shim filters unknown kwargs."""
-    payload = {"message": "parse failed", "future_arg": "dropped"}
-
-    async def fixed_handler(_statement, _db, *, message):
-        return message
-
-    monkeypatch.setattr(statement_parsing, "handle_parse_failure", fixed_handler)
-
-    assert _filter_failure_handler_kwargs(payload) == {"message": "parse failed"}
 
 
 def test_parse_brokerage_positions_skips_malformed_moomoo_subscription_row():
@@ -533,15 +496,17 @@ async def test_parse_statement_background_imports_brokerage_positions(client, db
     )
 
     await parse_statement_background(
-        statement_id=statement_id,
-        filename="moomoo-positions.pdf",
-        institution="Moomoo",
-        user_id=user_id,
-        account_id=None,
-        file_hash=file_hash,
-        storage_key="statements/moomoo.pdf",
+        job=ParseJob(
+            statement_id=statement_id,
+            filename="moomoo-positions.pdf",
+            institution="Moomoo",
+            user_id=user_id,
+            account_id=None,
+            file_hash=file_hash,
+            storage_key="statements/moomoo.pdf",
+            model=None,
+        ),
         content=b"%PDF-1.7",
-        model=None,
         session_maker=create_session_maker_from_db(db),
     )
 
@@ -643,15 +608,17 @@ async def test_parse_statement_background_routes_brokerage_to_review_without_imp
     )
 
     await parse_statement_background(
-        statement_id=statement_id,
-        filename="moomoo-review.pdf",
-        institution="Moomoo",
-        user_id=user_id,
-        account_id=None,
-        file_hash=file_hash,
-        storage_key="statements/moomoo-review.pdf",
+        job=ParseJob(
+            statement_id=statement_id,
+            filename="moomoo-review.pdf",
+            institution="Moomoo",
+            user_id=user_id,
+            account_id=None,
+            file_hash=file_hash,
+            storage_key="statements/moomoo-review.pdf",
+            model=None,
+        ),
         content=b"%PDF-1.7",
-        model=None,
         session_maker=create_session_maker_from_db(db),
     )
 

--- a/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
+++ b/apps/backend/tests/extraction/test_statement_parsing_audit_logging.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from src.database import create_session_maker_from_db
+from src.extraction import ParseJob
 from src.extraction.extension import statement_parsing
 from src.extraction.extension.service import ExtractionError
 from src.extraction.extension.statement_parsing import parse_statement_background, route_brokerage_for_review_if_present
@@ -70,17 +71,19 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     )
 
     await parse_statement_background(
-        statement_id=success.id,
-        filename="audit.pdf",
-        institution="DBS",
-        user_id=user_id,
-        account_id=None,
-        file_hash="success-hash",
-        storage_key="statements/audit.pdf",
+        job=ParseJob(
+            statement_id=success.id,
+            filename="audit.pdf",
+            institution="DBS",
+            user_id=user_id,
+            account_id=None,
+            file_hash="success-hash",
+            storage_key="statements/audit.pdf",
+            model="glm-5.1",
+            request_id="req-success",
+        ),
         content=b"%PDF-1.7",
-        model="glm-5.1",
         session_maker=create_session_maker_from_db(db),
-        request_id="req-success",
     )
 
     info_calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
@@ -117,17 +120,19 @@ async def test_AC10_8_2_parse_checkpoints_and_failure_logs_are_structured(db, te
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", fail_parse_document)
 
     await parse_statement_background(
-        statement_id=failure.id,
-        filename="audit.pdf",
-        institution="DBS",
-        user_id=user_id,
-        account_id=None,
-        file_hash="failure-hash",
-        storage_key="statements/audit.pdf",
+        job=ParseJob(
+            statement_id=failure.id,
+            filename="audit.pdf",
+            institution="DBS",
+            user_id=user_id,
+            account_id=None,
+            file_hash="failure-hash",
+            storage_key="statements/audit.pdf",
+            model="glm-5.1",
+            request_id="req-failure",
+        ),
         content=b"%PDF-1.7 secret source bytes",
-        model="glm-5.1",
         session_maker=create_session_maker_from_db(db),
-        request_id="req-failure",
     )
 
     failed = next(call.kwargs for call in mock_warning.call_args_list if call.args[0] == "statement.parse.failed")
@@ -180,17 +185,19 @@ async def test_AC_observability_11_4_expected_parse_failure_never_logs_at_error(
     )
 
     await parse_statement_background(
-        statement_id=statement.id,
-        filename="contract.pdf",
-        institution="DBS",
-        user_id=user_id,
-        account_id=None,
-        file_hash="contract-hash",
-        storage_key="statements/contract.pdf",
+        job=ParseJob(
+            statement_id=statement.id,
+            filename="contract.pdf",
+            institution="DBS",
+            user_id=user_id,
+            account_id=None,
+            file_hash="contract-hash",
+            storage_key="statements/contract.pdf",
+            model="glm-5.1",
+            request_id="req-contract",
+        ),
         content=b"%PDF-1.7",
-        model="glm-5.1",
         session_maker=create_session_maker_from_db(db),
-        request_id="req-contract",
     )
 
     mock_error.assert_not_called()
@@ -318,17 +325,19 @@ async def test_AC10_10_4_parse_outcome_metric_emitted(db, test_user, monkeypatch
 
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", ok_parse_document)
     await parse_statement_background(
-        statement_id=success.id,
-        filename="audit.pdf",
-        institution="DBS",
-        user_id=user_id,
-        account_id=None,
-        file_hash="metric-success",
-        storage_key="statements/audit.pdf",
+        job=ParseJob(
+            statement_id=success.id,
+            filename="audit.pdf",
+            institution="DBS",
+            user_id=user_id,
+            account_id=None,
+            file_hash="metric-success",
+            storage_key="statements/audit.pdf",
+            model="glm-5.1",
+            request_id="req-metric-ok",
+        ),
         content=b"%PDF-1.7",
-        model="glm-5.1",
         session_maker=create_session_maker_from_db(db),
-        request_id="req-metric-ok",
     )
 
     failure = await _create_statement(db, user_id, file_hash="metric-failure")
@@ -338,17 +347,19 @@ async def test_AC10_10_4_parse_outcome_metric_emitted(db, test_user, monkeypatch
 
     monkeypatch.setattr(statement_parsing.ExtractionService, "parse_document", bad_parse_document)
     await parse_statement_background(
-        statement_id=failure.id,
-        filename="audit.pdf",
-        institution="DBS",
-        user_id=user_id,
-        account_id=None,
-        file_hash="metric-failure",
-        storage_key="statements/audit.pdf",
+        job=ParseJob(
+            statement_id=failure.id,
+            filename="audit.pdf",
+            institution="DBS",
+            user_id=user_id,
+            account_id=None,
+            file_hash="metric-failure",
+            storage_key="statements/audit.pdf",
+            model="glm-5.1",
+            request_id="req-metric-fail",
+        ),
         content=b"%PDF-1.7",
-        model="glm-5.1",
         session_maker=create_session_maker_from_db(db),
-        request_id="req-metric-fail",
     )
 
     assert outcomes == ["success", "failure"]

--- a/apps/backend/tests/extraction/test_statements_supervisor_errors.py
+++ b/apps/backend/tests/extraction/test_statements_supervisor_errors.py
@@ -13,6 +13,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from src.database import create_session_maker_from_db
+from src.extraction import ParseJob
 from src.extraction.extension.statement_parsing import parse_statement_background
 from src.extraction.extension.statement_parsing_supervisor import (
     run_parsing_supervisor,
@@ -176,15 +177,17 @@ async def test_statement_router_error_cases(db, test_user, monkeypatch):
     # Background parsing not found
     session_maker = create_session_maker_from_db(db)
     await parse_statement_background(
-        statement_id=uuid4(),
-        filename="f",
-        institution="i",
-        user_id=uid,
-        account_id=None,
-        file_hash="h",
-        storage_key="k",
+        job=ParseJob(
+            statement_id=uuid4(),
+            filename="f",
+            institution="i",
+            user_id=uid,
+            account_id=None,
+            file_hash="h",
+            storage_key="k",
+            model=None,
+        ),
         content=b"",
-        model=None,
         session_maker=session_maker,
     )
 
@@ -247,15 +250,17 @@ async def test_parse_statement_background_error_paths(db, test_user, monkeypatch
         mock_storage.generate_presigned_url.side_effect = StorageError("S3 Fail")
 
         await parse_statement_background(
-            statement_id=sid,
-            filename="f",
-            institution="i",
-            user_id=uid,
-            account_id=None,
-            file_hash="h2",
-            storage_key="k",
+            job=ParseJob(
+                statement_id=sid,
+                filename="f",
+                institution="i",
+                user_id=uid,
+                account_id=None,
+                file_hash="h2",
+                storage_key="k",
+                model=None,
+            ),
             content=b"",
-            model=None,
             session_maker=session_maker,
         )
 
@@ -276,15 +281,17 @@ async def test_parse_statement_background_error_paths(db, test_user, monkeypatch
         monkeypatch.setattr("src.extraction.extension.statement_parsing.ExtractionService.parse_document", mock_parse)
 
         await parse_statement_background(
-            statement_id=sid,
-            filename="f",
-            institution="i",
-            user_id=uid,
-            account_id=None,
-            file_hash="h2",
-            storage_key="k",
+            job=ParseJob(
+                statement_id=sid,
+                filename="f",
+                institution="i",
+                user_id=uid,
+                account_id=None,
+                file_hash="h2",
+                storage_key="k",
+                model=None,
+            ),
             content=b"",
-            model=None,
             session_maker=session_maker,
         )
 
@@ -303,15 +310,17 @@ async def test_parse_statement_background_error_paths(db, test_user, monkeypatch
         monkeypatch.setattr("src.extraction.extension.statement_parsing.ExtractionService.parse_document", mock_parse)
 
         await parse_statement_background(
-            statement_id=sid,
-            filename="f",
-            institution="i",
-            user_id=uid,
-            account_id=None,
-            file_hash="h2",
-            storage_key="k",
+            job=ParseJob(
+                statement_id=sid,
+                filename="f",
+                institution="i",
+                user_id=uid,
+                account_id=None,
+                file_hash="h2",
+                storage_key="k",
+                model=None,
+            ),
             content=b"",
-            model=None,
             session_maker=session_maker,
         )
 

--- a/apps/backend/tests/infra/test_telemetry_metrics.py
+++ b/apps/backend/tests/infra/test_telemetry_metrics.py
@@ -376,10 +376,10 @@ def test_AC10_12_2_async_parse_tracking_receives_statement_context() -> None:
         encoding="utf-8"
     )
 
-    assert "statement_id=statement_id" in pipeline
-    assert "request_id=request_id" in pipeline
-    assert "statement_id=statement_id" in flow
-    assert "request_id=request_id" in flow
+    assert "statement_id=job.statement_id" in pipeline
+    assert "request_id=job.request_id" in pipeline
+    assert "statement_id=parse_job.statement_id" in flow
+    assert "request_id=parse_job.request_id" in flow
 
 
 def test_AC10_12_3_parse_failure_state_and_log_contract_are_preserved() -> None:

--- a/apps/backend/tests/integration/test_statement_reject_cleans_up_orphan_account.py
+++ b/apps/backend/tests/integration/test_statement_reject_cleans_up_orphan_account.py
@@ -9,11 +9,13 @@ chart of accounts and the balance sheet, with nothing pointing at it.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 from sqlalchemy import select
 
+from src.extraction import DocumentSource
 from src.extraction.extension.service import ExtractionService
 from src.extraction.orm.statement_enums import BankStatementStatus
 from src.ledger import Account, AccountType
@@ -82,11 +84,13 @@ async def test_AC_extraction_1832_4_rejected_parse_deletes_the_account_it_just_c
     service.extract_financial_data = AsyncMock(return_value=_unreconciled_payload("DBS", "9911"))
 
     statement, _txns = await service.parse_document(
-        file_path=None,
+        DocumentSource.resolve(
+            path=Path("ac-1832-4a.pdf"),
+            content=b"%PDF-1.7",
+            content_hash="ac-1832-4a",
+        ),
         institution="DBS",
         user_id=test_user.id,
-        file_content=b"%PDF-1.7",
-        file_hash="ac-1832-4a",
         db=db,
     )
     await db.flush()
@@ -105,11 +109,13 @@ async def test_AC_extraction_1832_4_rejected_parse_never_deletes_a_preexisting_a
         return_value=_balanced_payload("GXS", "7174", "500.00", "600.00", "100.00")
     )
     first, _txns = await service.parse_document(
-        file_path=None,
+        DocumentSource.resolve(
+            path=Path("ac-1832-4b-first.pdf"),
+            content=b"%PDF-1.7",
+            content_hash="ac-1832-4b-first",
+        ),
         institution="GXS",
         user_id=test_user.id,
-        file_content=b"%PDF-1.7",
-        file_hash="ac-1832-4b-first",
         db=db,
     )
     await db.flush()
@@ -118,11 +124,13 @@ async def test_AC_extraction_1832_4_rejected_parse_never_deletes_a_preexisting_a
 
     service.extract_financial_data = AsyncMock(return_value=_unreconciled_payload("GXS", "7174"))
     second, _txns = await service.parse_document(
-        file_path=None,
+        DocumentSource.resolve(
+            path=Path("ac-1832-4b-second.pdf"),
+            content=b"%PDF-1.7",
+            content_hash="ac-1832-4b-second",
+        ),
         institution="GXS",
         user_id=test_user.id,
-        file_content=b"%PDF-1.7",
-        file_hash="ac-1832-4b-second",
         db=db,
     )
     await db.flush()
@@ -145,11 +153,13 @@ async def test_AC_extraction_1832_4_no_db_session_skips_account_lifecycle_entire
     service.extract_financial_data = AsyncMock(return_value=_unreconciled_payload("DBS", "4242"))
 
     statement, _txns = await service.parse_document(
-        file_path=None,
+        DocumentSource.resolve(
+            path=Path("ac-1832-4c.pdf"),
+            content=b"%PDF-1.7",
+            content_hash="ac-1832-4c",
+        ),
         institution="DBS",
         user_id=uuid4(),
-        file_content=b"%PDF-1.7",
-        file_hash="ac-1832-4c",
         db=None,
     )
 

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -155,6 +155,13 @@ CONTRACT = PackageContract(
         # is only metrics-logged; publishing via the platform outbox is the
         # planned upgrade — package-internal, not a re-cutover) ──
         Unit(name="BalanceChainViolated", kind=Kind.DOMAIN_EVENT),
+        Unit(name="DocumentSource", kind=Kind.VALUE_OBJECT, module="base/types.py"),
+        Unit(
+            name="ExtractedTransactionRow",
+            kind=Kind.VALUE_OBJECT,
+            module="base/types.py",
+        ),
+        Unit(name="ParseJob", kind=Kind.VALUE_OBJECT, module="base/types.py"),
     ],
     implementations={"be": "apps/backend/src/extraction", "fe": None},
     interface=[
@@ -170,6 +177,7 @@ CONTRACT = PackageContract(
         "CurrencyUnresolvedError",
         "DEFAULT_MAX_DEPTH",
         "DeduplicationService",
+        "DocumentSource",
         "DocumentStatus",
         "DocumentType",
         "EvidenceEdge",
@@ -180,12 +188,14 @@ CONTRACT = PackageContract(
         "EvidenceTraversalStep",
         "ExtractionError",
         "ExtractionService",
+        "ExtractedTransactionRow",
         "ManagedPosition",
         "ManualValuationBasis",
         "ManualValuationComponentType",
         "ManualValuationLiquidityClass",
         "ManualValuationSnapshot",
         "PositionStatus",
+        "ParseJob",
         "ReportSnapshot",
         "ReportType",
         "SYSTEM_PROMPT",
@@ -3946,6 +3956,73 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1832_4_rejected_parse_deletes_the_account_it_just_created"
             ),
             priority="P1",
+            status="done",
+            proof_kind="property",
+        ),
+        # ── issue #1866 PR-B: the extraction orchestration boundary carries
+        # cohesive typed values instead of repeating primitive parameter
+        # clusters or attaching transient persistence data to ORM instances. ──
+        ACRecord(
+            id="AC-extraction.signature-seams.1",
+            statement=(
+                "A single frozen ParseJob value object crosses the upload, "
+                "in-process worker, and Prefect boundaries; its explicit "
+                "to/from Prefect conversion round-trips UUIDs and contains no "
+                "bytes or database/session objects."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_signature_seams.py"
+                "::test_AC_extraction_signature_seams_1_parse_job_round_trips_prefect_params"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.signature-seams.2",
+            statement=(
+                "DocumentSource resolves the document path, content, URL, "
+                "content hash, and display filename once before parsing; CSV "
+                "and vision extraction then consume that immutable source."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_signature_seams.py"
+                "::test_AC_extraction_signature_seams_2_document_source_resolves_once"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.signature-seams.3",
+            statement=(
+                "parse_document delegates CSV and vision source extraction to "
+                "separate typed paths while preserving the shared validation "
+                "and persistence pipeline."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_signature_seams.py"
+                "::test_AC_extraction_signature_seams_3_csv_and_vision_paths_are_separate"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.signature-seams.4",
+            statement=(
+                "Parsed transaction rows carry dedup_hash, balance_after, "
+                "occurrence_index, and currency resolution as a typed immutable "
+                "DTO; Layer-2 persistence accepts AsyncSession and never reads "
+                "transient attributes from ORM objects or filters failure "
+                "arguments with inspect.signature. ParseJob also owns the "
+                "failure-lineage identity instead of repeating its fields."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_signature_seams.py"
+                "::test_AC_extraction_signature_seams_4_typed_rows_and_failure_contract"
+            ),
+            priority="P0",
             status="done",
             proof_kind="property",
         ),

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -80,8 +80,21 @@ flowchart TB
 Ingestion writes the ODS/DWD tables directly. A successful parse persists one
 `UploadedDocument` (ODS), the deduplicated `AtomicTransaction` rows (DWD), and a
 `StatementSummary` envelope (DWD). `parse_document` returns
-`(StatementSummary, list[AtomicTransaction])`. There is no legacy `BankStatement`
-write path and no dual-write flag.
+`(StatementSummary, list[ExtractedTransactionRow])`; the immutable DTO carries
+`dedup_hash`, `balance_after`, `occurrence_index`, and currency-resolution state
+explicitly until `dual_write_layer2` persists an `AtomicTransaction`. No
+pre-persistence metadata is hidden on transient ORM attributes. There is no
+legacy `BankStatement` write path and no dual-write flag.
+
+The upload, in-process worker, and durable Prefect worker share one frozen
+`ParseJob` value object. Only `ParseJob.to_prefect_params()` crosses the Prefect
+boundary, and `from_prefect_params()` reconstructs typed UUIDs in the worker;
+raw bytes and database sessions never enter the durable parameter payload.
+`DocumentSource` similarly resolves storage path, content, URL, content hash,
+and display filename once before `parse_document` dispatches to separate CSV or
+vision extraction paths. The parser and Layer-2 writer accept typed
+`AsyncSession` seams, and failure handling uses one explicit call contract
+rather than runtime signature reflection.
 
 **ODS: Raw Documents (`UploadedDocument`)**
 - Stores immutable metadata for every uploaded file

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,5 +15,5 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:154 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:525 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:805 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:537 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:685 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:542 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:690 |


### PR DESCRIPTION
Part of #1866

## Summary
- add a frozen `ParseJob` with an explicit JSON-safe Prefect round trip, shared by upload dispatch, Prefect flow, background parsing, and failure lineage
- normalize document identity into immutable `DocumentSource` and split CSV versus vision extraction paths
- return immutable `ExtractedTransactionRow` DTOs through the persistence seam, eliminating transient ORM attributes and typing DB boundaries as `AsyncSession`
- make parsing/persistence entry points keyword-only where applicable and remove runtime `inspect.signature` filtering
- preserve byte-only legacy parsing through the normalized source boundary and fail fast when Layer-2 receives a non-DTO row

## Acceptance contracts
- `AC-extraction.signature-seams.1` through `.4` in `common/extraction/contract.py`
- contract/readme and generated router maturity reference updated in the same change

## Verification
- rebased onto `main@54553dbc`
- focused extraction/router/review regressions: 204 passed
- `tools/preflight.py --tier=static --base origin/main`: passed, 9/9 relevant gates
- `tools/preflight.py --tier=full --base origin/main`: passed, 10/10 relevant gates; tooling 2,172 passed
- scoped coverage: `base/types.py` 97%; pipeline/flow/types aggregate 96%
- `moon run :lint`: passed

## Explicitly out of scope
- PR-A reconciliation/ledger and PR-C llm/advisor/portfolio slices of #1866
- PR-D typed FX ports and explicit FX loading, `ReportSnapshot` relocation, workflow package extraction, async counter port/delegation, and ghost-directory/stale-comment cleanup