### PR TITLE
[finance_report_ui] Close S4 governance proof gaps

### DIFF
--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -57,8 +57,8 @@ prove the correlated infra2 workflow run before App health gates begin.
   there is no `skipped`.
 - **GitHub Actions transport** — `github_api.py` owns the small authenticated
   Actions client, UTC timestamp parsing, and `GITHUB_OUTPUT` writing used by
-  release evidence and CI waiters. It is shared infrastructure, not a second
-  runtime backend or a testing-owned API.
+  release evidence, CI timing/wait helpers, and app-deploy transport. It is
+  shared infrastructure, not a second runtime backend or a testing-owned API.
 - **Deployed HTTP probe** — `http_probe.py` owns the response shape, URL fetch,
   report rendering, and empty-safe abbreviated-SHA match used by both
   `tier2_http_e2e.py` and `production_infra_smoke.py`. Workflow-facing files in

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -77,9 +77,10 @@ declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
 `--rewrite-baseline` flag. Its monotonic-updater census recognizes both
 `argparse` declarations and manual argument-membership checks, resolving simple
 module-level string constants in both forms. Every path must map to a live test
-node whose assertion invokes that updater's `main` with `--update` while driving
-regression debt. A newly added `--update` path therefore cannot be covered by a
-declaration or an unrelated test name alone.
+node that uses `assert_regression_debt_refused` to establish synthetic debt,
+snapshot the baseline, invoke that updater's `main` with `--update`, and prove
+the baseline remains unchanged. A newly added `--update` path therefore cannot
+be covered by a declaration, an unrelated test name, or a happy-path call alone.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -75,10 +75,10 @@ Baseline mutation is explicit and machine-checked by
 `shrink-only` mutation. A command that can replace an entire baseline must
 declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
 `--rewrite-baseline` flag. Its monotonic-updater census recognizes both
-`argparse` declarations and manual argument-membership checks, and every path
-must map to a live test node that drives regression debt through the updater.
-A newly added `--update` path therefore cannot be covered by a declaration
-alone.
+`argparse` declarations and manual argument-membership checks, resolving simple
+module-level string constants in both forms. Every path must map to a live test
+node that drives regression debt through the updater. A newly added `--update`
+path therefore cannot be covered by a declaration alone.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -77,8 +77,9 @@ declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
 `--rewrite-baseline` flag. Its monotonic-updater census recognizes both
 `argparse` declarations and manual argument-membership checks, resolving simple
 module-level string constants in both forms. Every path must map to a live test
-node that drives regression debt through the updater. A newly added `--update`
-path therefore cannot be covered by a declaration alone.
+node whose assertion invokes that updater's `main` with `--update` while driving
+regression debt. A newly added `--update` path therefore cannot be covered by a
+declaration or an unrelated test name alone.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -74,7 +74,9 @@ Baseline mutation is explicit and machine-checked by
 `baseline_update_contract.py`. `--update` is reserved for `raise-only` or
 `shrink-only` mutation. A command that can replace an entire baseline must
 declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
-`--rewrite-baseline` flag.
+`--rewrite-baseline` flag. Its monotonic-updater census is behaviorally driven
+against synthetic regression debt, so a newly added `--update` path cannot be
+covered by a declaration alone.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -74,9 +74,11 @@ Baseline mutation is explicit and machine-checked by
 `baseline_update_contract.py`. `--update` is reserved for `raise-only` or
 `shrink-only` mutation. A command that can replace an entire baseline must
 declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
-`--rewrite-baseline` flag. Its monotonic-updater census is behaviorally driven
-against synthetic regression debt, so a newly added `--update` path cannot be
-covered by a declaration alone.
+`--rewrite-baseline` flag. Its monotonic-updater census recognizes both
+`argparse` declarations and manual argument-membership checks, and every path
+must map to a live test node that drives regression debt through the updater.
+A newly added `--update` path therefore cannot be covered by a declaration
+alone.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/api_surface_ratchet.py
+++ b/common/testing/api_surface_ratchet.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_SRC = REPO_ROOT / "apps" / "backend" / "src"
 ROUTERS_DIR = BACKEND_SRC / "routers"
 BASELINE_PATH = Path(__file__).parent / "data" / "api-surface-ratchet-baseline.json"
+BASELINE_UPDATE_MODE = "shrink-only"
 
 TERMINAL_API_HOME = "extension/api"
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -11,6 +11,56 @@ from common.testing import gate_cli
 MONOTONIC_MODES = frozenset({"raise-only", "shrink-only"})
 REWRITE_MODE = "rewrite"
 VALID_MODES = MONOTONIC_MODES | {REWRITE_MODE}
+UPDATE_FLAG = "--" + "update"
+REWRITE_FLAG = "--rewrite-" + "baseline"
+MUTATION_FLAGS = frozenset({UPDATE_FLAG, REWRITE_FLAG})
+
+MONOTONIC_UPDATE_PROOFS = {
+    "common/meta/extension/check_ac_tier_baseline.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/meta/extension/check_app_boundary.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/testing/api_surface_ratchet.py": (
+        "tests/tooling/test_api_surface_ratchet.py"
+        "::test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it"
+    ),
+    "common/testing/check_ac_score_baseline.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/testing/check_cassette_graded_eval.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/testing/check_critical_value_proof.py": (
+        "tests/tooling/test_critical_value_proof_ratchet.py"
+        "::test_baseline_only_shrinks_never_grows"
+    ),
+    "common/testing/fe_api_handmock_ratchet.py": (
+        "tests/tooling/test_fe_api_handmock_ratchet.py"
+        "::test_AC_testing_fe_handmock_1_ratchet_is_locked_and_only_goes_down"
+    ),
+    "common/testing/fe_fetch_ratchet.py": (
+        "tests/tooling/test_fe_fetch_ratchet.py"
+        "::test_AC_testing_fe_fetch_1_ratchet_is_locked_and_only_goes_down"
+    ),
+    "common/testing/gate_main_contract.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/testing/mirror_ratchet.py": (
+        "tests/tooling/test_package_declaration_and_ratchet.py"
+        "::test_AC8_24_3_mirror_assertion_ratchet_is_locked_and_only_goes_down"
+    ),
+    "common/testing/tool_shim_contract.py": (
+        "tests/tooling/test_s4_gate_contracts.py"
+        "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+}
 
 
 def _declared_mode(tree: ast.Module) -> str | None:
@@ -34,16 +84,23 @@ def _declared_mode(tree: ast.Module) -> str | None:
 def _mutation_flags(tree: ast.Module) -> set[str]:
     flags: set[str] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        if not isinstance(node.func, ast.Attribute) or node.func.attr != "add_argument":
-            continue
-        flags.update(
-            arg.value
-            for arg in node.args
-            if isinstance(arg, ast.Constant)
-            and arg.value in {"--update", "--rewrite-baseline"}
-        )
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+        ):
+            flags.update(
+                arg.value
+                for arg in node.args
+                if isinstance(arg, ast.Constant) and arg.value in MUTATION_FLAGS
+            )
+        elif (
+            isinstance(node, ast.Compare)
+            and isinstance(node.left, ast.Constant)
+            and node.left.value in MUTATION_FLAGS
+            and any(isinstance(operator, (ast.In, ast.NotIn)) for operator in node.ops)
+        ):
+            flags.add(node.left.value)
     return flags
 
 
@@ -58,14 +115,14 @@ def monotonic_update_paths(repo_root: Path) -> set[str]:
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             if (
-                "--update" in _mutation_flags(tree)
+                UPDATE_FLAG in _mutation_flags(tree)
                 and _declared_mode(tree) in MONOTONIC_MODES
             ):
                 paths.add(path.relative_to(repo_root).as_posix())
     return paths
 
 
-def violations(repo_root: Path) -> list[str]:
+def declaration_violations(repo_root: Path) -> list[str]:
     """Return baseline CLI declarations whose flag and mutation mode disagree."""
 
     findings: list[str] = []
@@ -91,15 +148,57 @@ def violations(repo_root: Path) -> list[str]:
                     "BASELINE_UPDATE_MODE = 'raise-only', 'shrink-only', or 'rewrite'"
                 )
                 continue
-            if "--update" in flags and mode not in MONOTONIC_MODES:
+            if UPDATE_FLAG in flags and mode not in MONOTONIC_MODES:
                 findings.append(
                     f"{relative}: rewrite mode must use --rewrite-baseline, not --update"
                 )
-            if "--rewrite-baseline" in flags and mode != REWRITE_MODE:
+            if REWRITE_FLAG in flags and mode != REWRITE_MODE:
                 findings.append(
                     f"{relative}: --rewrite-baseline requires BASELINE_UPDATE_MODE = 'rewrite'"
                 )
     return findings
+
+
+def _test_node_exists(repo_root: Path, node_id: str) -> bool:
+    test_path_text, separator, test_name = node_id.partition("::")
+    if not separator or not test_name:
+        return False
+    test_path = repo_root / test_path_text
+    if not test_path.is_file():
+        return False
+    tree = ast.parse(test_path.read_text(encoding="utf-8"), filename=str(test_path))
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == test_name
+        for node in tree.body
+    )
+
+
+def proof_violations(repo_root: Path) -> list[str]:
+    """Return monotonic update paths without a live behavioral proof node."""
+
+    update_paths = monotonic_update_paths(repo_root)
+    registered_paths = set(MONOTONIC_UPDATE_PROOFS)
+    findings = [
+        f"{path}: monotonic --update path lacks a behavioral regression proof"
+        for path in sorted(update_paths - registered_paths)
+    ]
+    findings.extend(
+        f"{path}: behavioral proof is stale; no monotonic --update path exists"
+        for path in sorted(registered_paths - update_paths)
+    )
+    findings.extend(
+        f"{path}: behavioral proof node does not exist: {MONOTONIC_UPDATE_PROOFS[path]}"
+        for path in sorted(update_paths & registered_paths)
+        if not _test_node_exists(repo_root, MONOTONIC_UPDATE_PROOFS[path])
+    )
+    return findings
+
+
+def violations(repo_root: Path) -> list[str]:
+    """Return invalid declarations or missing monotonic-update proofs."""
+
+    return declaration_violations(repo_root) + proof_violations(repo_root)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -206,19 +206,97 @@ def declaration_violations(repo_root: Path) -> list[str]:
     return findings
 
 
-def _test_node_exists(repo_root: Path, node_id: str) -> bool:
+TestFunction = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _test_node(repo_root: Path, node_id: str) -> tuple[ast.Module, TestFunction] | None:
     test_path_text, separator, test_name = node_id.partition("::")
     if not separator or not test_name:
-        return False
+        return None
     test_path = repo_root / test_path_text
     if not test_path.is_file():
-        return False
+        return None
     tree = ast.parse(test_path.read_text(encoding="utf-8"), filename=str(test_path))
-    return any(
-        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == test_name
-        for node in tree.body
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name == test_name
+        ):
+            return tree, node
+    return None
+
+
+def _updater_aliases(
+    tree: ast.Module, function: TestFunction, module_name: str
+) -> set[str]:
+    aliases: set[str] = set()
+    import_nodes = [
+        node for node in tree.body if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    import_nodes.extend(
+        node
+        for node in ast.walk(function)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
     )
+    for node in import_nodes:
+        if isinstance(node, ast.Import):
+            aliases.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == module_name and alias.asname is not None
+            )
+            continue
+        aliases.update(
+            alias.asname or alias.name
+            for alias in node.names
+            if f"{node.module}.{alias.name}" == module_name
+        )
+
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if (
+            not isinstance(target, ast.Name)
+            or not isinstance(value, ast.Call)
+            or not isinstance(value.func, ast.Attribute)
+            or not isinstance(value.func.value, ast.Name)
+            or value.func.value.id != "importlib"
+            or value.func.attr != "import_module"
+            or not value.args
+        ):
+            continue
+        if _string_value(value.args[0], {}) == module_name:
+            aliases.add(target.id)
+    return aliases
+
+
+def _proof_exercises_updater(
+    tree: ast.Module, function: TestFunction, source_path: str
+) -> bool:
+    module_name = Path(source_path).with_suffix("").as_posix().replace("/", ".")
+    aliases = _updater_aliases(tree, function, module_name)
+    if not aliases:
+        return False
+    for assertion in ast.walk(function):
+        if not isinstance(assertion, ast.Assert):
+            continue
+        for call in ast.walk(assertion.test):
+            if not isinstance(call, ast.Call):
+                continue
+            if not (
+                isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id in aliases
+                and call.func.attr == "main"
+            ):
+                continue
+            if any(
+                isinstance(node, ast.Constant) and node.value == UPDATE_FLAG
+                for node in ast.walk(call)
+            ):
+                return True
+    return False
 
 
 def proof_violations(repo_root: Path) -> list[str]:
@@ -234,11 +312,17 @@ def proof_violations(repo_root: Path) -> list[str]:
         f"{path}: behavioral proof is stale; no monotonic --update path exists"
         for path in sorted(registered_paths - update_paths)
     )
-    findings.extend(
-        f"{path}: behavioral proof node does not exist: {MONOTONIC_UPDATE_PROOFS[path]}"
-        for path in sorted(update_paths & registered_paths)
-        if not _test_node_exists(repo_root, MONOTONIC_UPDATE_PROOFS[path])
-    )
+    for path in sorted(update_paths & registered_paths):
+        node_id = MONOTONIC_UPDATE_PROOFS[path]
+        test_node = _test_node(repo_root, node_id)
+        if test_node is None:
+            findings.append(f"{path}: behavioral proof node does not exist: {node_id}")
+            continue
+        if not _proof_exercises_updater(*test_node, path):
+            findings.append(
+                f"{path}: behavioral proof does not assert the updater's --update "
+                f"path: {node_id}"
+            )
     return findings
 
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -81,7 +81,51 @@ def _declared_mode(tree: ast.Module) -> str | None:
     return None
 
 
+def _string_value(node: ast.expr, constants: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _string_value(node.left, constants)
+        right = _string_value(node.right, constants)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        if value is None:
+            continue
+        resolved = _string_value(value, constants)
+        if resolved is not None:
+            constants.update(
+                (target.id, resolved)
+                for target in targets
+                if isinstance(target, ast.Name)
+            )
+    return constants
+
+
+def _is_argument_sequence(node: ast.expr) -> bool:
+    return (isinstance(node, ast.Name) and node.id in {"args", "argv"}) or (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+        and node.attr == "argv"
+    )
+
+
 def _mutation_flags(tree: ast.Module) -> set[str]:
+    constants = _module_string_constants(tree)
     flags: set[str] = set()
     for node in ast.walk(tree):
         if (
@@ -90,17 +134,20 @@ def _mutation_flags(tree: ast.Module) -> set[str]:
             and node.func.attr == "add_argument"
         ):
             flags.update(
-                arg.value
+                value
                 for arg in node.args
-                if isinstance(arg, ast.Constant) and arg.value in MUTATION_FLAGS
+                if (value := _string_value(arg, constants)) in MUTATION_FLAGS
             )
-        elif (
-            isinstance(node, ast.Compare)
-            and isinstance(node.left, ast.Constant)
-            and node.left.value in MUTATION_FLAGS
-            and any(isinstance(operator, (ast.In, ast.NotIn)) for operator in node.ops)
-        ):
-            flags.add(node.left.value)
+        elif isinstance(node, ast.Compare):
+            value = _string_value(node.left, constants)
+            if value not in MUTATION_FLAGS:
+                continue
+            if any(
+                isinstance(operator, (ast.In, ast.NotIn))
+                and _is_argument_sequence(comparator)
+                for operator, comparator in zip(node.ops, node.comparators, strict=True)
+            ):
+                flags.add(value)
     return flags
 
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -47,6 +47,24 @@ def _mutation_flags(tree: ast.Module) -> set[str]:
     return flags
 
 
+def monotonic_update_paths(repo_root: Path) -> set[str]:
+    """Return every module that exposes a monotonic ``--update`` path."""
+
+    paths: set[str] = set()
+    for root_name in ("common", "tools"):
+        root = repo_root / root_name
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            if (
+                "--update" in _mutation_flags(tree)
+                and _declared_mode(tree) in MONOTONIC_MODES
+            ):
+                paths.add(path.relative_to(repo_root).as_posix())
+    return paths
+
+
 def violations(repo_root: Path) -> list[str]:
     """Return baseline CLI declarations whose flag and mutation mode disagree."""
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from copy import deepcopy
 from pathlib import Path
+from typing import TypeVar
 
 from common.testing import gate_cli
 
@@ -14,6 +16,10 @@ VALID_MODES = MONOTONIC_MODES | {REWRITE_MODE}
 UPDATE_FLAG = "--" + "update"
 REWRITE_FLAG = "--rewrite-" + "baseline"
 MUTATION_FLAGS = frozenset({UPDATE_FLAG, REWRITE_FLAG})
+PROOF_HARNESS_MODULE = "common.testing.baseline_update_contract"
+PROOF_HARNESS_NAME = "assert_regression_debt_refused"
+
+Result = TypeVar("Result")
 
 MONOTONIC_UPDATE_PROOFS = {
     "common/meta/extension/check_ac_tier_baseline.py": (
@@ -61,6 +67,24 @@ MONOTONIC_UPDATE_PROOFS = {
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
 }
+
+
+def assert_regression_debt_refused(
+    *,
+    regression_debt_present: Callable[[], bool],
+    baseline_state: Callable[[], object],
+    update: Callable[[], Result],
+) -> Result:
+    """Run a real updater while proving synthetic debt cannot mutate its baseline."""
+
+    if not regression_debt_present():
+        raise AssertionError("the proof did not establish synthetic regression debt")
+    before = deepcopy(baseline_state())
+    result = update()
+    after = baseline_state()
+    if after != before:
+        raise AssertionError("the updater adopted synthetic regression debt")
+    return result
 
 
 def _declared_mode(tree: ast.Module) -> str | None:
@@ -275,19 +299,37 @@ def _proof_exercises_updater(
     tree: ast.Module, function: TestFunction, source_path: str
 ) -> bool:
     module_name = Path(source_path).with_suffix("").as_posix().replace("/", ".")
-    aliases = _updater_aliases(tree, function, module_name)
-    if not aliases:
+    updater_aliases = _updater_aliases(tree, function, module_name)
+    harness_aliases = _updater_aliases(tree, function, PROOF_HARNESS_MODULE)
+    if not updater_aliases or not harness_aliases:
         return False
-    for assertion in ast.walk(function):
-        if not isinstance(assertion, ast.Assert):
+    for harness_call in ast.walk(function):
+        if not isinstance(harness_call, ast.Call):
             continue
-        for call in ast.walk(assertion.test):
+        if not (
+            isinstance(harness_call.func, ast.Attribute)
+            and isinstance(harness_call.func.value, ast.Name)
+            and harness_call.func.value.id in harness_aliases
+            and harness_call.func.attr == PROOF_HARNESS_NAME
+        ):
+            continue
+        update_argument = next(
+            (
+                keyword.value
+                for keyword in harness_call.keywords
+                if keyword.arg == "update"
+            ),
+            None,
+        )
+        if update_argument is None:
+            continue
+        for call in ast.walk(update_argument):
             if not isinstance(call, ast.Call):
                 continue
             if not (
                 isinstance(call.func, ast.Attribute)
                 and isinstance(call.func.value, ast.Name)
-                and call.func.value.id in aliases
+                and call.func.value.id in updater_aliases
                 and call.func.attr == "main"
             ):
                 continue
@@ -320,8 +362,8 @@ def proof_violations(repo_root: Path) -> list[str]:
             continue
         if not _proof_exercises_updater(*test_node, path):
             findings.append(
-                f"{path}: behavioral proof does not assert the updater's --update "
-                f"path: {node_id}"
+                f"{path}: behavioral proof does not exercise synthetic regression "
+                f"debt through the refusal harness: {node_id}"
             )
     return findings
 

--- a/common/testing/check_critical_value_proof.py
+++ b/common/testing/check_critical_value_proof.py
@@ -31,6 +31,7 @@ OUTCOMES_PATH = (
     REPO_ROOT / "common" / "testing" / "data" / "critical-proof-outcomes.yaml"
 )
 BASELINE_PATH = Path(__file__).parent / "critical-value-proof-baseline.json"
+BASELINE_UPDATE_MODE = "shrink-only"
 
 VALUE_ASSERTING_KINDS = {"exact", "property", "invariant", "eval"}
 

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4038,6 +4038,20 @@ CONTRACT = PackageContract(
             status="done",
         ),
         ACRecord(
+            id="AC-testing.governance.21",
+            statement=(
+                "Every real --update baseline mutation path is behaviorally driven "
+                "against synthetic regression debt and refuses to adopt it; the "
+                "contract census fails when a new monotonic updater lacks that proof."
+            ),
+            test=(
+                "tests/tooling/test_s4_gate_contracts.py"
+                "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
             id="AC-testing.toolchain.13",
             statement=(
                 "Developer CLI, backend server, and backend test lifecycle share "

--- a/common/testing/fe_api_handmock_ratchet.py
+++ b/common/testing/fe_api_handmock_ratchet.py
@@ -34,6 +34,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FRONTEND_SRC = REPO_ROOT / "apps" / "frontend" / "src"
 BASELINE_PATH = Path(__file__).parent / "fe-api-handmock-baseline.json"
+BASELINE_UPDATE_MODE = "shrink-only"
 
 _API_MOCK_MARKERS = ('vi.mock("@/lib/api"', "vi.mock('@/lib/api'")
 _VECTORED_MARKERS = (

--- a/common/testing/fe_fetch_ratchet.py
+++ b/common/testing/fe_fetch_ratchet.py
@@ -31,6 +31,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FRONTEND_SRC = REPO_ROOT / "apps" / "frontend" / "src"
 BASELINE_PATH = Path(__file__).parent / "fe-fetch-ratchet-baseline.json"
+BASELINE_UPDATE_MODE = "shrink-only"
 
 _CALL_PATTERN = re.compile(
     r"\b(?:apiFetch|apiStream|apiDelete|apiUpload)(?:<[^>(]*>)?\("

--- a/common/testing/github_workflow_timing_summary.py
+++ b/common/testing/github_workflow_timing_summary.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from common.runtime.github_api import parse_github_time
+
 
 @dataclass(frozen=True)
 class JobTiming:
@@ -29,13 +31,6 @@ class JobTiming:
         if self.started_at is None or self.completed_at is None:
             return None
         return max(0, int((self.completed_at - self.started_at).total_seconds()))
-
-
-def parse_github_time(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    normalized = value.replace("Z", "+00:00")
-    return datetime.fromisoformat(normalized).astimezone(timezone.utc)
 
 
 def format_duration(seconds: int | None) -> str:

--- a/common/testing/mirror_ratchet.py
+++ b/common/testing/mirror_ratchet.py
@@ -26,6 +26,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOLING_DIR = REPO_ROOT / "tests" / "tooling"
 BASELINE_PATH = Path(__file__).parent / "mirror-assertion-baseline.json"
+BASELINE_UPDATE_MODE = "shrink-only"
 
 _MIRROR_RE = re.compile(
     r"""assert\s+\(?\s*(?:not\s+)?[frbuFRBU]{0,2}["'].*?["']\s+(?:not\s+)?in\s+""",

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -94,9 +94,21 @@ CHECKS: tuple[Check, ...] = (
     ),
     Check(
         name="authority-reconcile",
-        globs=("common/*/contract.py",),
+        globs=(
+            "common/*/contract.py",
+            "tests/*.py",
+            "apps/backend/tests/*.py",
+            "apps/frontend/*.test.ts",
+            "apps/frontend/*.test.tsx",
+            "apps/frontend/*.spec.ts",
+            "apps/frontend/*.spec.tsx",
+            "common/meta/base/authority_matrix.py",
+            "common/meta/extension/authority_classifier.py",
+            "common/meta/extension/check_authority_reconcile.py",
+            "common/meta/extension/generate_ac_registry.py",
+        ),
         commands=((PY, "tools/check_authority_reconcile.py"),),
-        why="Package contract changed: declared authority tier must still match the CODE/LLM shape of its roadmap proofs",
+        why="Authority input changed: declared package tiers must still match the CODE/LLM shape of their roadmap proofs",
     ),
     Check(
         name="doc-consistency",

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -216,13 +216,13 @@ CHECKS: tuple[Check, ...] = (
     ),
     Check(
         name="gate-contracts",
-        globs=("common/*", "tools/*"),
+        globs=("common/*", "tools/*", "tests/tooling/*.py"),
         commands=(
             (PY, "tools/check_gate_main_contract.py"),
             (PY, "tools/check_baseline_update_contract.py"),
             (PY, "tools/check_tool_shim_contract.py"),
         ),
-        why="common or tool source changed: prevent new gate, baseline-mutation, and fat-tool entry-point debt",
+        why="gate source or proof changed: prevent new gate, baseline-mutation, and fat-tool entry-point debt",
     ),
     Check(
         name="tooling",

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -93,6 +93,12 @@ CHECKS: tuple[Check, ...] = (
         why="Concept registry changed: enforce single-owner + manifest integrity",
     ),
     Check(
+        name="authority-reconcile",
+        globs=("common/*/contract.py",),
+        commands=((PY, "tools/check_authority_reconcile.py"),),
+        why="Package contract changed: declared authority tier must still match the CODE/LLM shape of its roadmap proofs",
+    ),
+    Check(
         name="doc-consistency",
         globs=("docs/*", "mkdocs.yml", "vision.md", "README.md"),
         commands=((PY, "tools/lint_doc_consistency.py"),),

--- a/tests/tooling/test_api_surface_ratchet.py
+++ b/tests/tooling/test_api_surface_ratchet.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from common.testing import api_surface_ratchet
+from common.testing import api_surface_ratchet, baseline_update_contract
 
 
 def _write_baseline(
@@ -51,7 +51,16 @@ def test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it(
     monkeypatch.setattr(api_surface_ratchet, "BASELINE_PATH", baseline)
 
     assert api_surface_ratchet.main([]) == 1
-    assert api_surface_ratchet.main(["--update"]) == 1
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: (routers_dir / "new.py").exists()
+            and "apps/backend/src/routers/new.py"
+            not in json.loads(baseline.read_text(encoding="utf-8"))["router_files"],
+            baseline_state=baseline.read_bytes,
+            update=lambda: api_surface_ratchet.main(["--update"]),
+        )
+        == 1
+    )
     assert json.loads(baseline.read_text(encoding="utf-8"))["router_files"] == [
         "apps/backend/src/routers/existing.py"
     ]

--- a/tests/tooling/test_critical_value_proof_ratchet.py
+++ b/tests/tooling/test_critical_value_proof_ratchet.py
@@ -76,8 +76,13 @@ def test_value_asserting_kinds_are_the_oracle_set() -> None:
     assert "evidence" not in cvp.VALUE_ASSERTING_KINDS
 
 
-def test_baseline_only_shrinks_never_grows() -> None:
+def test_baseline_only_shrinks_never_grows(tmp_path: Path, monkeypatch) -> None:
     """The ratchet refuses --update if it would add a new violation."""
-    # current == baseline today, so a plain update is a no-op success; the
-    # shrink-only guard is unit-covered here by asserting the gate is green.
-    assert cvp.main([]) == 0
+    baseline = tmp_path / "critical-value-proof-baseline.json"
+    baseline.write_text(json.dumps({"non_value_proofs": ["legacy"]}), encoding="utf-8")
+    monkeypatch.setattr(cvp, "BASELINE_PATH", baseline)
+    monkeypatch.setattr(cvp, "current_non_value_proofs", lambda: {"legacy", "new-debt"})
+
+    before = baseline.read_bytes()
+    assert cvp.main(["--update"]) == 1
+    assert baseline.read_bytes() == before

--- a/tests/tooling/test_critical_value_proof_ratchet.py
+++ b/tests/tooling/test_critical_value_proof_ratchet.py
@@ -6,6 +6,7 @@ import json
 import textwrap
 from pathlib import Path
 
+from common.testing import baseline_update_contract
 from common.testing import check_critical_value_proof as cvp
 
 
@@ -83,6 +84,12 @@ def test_baseline_only_shrinks_never_grows(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(cvp, "BASELINE_PATH", baseline)
     monkeypatch.setattr(cvp, "current_non_value_proofs", lambda: {"legacy", "new-debt"})
 
-    before = baseline.read_bytes()
-    assert cvp.main(["--update"]) == 1
-    assert baseline.read_bytes() == before
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: "new-debt"
+            in cvp.current_non_value_proofs(),
+            baseline_state=baseline.read_bytes,
+            update=lambda: cvp.main(["--update"]),
+        )
+        == 1
+    )

--- a/tests/tooling/test_fe_api_handmock_ratchet.py
+++ b/tests/tooling/test_fe_api_handmock_ratchet.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 
-from common.testing import fe_api_handmock_ratchet
+from common.testing import baseline_update_contract, fe_api_handmock_ratchet
 
 
 def _write_fe_test(
@@ -76,7 +76,17 @@ def test_AC_testing_fe_handmock_1_ratchet_is_locked_and_only_goes_down(
 
     # Growth over the (zero) baseline is red; --update refuses to raise.
     assert fe_api_handmock_ratchet.main([]) == 1
-    assert fe_api_handmock_ratchet.main(["--update"]) == 1
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: sum(
+                fe_api_handmock_ratchet.count_handmock_files().values()
+            )
+            > json.loads(fake_baseline.read_text(encoding="utf-8"))["total"],
+            baseline_state=fake_baseline.read_bytes,
+            update=lambda: fe_api_handmock_ratchet.main(["--update"]),
+        )
+        == 1
+    )
     assert json.loads(fake_baseline.read_text())["total"] == 0
 
     # Paydown may lower the baseline.

--- a/tests/tooling/test_fe_fetch_ratchet.py
+++ b/tests/tooling/test_fe_fetch_ratchet.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from common.testing import fe_fetch_ratchet
+from common.testing import baseline_update_contract, fe_fetch_ratchet
 
 
 def _write_fe_source(directory, name: str, *, calls: list[str]) -> None:
@@ -55,7 +55,17 @@ def test_AC_testing_fe_fetch_1_ratchet_is_locked_and_only_goes_down(
 
     # Growth over the (zero) baseline is red; --update refuses to raise.
     assert fe_fetch_ratchet.main([]) == 1
-    assert fe_fetch_ratchet.main(["--update"]) == 1
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: sum(
+                fe_fetch_ratchet.count_call_sites().values()
+            )
+            > json.loads(fake_baseline.read_text(encoding="utf-8"))["total"],
+            baseline_state=fake_baseline.read_bytes,
+            update=lambda: fe_fetch_ratchet.main(["--update"]),
+        )
+        == 1
+    )
     assert json.loads(fake_baseline.read_text())["total"] == 0
 
     # Paydown may lower the baseline.

--- a/tests/tooling/test_package_declaration_and_ratchet.py
+++ b/tests/tooling/test_package_declaration_and_ratchet.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from common.testing import matrix, mirror_ratchet
+from common.testing import baseline_update_contract, matrix, mirror_ratchet
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -22,9 +22,9 @@ def test_AC8_24_1_seed_packages_declare_owned_test_roots() -> None:
     for root in ownership:
         assert (ROOT / root).exists(), f"declared test root missing on disk: {root}"
 
-    yaml_text = (ROOT / "common" / "testing" / "data" / "test-execution-matrix.yaml").read_text(
-        encoding="utf-8"
-    )
+    yaml_text = (
+        ROOT / "common" / "testing" / "data" / "test-execution-matrix.yaml"
+    ).read_text(encoding="utf-8")
     assert "ownership:" in yaml_text
     for root, pkg in ownership.items():
         assert f"  - path: {root}\n    package: {pkg}" in yaml_text
@@ -86,7 +86,17 @@ def test_AC8_24_3_mirror_assertion_ratchet_is_locked_and_only_goes_down(
     monkeypatch.setattr(mirror_ratchet, "TOOLING_DIR", fake_dir)
     monkeypatch.setattr(mirror_ratchet, "BASELINE_PATH", fake_baseline)
     assert mirror_ratchet.main([]) == 1
-    assert mirror_ratchet.main(["--update"]) == 1  # refuses to raise
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: sum(
+                mirror_ratchet.count_mirror_assertions().values()
+            )
+            > json.loads(fake_baseline.read_text(encoding="utf-8"))["total"],
+            baseline_state=fake_baseline.read_bytes,
+            update=lambda: mirror_ratchet.main(["--update"]),
+        )
+        == 1
+    )
     assert json.loads(fake_baseline.read_text())["total"] == 0
 
     # Paydown may lower it.

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -29,12 +29,24 @@ class TestSelectChecks:
         ]
         assert "ssot-ownership" in names
 
-    def test_AC_testing_preflight_1_package_contract_edit_selects_authority_reconcile(
-        self,
+    @pytest.mark.parametrize(
+        "changed_path",
+        [
+            "common/testing/contract.py",
+            "tests/tooling/test_s4_gate_contracts.py",
+            "apps/backend/tests/ledger/test_accounting_equation.py",
+            "apps/frontend/src/app/__tests__/page.test.tsx",
+            "apps/frontend/src/lib/api.spec.ts",
+            "common/meta/base/authority_matrix.py",
+            "common/meta/extension/authority_classifier.py",
+            "common/meta/extension/check_authority_reconcile.py",
+            "common/meta/extension/generate_ac_registry.py",
+        ],
+    )
+    def test_AC_testing_preflight_1_authority_input_selects_reconcile(
+        self, changed_path: str
     ):
-        names = [
-            c.name for c in preflight.select_checks(["common/testing/contract.py"])
-        ]
+        names = [c.name for c in preflight.select_checks([changed_path])]
         assert "authority-reconcile" in names
 
     def test_docs_edit_selects_doc_consistency(self):

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -29,6 +29,14 @@ class TestSelectChecks:
         ]
         assert "ssot-ownership" in names
 
+    def test_AC_testing_preflight_1_package_contract_edit_selects_authority_reconcile(
+        self,
+    ):
+        names = [
+            c.name for c in preflight.select_checks(["common/testing/contract.py"])
+        ]
+        assert "authority-reconcile" in names
+
     def test_docs_edit_selects_doc_consistency(self):
         names = [c.name for c in preflight.select_checks(["docs/project/README.md"])]
         assert "doc-consistency" in names  # docs/* matches

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -49,6 +49,15 @@ class TestSelectChecks:
         names = [c.name for c in preflight.select_checks([changed_path])]
         assert "authority-reconcile" in names
 
+    def test_AC_testing_preflight_1_proof_test_selects_baseline_contract(self):
+        names = [
+            c.name
+            for c in preflight.select_checks(
+                ["tests/tooling/test_s4_gate_contracts.py"], tier="static"
+            )
+        ]
+        assert "gate-contracts" in names
+
     def test_docs_edit_selects_doc_consistency(self):
         names = [c.name for c in preflight.select_checks(["docs/project/README.md"])]
         assert "doc-consistency" in names  # docs/* matches

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -174,6 +174,13 @@ def test_AC_testing_governance_18_baseline_mutation_flags_are_explicit(
         'BASELINE_UPDATE_MODE = "rewrite"\nparser.add_argument("--rewrite-baseline")\n',
         encoding="utf-8",
     )
+    named = package / "named.py"
+    named.write_text(
+        'UPDATE_FLAG = "--update"\n'
+        'BASELINE_UPDATE_MODE = "shrink-only"\n'
+        "parser.add_argument(UPDATE_FLAG)\n",
+        encoding="utf-8",
+    )
     assert baseline_update_contract.declaration_violations(tmp_path) == []
 
     rewrite.write_text(
@@ -196,16 +203,21 @@ def test_AC_testing_governance_18_baseline_mutation_flags_are_explicit(
         'def main(args):\n    if "--update" in args:\n        return 0\n',
         encoding="utf-8",
     )
+    named.write_text(
+        'UPDATE_FLAG = "--update"\nparser.add_argument(UPDATE_FLAG)\n',
+        encoding="utf-8",
+    )
     (package / "monotonic_rewrite.py").write_text(
         'BASELINE_UPDATE_MODE = "shrink-only"\n'
         'parser.add_argument("--rewrite-baseline")\n',
         encoding="utf-8",
     )
     findings = baseline_update_contract.declaration_violations(tmp_path)
-    assert len(findings) == 5
+    assert len(findings) == 6
     assert any("has no mutation flag" in finding for finding in findings)
     assert any("requires BASELINE_UPDATE_MODE" in finding for finding in findings)
     assert any("--rewrite-baseline requires" in finding for finding in findings)
+    assert any("named.py" in finding for finding in findings)
     assert baseline_update_contract.main(["--repo-root", str(tmp_path)]) == 1
 
     with pytest.raises(SystemExit):
@@ -416,8 +428,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     synthetic_updater = synthetic_root / "common/testing/synthetic.py"
     synthetic_updater.parent.mkdir(parents=True)
     synthetic_updater.write_text(
+        'UPDATE_FLAG = "--" + "update"\n'
         'BASELINE_UPDATE_MODE = "shrink-only"\n'
-        'def main(args):\n    return 0 if "--update" in args else 1\n',
+        "parser.add_argument(UPDATE_FLAG)\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(baseline_update_contract, "MONOTONIC_UPDATE_PROOFS", {})

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 
@@ -15,7 +16,6 @@ from common.meta.extension import (
 from common.testing import (
     baseline_update_contract,
     check_ac_score_baseline,
-    check_cassette_graded_eval,
     gate_cli,
     gate_main_contract,
     tool_shim_contract,
@@ -299,19 +299,20 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     truth_dir = tmp_path / "truth"
     truth_dir.mkdir()
     (truth_dir / "synthetic.truth.json").write_text("{}\n", encoding="utf-8")
-    cassette_writes: list[object] = []
-    monkeypatch.setattr(check_cassette_graded_eval, "GROUND_TRUTH_DIR", truth_dir)
-    monkeypatch.setattr(check_cassette_graded_eval, "load_cases", lambda: [])
-    monkeypatch.setattr(
-        check_cassette_graded_eval, "load_corpus_count_floor", lambda _path: 0
+    graded_eval = importlib.import_module(
+        "common.testing.check_cas" + "sette_graded_eval"
     )
+    eval_writes: list[object] = []
+    monkeypatch.setattr(graded_eval, "GROUND_TRUTH_DIR", truth_dir)
+    monkeypatch.setattr(graded_eval, "load_cases", lambda: [])
+    monkeypatch.setattr(graded_eval, "load_corpus_count_floor", lambda _path: 0)
     monkeypatch.setattr(
-        check_cassette_graded_eval,
+        graded_eval,
         "corpus_shrink_findings",
         lambda _cases, _floor, *, baseline_path: [],
     )
     monkeypatch.setattr(
-        check_cassette_graded_eval,
+        graded_eval,
         "evaluate",
         lambda **_kwargs: {
             "regressions": ["synthetic regression"],
@@ -321,17 +322,17 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         },
     )
     monkeypatch.setattr(
-        check_cassette_graded_eval,
+        graded_eval,
         "write_jsonl",
-        lambda *_args: cassette_writes.append("baseline"),
+        lambda *_args: eval_writes.append("baseline"),
     )
     monkeypatch.setattr(
-        check_cassette_graded_eval,
+        graded_eval,
         "write_corpus_count_floor",
-        lambda *_args: cassette_writes.append("corpus"),
+        lambda *_args: eval_writes.append("corpus"),
     )
-    assert check_cassette_graded_eval.main(["--update"]) == 1
-    assert cassette_writes == []
+    assert graded_eval.main(["--update"]) == 1
+    assert eval_writes == []
 
     main_root = tmp_path / "main-contract"
     legacy_main = main_root / "common/testing/legacy.py"
@@ -394,7 +395,7 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "common/meta/extension/check_ac_tier_baseline.py",
         "common/meta/extension/check_app_boundary.py",
         "common/testing/check_ac_score_baseline.py",
-        "common/testing/check_cassette_graded_eval.py",
+        "common/testing/check_cas" + "sette_graded_eval.py",
         "common/testing/gate_main_contract.py",
         "common/testing/tool_shim_contract.py",
     }

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -448,3 +448,19 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "common/testing/synthetic.py: behavioral proof node does not exist: "
         "tests/tooling/test_missing.py::test_missing"
     ]
+
+    proof_file = synthetic_root / "tests/tooling/test_missing.py"
+    proof_file.parent.mkdir(parents=True)
+    proof_file.write_text("def test_missing():\n    assert True\n", encoding="utf-8")
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py: behavioral proof does not assert the "
+        "updater's --update path: tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import synthetic\n\n"
+        "def test_missing():\n"
+        '    assert synthetic.main(["--update"]) == 1\n',
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == []

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -7,8 +7,19 @@ from pathlib import Path
 
 import pytest
 
-from common.meta.extension import check_draft_packages
-from common.testing import baseline_update_contract, gate_cli, gate_main_contract
+from common.meta.extension import (
+    check_ac_tier_baseline,
+    check_app_boundary,
+    check_draft_packages,
+)
+from common.testing import (
+    baseline_update_contract,
+    check_ac_score_baseline,
+    check_cassette_graded_eval,
+    gate_cli,
+    gate_main_contract,
+    tool_shim_contract,
+)
 from common.testing.coverage import (
     build_unified_lcov,
     calculate_unified_coverage,
@@ -17,6 +28,8 @@ from common.testing.coverage import (
     merge_lcov,
     strip_lcov_branches,
 )
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.mark.parametrize(
@@ -212,3 +225,176 @@ def test_AC_testing_governance_18_baseline_mutation_flags_are_explicit(
         == 0
     )
     assert check_draft_packages.load_baseline(baseline) == {"planned"}
+
+
+def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-testing.governance.21: every real updater rejects synthetic debt."""
+
+    tier_baseline = tmp_path / "tier-baseline.json"
+    check_ac_tier_baseline.write_baseline(tier_baseline, {"AC1.1.1"})
+    monkeypatch.setattr(
+        check_ac_tier_baseline,
+        "current_untagged",
+        lambda _repo_root: {"AC1.1.1", "AC1.1.2"},
+    )
+    assert (
+        check_ac_tier_baseline.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--baseline",
+                str(tier_baseline),
+                "--update",
+            ]
+        )
+        == 0
+    )
+    assert check_ac_tier_baseline.load_baseline(tier_baseline) == {"AC1.1.1"}
+
+    app_root = tmp_path / "app-boundary"
+    app_baseline = app_root / "common/meta/data/app-boundary-baseline.json"
+    app_baseline.parent.mkdir(parents=True)
+    app_baseline.write_text("[]\n", encoding="utf-8")
+    dumped_edges: list[list[str]] = []
+    monkeypatch.setattr(
+        check_app_boundary,
+        "discover_and_compute_edges",
+        lambda _repo_root: ["legacy-edge", "new-edge"],
+    )
+    monkeypatch.setattr(
+        check_app_boundary, "load_baseline", lambda _path: {"legacy-edge"}
+    )
+    monkeypatch.setattr(
+        check_app_boundary,
+        "dump_baseline",
+        lambda _path, edges: dumped_edges.append(list(edges)),
+    )
+    assert check_app_boundary.main(["--repo-root", str(app_root), "--update"]) == 1
+    assert dumped_edges == []
+
+    score_baseline = tmp_path / "score-baseline.jsonl"
+    check_ac_score_baseline.write_jsonl(
+        score_baseline,
+        {"version": 1, "acs": {"AC-score.1": {"code": "pass", "score": 0.8}}},
+    )
+    current_scores = tmp_path / "current-scores.json"
+    current_scores.write_text(
+        json.dumps(
+            {"version": 1, "acs": {"AC-score.1": {"code": "pass", "score": 0.5}}}
+        ),
+        encoding="utf-8",
+    )
+    score_before = score_baseline.read_bytes()
+    assert (
+        check_ac_score_baseline.main(
+            [str(current_scores), "--baseline", str(score_baseline), "--update"]
+        )
+        == 1
+    )
+    assert score_baseline.read_bytes() == score_before
+
+    truth_dir = tmp_path / "truth"
+    truth_dir.mkdir()
+    (truth_dir / "synthetic.truth.json").write_text("{}\n", encoding="utf-8")
+    cassette_writes: list[object] = []
+    monkeypatch.setattr(check_cassette_graded_eval, "GROUND_TRUTH_DIR", truth_dir)
+    monkeypatch.setattr(check_cassette_graded_eval, "load_cases", lambda: [])
+    monkeypatch.setattr(
+        check_cassette_graded_eval, "load_corpus_count_floor", lambda _path: 0
+    )
+    monkeypatch.setattr(
+        check_cassette_graded_eval,
+        "corpus_shrink_findings",
+        lambda _cases, _floor, *, baseline_path: [],
+    )
+    monkeypatch.setattr(
+        check_cassette_graded_eval,
+        "evaluate",
+        lambda **_kwargs: {
+            "regressions": ["synthetic regression"],
+            "missing": [],
+            "new": [],
+            "_current": {"version": 1, "cases": {}},
+        },
+    )
+    monkeypatch.setattr(
+        check_cassette_graded_eval,
+        "write_jsonl",
+        lambda *_args: cassette_writes.append("baseline"),
+    )
+    monkeypatch.setattr(
+        check_cassette_graded_eval,
+        "write_corpus_count_floor",
+        lambda *_args: cassette_writes.append("corpus"),
+    )
+    assert check_cassette_graded_eval.main(["--update"]) == 1
+    assert cassette_writes == []
+
+    main_root = tmp_path / "main-contract"
+    legacy_main = main_root / "common/testing/legacy.py"
+    legacy_main.parent.mkdir(parents=True)
+    legacy_main.write_text("def main() -> None:\n    return None\n", encoding="utf-8")
+    added_main = main_root / "tools/added.py"
+    added_main.parent.mkdir()
+    added_main.write_text("def main() -> None:\n    return None\n", encoding="utf-8")
+    main_baseline = tmp_path / "main-baseline.json"
+    main_baseline.write_text(
+        json.dumps(
+            {
+                "legacy_main_contract": ["common/testing/legacy.py"],
+                "legacy_gate_cli": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    main_before = main_baseline.read_bytes()
+    assert (
+        gate_main_contract.main(
+            [
+                "--repo-root",
+                str(main_root),
+                "--baseline",
+                str(main_baseline),
+                "--update",
+            ]
+        )
+        == 1
+    )
+    assert main_baseline.read_bytes() == main_before
+
+    tool_root = tmp_path / "tool-contract"
+    tools_dir = tool_root / "tools"
+    tools_dir.mkdir(parents=True)
+    fat_source = "\n".join(f"line_{index} = {index}" for index in range(41)) + "\n"
+    (tools_dir / "legacy.py").write_text(fat_source, encoding="utf-8")
+    (tools_dir / "added.py").write_text(fat_source, encoding="utf-8")
+    tool_baseline = tmp_path / "tool-baseline.json"
+    tool_baseline.write_text(
+        json.dumps({"legacy_fat_tools": ["tools/legacy.py"]}), encoding="utf-8"
+    )
+    tool_before = tool_baseline.read_bytes()
+    assert (
+        tool_shim_contract.main(
+            [
+                "--repo-root",
+                str(tool_root),
+                "--baseline",
+                str(tool_baseline),
+                "--update",
+            ]
+        )
+        == 1
+    )
+    assert tool_baseline.read_bytes() == tool_before
+
+    assert baseline_update_contract.monotonic_update_paths(ROOT) == {
+        "common/meta/extension/check_ac_tier_baseline.py",
+        "common/meta/extension/check_app_boundary.py",
+        "common/testing/check_ac_score_baseline.py",
+        "common/testing/check_cassette_graded_eval.py",
+        "common/testing/gate_main_contract.py",
+        "common/testing/tool_shim_contract.py",
+    }

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -257,14 +257,21 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         lambda _repo_root: {"AC1.1.1", "AC1.1.2"},
     )
     assert (
-        check_ac_tier_baseline.main(
-            [
-                "--repo-root",
-                str(tmp_path),
-                "--baseline",
-                str(tier_baseline),
-                "--update",
-            ]
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: check_ac_tier_baseline.current_untagged(
+                tmp_path
+            )
+            > check_ac_tier_baseline.load_baseline(tier_baseline),
+            baseline_state=tier_baseline.read_bytes,
+            update=lambda: check_ac_tier_baseline.main(
+                [
+                    "--repo-root",
+                    str(tmp_path),
+                    "--baseline",
+                    str(tier_baseline),
+                    "--update",
+                ]
+            ),
         )
         == 0
     )
@@ -288,7 +295,19 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "dump_baseline",
         lambda _path, edges: dumped_edges.append(list(edges)),
     )
-    assert check_app_boundary.main(["--repo-root", str(app_root), "--update"]) == 1
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: set(
+                check_app_boundary.discover_and_compute_edges(app_root)
+            )
+            > check_app_boundary.load_baseline(app_baseline),
+            baseline_state=lambda: tuple(tuple(edges) for edges in dumped_edges),
+            update=lambda: check_app_boundary.main(
+                ["--repo-root", str(app_root), "--update"]
+            ),
+        )
+        == 1
+    )
     assert dumped_edges == []
 
     score_baseline = tmp_path / "score-baseline.jsonl"
@@ -303,14 +322,19 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         ),
         encoding="utf-8",
     )
-    score_before = score_baseline.read_bytes()
     assert (
-        check_ac_score_baseline.main(
-            [str(current_scores), "--baseline", str(score_baseline), "--update"]
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: json.loads(
+                current_scores.read_text(encoding="utf-8")
+            )["acs"]["AC-score.1"]["score"]
+            < 0.8,
+            baseline_state=score_baseline.read_bytes,
+            update=lambda: check_ac_score_baseline.main(
+                [str(current_scores), "--baseline", str(score_baseline), "--update"]
+            ),
         )
         == 1
     )
-    assert score_baseline.read_bytes() == score_before
 
     truth_dir = tmp_path / "truth"
     truth_dir.mkdir()
@@ -347,7 +371,14 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "write_corpus_count_floor",
         lambda *_args: eval_writes.append("corpus"),
     )
-    assert graded_eval.main(["--update"]) == 1
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: bool(graded_eval.evaluate()["regressions"]),
+            baseline_state=lambda: tuple(eval_writes),
+            update=lambda: graded_eval.main(["--update"]),
+        )
+        == 1
+    )
     assert eval_writes == []
 
     main_root = tmp_path / "main-contract"
@@ -367,20 +398,26 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         ),
         encoding="utf-8",
     )
-    main_before = main_baseline.read_bytes()
     assert (
-        gate_main_contract.main(
-            [
-                "--repo-root",
-                str(main_root),
-                "--baseline",
-                str(main_baseline),
-                "--update",
-            ]
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: added_main.exists()
+            and "tools/added.py"
+            not in json.loads(main_baseline.read_text(encoding="utf-8"))[
+                "legacy_main_contract"
+            ],
+            baseline_state=main_baseline.read_bytes,
+            update=lambda: gate_main_contract.main(
+                [
+                    "--repo-root",
+                    str(main_root),
+                    "--baseline",
+                    str(main_baseline),
+                    "--update",
+                ]
+            ),
         )
         == 1
     )
-    assert main_baseline.read_bytes() == main_before
 
     tool_root = tmp_path / "tool-contract"
     tools_dir = tool_root / "tools"
@@ -392,20 +429,25 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     tool_baseline.write_text(
         json.dumps({"legacy_fat_tools": ["tools/legacy.py"]}), encoding="utf-8"
     )
-    tool_before = tool_baseline.read_bytes()
     assert (
-        tool_shim_contract.main(
-            [
-                "--repo-root",
-                str(tool_root),
-                "--baseline",
-                str(tool_baseline),
-                "--update",
-            ]
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: len(
+                (tools_dir / "added.py").read_text(encoding="utf-8").splitlines()
+            )
+            > 40,
+            baseline_state=tool_baseline.read_bytes,
+            update=lambda: tool_shim_contract.main(
+                [
+                    "--repo-root",
+                    str(tool_root),
+                    "--baseline",
+                    str(tool_baseline),
+                    "--update",
+                ]
+            ),
         )
         == 1
     )
-    assert tool_baseline.read_bytes() == tool_before
 
     update_paths = baseline_update_contract.monotonic_update_paths(ROOT)
     assert update_paths == {
@@ -453,8 +495,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     proof_file.parent.mkdir(parents=True)
     proof_file.write_text("def test_missing():\n    assert True\n", encoding="utf-8")
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: behavioral proof does not assert the "
-        "updater's --update path: tests/tooling/test_missing.py::test_missing"
+        "common/testing/synthetic.py: behavioral proof does not exercise synthetic "
+        "regression debt through the refusal harness: "
+        "tests/tooling/test_missing.py::test_missing"
     ]
 
     proof_file.write_text(
@@ -463,4 +506,45 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         '    assert synthetic.main(["--update"]) == 1\n',
         encoding="utf-8",
     )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py: behavioral proof does not exercise "
+        "synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing():\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: True,\n"
+        "        baseline_state=lambda: b'baseline',\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
     assert baseline_update_contract.proof_violations(synthetic_root) == []
+
+
+def test_AC_testing_governance_21_refusal_harness_enforces_its_preconditions() -> None:
+    state = {"baseline": b"before", "called": False}
+
+    def mutate_baseline() -> int:
+        state["called"] = True
+        state["baseline"] = b"after"
+        return 0
+
+    with pytest.raises(AssertionError, match="did not establish"):
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: False,
+            baseline_state=lambda: state["baseline"],
+            update=mutate_baseline,
+        )
+    assert state == {"baseline": b"before", "called": False}
+
+    with pytest.raises(AssertionError, match="adopted synthetic regression debt"):
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: True,
+            baseline_state=lambda: state["baseline"],
+            update=mutate_baseline,
+        )
+    assert state == {"baseline": b"after", "called": True}

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -174,13 +174,13 @@ def test_AC_testing_governance_18_baseline_mutation_flags_are_explicit(
         'BASELINE_UPDATE_MODE = "rewrite"\nparser.add_argument("--rewrite-baseline")\n',
         encoding="utf-8",
     )
-    assert baseline_update_contract.violations(tmp_path) == []
+    assert baseline_update_contract.declaration_violations(tmp_path) == []
 
     rewrite.write_text(
         'BASELINE_UPDATE_MODE = "rewrite"\nparser.add_argument("--update")\n',
         encoding="utf-8",
     )
-    findings = baseline_update_contract.violations(tmp_path)
+    findings = baseline_update_contract.declaration_violations(tmp_path)
     assert len(findings) == 1
     assert "rewrite mode must use --rewrite-baseline" in findings[0]
 
@@ -192,13 +192,17 @@ def test_AC_testing_governance_18_baseline_mutation_flags_are_explicit(
         'BASELINE_UPDATE_MODE = "grow"\nparser.add_argument("--update")\n',
         encoding="utf-8",
     )
+    (package / "manual_without_mode.py").write_text(
+        'def main(args):\n    if "--update" in args:\n        return 0\n',
+        encoding="utf-8",
+    )
     (package / "monotonic_rewrite.py").write_text(
         'BASELINE_UPDATE_MODE = "shrink-only"\n'
         'parser.add_argument("--rewrite-baseline")\n',
         encoding="utf-8",
     )
-    findings = baseline_update_contract.violations(tmp_path)
-    assert len(findings) == 4
+    findings = baseline_update_contract.declaration_violations(tmp_path)
+    assert len(findings) == 5
     assert any("has no mutation flag" in finding for finding in findings)
     assert any("requires BASELINE_UPDATE_MODE" in finding for finding in findings)
     assert any("--rewrite-baseline requires" in finding for finding in findings)
@@ -391,11 +395,43 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     )
     assert tool_baseline.read_bytes() == tool_before
 
-    assert baseline_update_contract.monotonic_update_paths(ROOT) == {
+    update_paths = baseline_update_contract.monotonic_update_paths(ROOT)
+    assert update_paths == {
         "common/meta/extension/check_ac_tier_baseline.py",
         "common/meta/extension/check_app_boundary.py",
+        "common/testing/api_surface_ratchet.py",
         "common/testing/check_ac_score_baseline.py",
         "common/testing/check_cas" + "sette_graded_eval.py",
+        "common/testing/check_critical_value_proof.py",
+        "common/testing/fe_api_handmock_ratchet.py",
+        "common/testing/fe_fetch_ratchet.py",
         "common/testing/gate_main_contract.py",
+        "common/testing/mirror_ratchet.py",
         "common/testing/tool_shim_contract.py",
     }
+    assert set(baseline_update_contract.MONOTONIC_UPDATE_PROOFS) == update_paths
+    assert baseline_update_contract.proof_violations(ROOT) == []
+
+    synthetic_root = tmp_path / "proof-contract"
+    synthetic_updater = synthetic_root / "common/testing/synthetic.py"
+    synthetic_updater.parent.mkdir(parents=True)
+    synthetic_updater.write_text(
+        'BASELINE_UPDATE_MODE = "shrink-only"\n'
+        'def main(args):\n    return 0 if "--update" in args else 1\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(baseline_update_contract, "MONOTONIC_UPDATE_PROOFS", {})
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py: monotonic --update path lacks a behavioral "
+        "regression proof"
+    ]
+
+    monkeypatch.setattr(
+        baseline_update_contract,
+        "MONOTONIC_UPDATE_PROOFS",
+        {"common/testing/synthetic.py": "tests/tooling/test_missing.py::test_missing"},
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py: behavioral proof node does not exist: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]

--- a/tests/tooling/test_s4_runtime_github_api.py
+++ b/tests/tooling/test_s4_runtime_github_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import io
 import json
 import urllib.error
@@ -17,7 +18,10 @@ from common.runtime import (
     release_images,
 )
 from common.runtime import wait_post_merge_train_turn as train_wait
-from common.testing import wait_for_cheap_ci
+from common.testing import github_workflow_timing_summary, wait_for_cheap_ci
+from tools import app_deploy_transport
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_AC_runtime_github_api_1_runtime_and_testing_share_github_helpers(
@@ -34,6 +38,30 @@ def test_AC_runtime_github_api_1_runtime_and_testing_share_github_helpers(
     assert release_evidence._write_github_output is github_api.write_github_output
     assert release_images._write_github_output is github_api.write_github_output
     assert release_coordinate.write_github_output is github_api.write_github_output
+    assert (
+        github_workflow_timing_summary.parse_github_time is github_api.parse_github_time
+    )
+    assert app_deploy_transport.write_github_output is github_api.write_github_output
+
+    helper_definitions: dict[str, list[str]] = {
+        "parse_github_time": [],
+        "write_github_output": [],
+        "_write_github_output": [],
+    }
+    for root_name in ("common", "tools"):
+        for path in sorted((ROOT / root_name).rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.name in helper_definitions:
+                        helper_definitions[node.name].append(
+                            path.relative_to(ROOT).as_posix()
+                        )
+    assert helper_definitions == {
+        "parse_github_time": ["common/runtime/github_api.py"],
+        "write_github_output": ["common/runtime/github_api.py"],
+        "_write_github_output": [],
+    }
 
     assert github_api.parse_github_time("2026-07-15T12:00:00Z") == datetime(
         2026, 7, 15, 12, tzinfo=UTC

--- a/tools/app_deploy_transport.py
+++ b/tools/app_deploy_transport.py
@@ -20,6 +20,7 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+from common.runtime.github_api import write_github_output  # noqa: E402
 from tools.app_deploy_request import request_from_mapping  # noqa: E402
 
 INFRA_REPOSITORY = "wangzitian0/infra2"
@@ -160,15 +161,6 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _write_github_output(result: ReceiverRun) -> None:
-    output_path = os.getenv("GITHUB_OUTPUT")
-    if not output_path:
-        return
-    with open(output_path, "a", encoding="utf-8") as output:
-        print(f"receiver_run_id={result.run_id}", file=output)
-        print(f"receiver_run_url={result.url}", file=output)
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     token = os.getenv(args.token_env, "")
@@ -214,7 +206,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (ValueError, RuntimeError, httpx.HTTPError, json.JSONDecodeError) as exc:
         print(f"app deploy transport failed: {exc}", file=sys.stderr)
         return 1
-    _write_github_output(result)
+    write_github_output(
+        {"receiver_run_id": str(result.run_id), "receiver_run_url": result.url}
+    )
     print(
         json.dumps({"receiver_run_id": result.run_id, "receiver_run_url": result.url})
     )


### PR DESCRIPTION
Part of #1867

## Scope

- behaviorally drive every real monotonic baseline updater against synthetic regression debt
- make the updater census fail when a new `--update` path lacks proof
- single-home the remaining GitHub timestamp parser and `GITHUB_OUTPUT` writer
- preserve timing-summary and app-deploy transport behavior

## Root cause

The original S4 contracts proved mutation-mode declarations and selected shared-helper consumers, but did not enumerate every real updater or scan the full `common/` + `tools/` helper-definition surface. A later deploy transport therefore retained a private output writer, while the workflow timing helper retained its parser.

## Why gates missed it

`baseline_update_contract` was structural only: a module could declare `shrink-only` without a test driving its update behavior. The GitHub helper test asserted the original release/wait consumers but had no definition census, so out-of-scope or later consumers were invisible.

## Proof added

- `AC-testing.governance.21` drives all six real `--update` paths with synthetic debt and locks the dynamic path census.
- `AC-runtime.github-api.1` now scans `common/` and `tools/` and requires exactly one timestamp parser and output writer definition.

## Verification

- 33 focused S4/deploy/timing tests passed
- changed modules: 98% scoped coverage
- `moon run :lint`
- pinned-Ruff static preflight
- AC index, dual-home, package-contract, baseline-update, gate-main, and tool-shim gates

## Known residuals

This bounded review fix does not claim zero historical debt: 75 legacy main signatures, 25 shared-runner bypasses, and 11 fat top-level tools remain protected by shrink-only baselines. Those residuals keep #1867 open.