### PR TITLE
[finance_report_ui] Close late S4 updater review gaps

### DIFF
--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -71,16 +71,18 @@ signature or shared-runner debt and permits its checked-in baseline to shrink
 only.
 
 Baseline mutation is explicit and machine-checked by
-`baseline_update_contract.py`. `--update` is reserved for `raise-only` or
-`shrink-only` mutation. A command that can replace an entire baseline must
-declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the deliberately louder
-`--rewrite-baseline` flag. Its monotonic-updater census recognizes both
+`baseline_update_contract.py`. The `--update` / `--update-*` monotonic mutation
+family (including specialized flags such as `--update-floor`) is reserved for
+`raise-only` or `shrink-only` mutation. A command that can replace an entire
+baseline must declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the
+deliberately louder `--rewrite-baseline` flag. The updater census recognizes both
 `argparse` declarations and manual argument-membership checks, resolving simple
 module-level string constants in both forms. Every path must map to a live test
-node that uses `assert_regression_debt_refused` to establish synthetic debt,
-snapshot the baseline, invoke that updater's `main` with `--update`, and prove
-the baseline remains unchanged. A newly added `--update` path therefore cannot
-be covered by a declaration, an unrelated test name, or a happy-path call alone.
+node that uses `assert_regression_debt_refused` with non-vacuous debt and
+baseline-state observers, invokes that updater's `main` with its mutation flag,
+and proves the baseline remains unchanged. A new mutation path therefore cannot
+be covered by a declaration, an unrelated test name, constant callbacks, or a
+happy-path call.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -77,12 +77,13 @@ family (including specialized flags such as `--update-floor`) is reserved for
 baseline must declare `BASELINE_UPDATE_MODE = "rewrite"` and expose the
 deliberately louder `--rewrite-baseline` flag. The updater census recognizes both
 `argparse` declarations and manual argument-membership checks, resolving simple
-module-level string constants in both forms. Every path must map to a live test
-node that uses `assert_regression_debt_refused` with non-vacuous debt and
-baseline-state observers, invokes that updater's `main` with its mutation flag,
-and proves the baseline remains unchanged. A new mutation path therefore cannot
-be covered by a declaration, an unrelated test name, constant callbacks, or a
-happy-path call.
+module-level string constants in both forms. Every `(module, mutation flag)`
+command must map to a live test node that uses
+`assert_regression_debt_refused` with non-vacuous debt and baseline-state
+observers, invokes that updater's `main` with that exact flag, and proves the
+baseline remains unchanged. A new mutation command therefore cannot be covered
+by a declaration, another flag's proof, an unrelated test name, constant
+callbacks, or a happy-path call.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -575,6 +575,7 @@ def _expression_uses_runtime_state(
     *,
     observer_function: TestFunction | None = None,
     include_unmutated_containers: bool = False,
+    seen_functions: frozenset[tuple[int, int]] = frozenset(),
 ) -> bool:
     if _static_result(expression) is not _UNKNOWN_RESULT:
         return False
@@ -587,16 +588,59 @@ def _expression_uses_runtime_state(
             observer_function,
             include_unmutated_containers=include_unmutated_containers,
         )
+    named_calls: dict[str, TestFunction] = {}
+    for node in ast.walk(expression):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        called_function = _named_observer_function(node.func.id, tree, function)
+        if called_function is not None:
+            named_calls[node.func.id] = called_function
     referenced -= (
         literal_names
         | _OBSERVER_BUILTINS
+        | named_calls.keys()
         | _literal_local_names(
             function,
             include_unmutated_containers=include_unmutated_containers,
         )
         | _literal_module_names(tree)
     )
-    return bool(referenced)
+    return bool(referenced) or any(
+        _function_uses_runtime_state(
+            called_function,
+            tree,
+            function,
+            include_unmutated_containers=include_unmutated_containers,
+            seen_functions=seen_functions,
+        )
+        for called_function in named_calls.values()
+    )
+
+
+def _function_uses_runtime_state(
+    observer_function: TestFunction,
+    tree: ast.Module,
+    function: TestFunction,
+    *,
+    include_unmutated_containers: bool,
+    seen_functions: frozenset[tuple[int, int]] = frozenset(),
+) -> bool:
+    function_key = (observer_function.lineno, observer_function.col_offset)
+    if function_key in seen_functions or _has_arguments(observer_function):
+        return False
+    return_values = _return_values(observer_function)
+    next_seen = seen_functions | {function_key}
+    return bool(return_values) and all(
+        _expression_uses_runtime_state(
+            value,
+            tree,
+            function,
+            observer_function=observer_function,
+            include_unmutated_containers=include_unmutated_containers,
+            seen_functions=next_seen,
+        )
+        for value in return_values
+    )
 
 
 def _observer_uses_runtime_state(
@@ -608,18 +652,13 @@ def _observer_uses_runtime_state(
 ) -> bool:
     if isinstance(observer, ast.Name):
         observer_function = _named_observer_function(observer.id, tree, function)
-        if observer_function is None or _has_arguments(observer_function):
+        if observer_function is None:
             return False
-        return_values = _return_values(observer_function)
-        return bool(return_values) and all(
-            _expression_uses_runtime_state(
-                value,
-                tree,
-                function,
-                observer_function=observer_function,
-                include_unmutated_containers=include_unmutated_containers,
-            )
-            for value in return_values
+        return _function_uses_runtime_state(
+            observer_function,
+            tree,
+            function,
+            include_unmutated_containers=include_unmutated_containers,
         )
     if isinstance(observer, ast.Lambda) and _has_arguments(observer):
         return False

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -385,7 +385,7 @@ def _destructured_literal_names(target: ast.expr, value: ast.expr) -> set[str]:
 
 class _FunctionScopeVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
-        self.assignments: list[ast.Assign | ast.AnnAssign] = []
+        self.assignments: list[ast.Assign | ast.AnnAssign | ast.AugAssign] = []
         self.functions: list[TestFunction] = []
         self.return_values: list[ast.expr] = []
 
@@ -394,6 +394,10 @@ class _FunctionScopeVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.assignments.append(node)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
         self.assignments.append(node)
         self.generic_visit(node)
 
@@ -423,7 +427,7 @@ def _function_scope(function: TestFunction) -> _FunctionScopeVisitor:
 
 def _scoped_assignments(
     function: TestFunction,
-) -> list[ast.Assign | ast.AnnAssign]:
+) -> list[ast.Assign | ast.AnnAssign | ast.AugAssign]:
     return _function_scope(function).assignments
 
 
@@ -484,7 +488,22 @@ def _literal_local_names(
 ) -> set[str]:
     names: set[str] = set()
     mutated_names = _mutated_local_names(function)
+    direct_assignments = {
+        id(node)
+        for node in function.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+    }
     for node in _scoped_assignments(function):
+        targets: list[ast.expr]
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        else:
+            targets = [node.target]
+        bound_names = {name for target in targets for name in _bound_names(target)}
+        if id(node) in direct_assignments:
+            names.difference_update(bound_names)
+        if isinstance(node, ast.AugAssign):
+            continue
         if isinstance(node, ast.Assign):
             if len(node.targets) > 1:
                 try:
@@ -527,8 +546,13 @@ def _literal_module_names(tree: ast.Module) -> set[str]:
             targets, value = node.targets, node.value
         elif isinstance(node, ast.AnnAssign):
             targets, value = [node.target], node.value
+        elif isinstance(node, ast.AugAssign):
+            names.difference_update(_bound_names(node.target))
+            continue
         if value is None:
             continue
+        bound_names = {name for target in targets for name in _bound_names(target)}
+        names.difference_update(bound_names)
         try:
             ast.literal_eval(value)
         except (ValueError, TypeError):

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -383,9 +383,43 @@ def _destructured_literal_names(target: ast.expr, value: ast.expr) -> set[str]:
     }
 
 
+class _ScopedAssignmentVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.assignments: list[ast.Assign | ast.AnnAssign] = []
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.assignments.append(node)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.assignments.append(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+
+def _scoped_assignments(
+    function: TestFunction,
+) -> list[ast.Assign | ast.AnnAssign]:
+    visitor = _ScopedAssignmentVisitor()
+    for statement in function.body:
+        visitor.visit(statement)
+    return visitor.assignments
+
+
 def _literal_local_names(function: TestFunction) -> set[str]:
     names: set[str] = set()
-    for node in function.body:
+    for node in _scoped_assignments(function):
         if isinstance(node, ast.Assign):
             if len(node.targets) > 1:
                 try:
@@ -491,7 +525,17 @@ def _executed_string_value(node: ast.expr, constants: dict[str, str]) -> str | N
     return _string_value(node, constants)
 
 
-def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str]:
+def _is_explicit_non_option_value(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+        and len(node.args) == 1
+        and not node.keywords
+    )
+
+
+def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str] | None:
     argv = (
         call.args[0]
         if call.args
@@ -500,12 +544,15 @@ def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str]:
         )
     )
     if not isinstance(argv, (ast.List, ast.Tuple)):
-        return []
-    return [
-        value
-        for element in argv.elts
-        if (value := _executed_string_value(element, constants)) is not None
-    ]
+        return None
+    values: list[str] = []
+    for element in argv.elts:
+        value = _executed_string_value(element, constants)
+        if value is not None:
+            values.append(value)
+        elif not _is_explicit_non_option_value(element):
+            return None
+    return values
 
 
 def _proof_status(
@@ -555,10 +602,11 @@ def _proof_status(
                 and call.func.attr == "main"
             ):
                 continue
+            argv_strings = _call_argv_strings(call, proof_constants)
+            if argv_strings is None:
+                continue
             invocation_flags = [
-                value
-                for value in _call_argv_strings(call, proof_constants)
-                if _is_monotonic_mutation_flag(value)
+                value for value in argv_strings if _is_monotonic_mutation_flag(value)
             ]
             if invocation_flags == [mutation_flag]:
                 updater_is_bound = True

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -343,6 +343,7 @@ _OBSERVER_BUILTINS = frozenset(
         "tuple",
     }
 )
+_UNKNOWN_RESULT = object()
 
 
 def _bound_names(target: ast.expr) -> set[str]:
@@ -433,6 +434,9 @@ def _observer_uses_runtime_state(
 ) -> bool:
     if isinstance(observer, ast.Name):
         return False
+    expression = observer.body if isinstance(observer, ast.Lambda) else observer
+    if _static_result(expression) is not _UNKNOWN_RESULT:
+        return False
     lambda_arguments: set[str] = set()
     if isinstance(observer, ast.Lambda):
         lambda_arguments = {argument.arg for argument in observer.args.args}
@@ -446,6 +450,36 @@ def _observer_uses_runtime_state(
     return bool(referenced)
 
 
+def _static_result(node: ast.expr) -> object:
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        pass
+    if isinstance(node, ast.IfExp):
+        condition = _static_result(node.test)
+        if condition is not _UNKNOWN_RESULT:
+            return _static_result(node.body if condition else node.orelse)
+        body = _static_result(node.body)
+        alternative = _static_result(node.orelse)
+        if (
+            body is not _UNKNOWN_RESULT
+            and alternative is not _UNKNOWN_RESULT
+            and body == alternative
+        ):
+            return body
+    elif isinstance(node, ast.BoolOp):
+        for value_node in node.values[:-1]:
+            value = _static_result(value_node)
+            if value is _UNKNOWN_RESULT:
+                return _UNKNOWN_RESULT
+            if (isinstance(node.op, ast.Or) and value) or (
+                isinstance(node.op, ast.And) and not value
+            ):
+                return value
+        return _static_result(node.values[-1])
+    return _UNKNOWN_RESULT
+
+
 def _executed_string_value(node: ast.expr, constants: dict[str, str]) -> str | None:
     if isinstance(node, ast.IfExp):
         try:
@@ -457,7 +491,7 @@ def _executed_string_value(node: ast.expr, constants: dict[str, str]) -> str | N
     return _string_value(node, constants)
 
 
-def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> set[str]:
+def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str]:
     argv = (
         call.args[0]
         if call.args
@@ -466,12 +500,12 @@ def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> set[str]:
         )
     )
     if not isinstance(argv, (ast.List, ast.Tuple)):
-        return set()
-    return {
+        return []
+    return [
         value
         for element in argv.elts
         if (value := _executed_string_value(element, constants)) is not None
-    }
+    ]
 
 
 def _proof_status(
@@ -521,7 +555,12 @@ def _proof_status(
                 and call.func.attr == "main"
             ):
                 continue
-            if mutation_flag in _call_argv_strings(call, proof_constants):
+            invocation_flags = [
+                value
+                for value in _call_argv_strings(call, proof_constants)
+                if _is_monotonic_mutation_flag(value)
+            ]
+            if invocation_flags == [mutation_flag]:
                 updater_is_bound = True
                 break
         if not updater_is_bound:

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -345,17 +345,67 @@ _OBSERVER_BUILTINS = frozenset(
 )
 
 
+def _bound_names(target: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return {name for element in target.elts for name in _bound_names(element)}
+    if isinstance(target, ast.Starred):
+        return _bound_names(target.value)
+    return set()
+
+
+def _destructured_literal_names(target: ast.expr, value: ast.expr) -> set[str]:
+    if isinstance(target, ast.Name):
+        try:
+            ast.literal_eval(value)
+        except (ValueError, TypeError):
+            return set()
+        return {target.id}
+    if isinstance(target, (ast.List, ast.Tuple)):
+        try:
+            ast.literal_eval(value)
+        except (ValueError, TypeError):
+            pass
+        else:
+            return _bound_names(target)
+    if not (
+        isinstance(target, (ast.List, ast.Tuple))
+        and isinstance(value, (ast.List, ast.Tuple))
+        and len(target.elts) == len(value.elts)
+    ):
+        return set()
+    return {
+        name
+        for target_element, value_element in zip(target.elts, value.elts, strict=True)
+        for name in _destructured_literal_names(target_element, value_element)
+    }
+
+
 def _literal_local_names(function: TestFunction) -> set[str]:
     names: set[str] = set()
     for node in function.body:
-        target: ast.expr | None = None
-        value: ast.expr | None = None
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target, value = node.targets[0], node.value
-        elif isinstance(node, ast.AnnAssign):
-            target, value = node.target, node.value
-        if isinstance(target, ast.Name) and isinstance(value, ast.Constant):
-            names.add(target.id)
+        if isinstance(node, ast.Assign):
+            if len(node.targets) > 1:
+                try:
+                    ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    continue
+                names.update(
+                    name for target in node.targets for name in _bound_names(target)
+                )
+            elif isinstance(node.targets[0], (ast.List, ast.Tuple)):
+                names.update(_destructured_literal_names(node.targets[0], node.value))
+            elif isinstance(node.targets[0], ast.Name) and isinstance(
+                node.value, ast.Constant
+            ):
+                names.add(node.targets[0].id)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and isinstance(node.value, ast.Constant)
+        ):
+            names.add(node.target.id)
     return names
 
 
@@ -374,7 +424,7 @@ def _literal_module_names(tree: ast.Module) -> set[str]:
             ast.literal_eval(value)
         except (ValueError, TypeError):
             continue
-        names.update(target.id for target in targets if isinstance(target, ast.Name))
+        names.update(name for target in targets for name in _bound_names(target))
     return names
 
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -15,7 +15,6 @@ REWRITE_MODE = "rewrite"
 VALID_MODES = MONOTONIC_MODES | {REWRITE_MODE}
 UPDATE_FLAG = "--" + "update"
 REWRITE_FLAG = "--rewrite-" + "baseline"
-MUTATION_FLAGS = frozenset({UPDATE_FLAG, REWRITE_FLAG})
 PROOF_HARNESS_MODULE = "common.testing.baseline_update_contract"
 PROOF_HARNESS_NAME = "assert_regression_debt_refused"
 
@@ -37,6 +36,10 @@ MONOTONIC_UPDATE_PROOFS = {
     "common/testing/check_ac_score_baseline.py": (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
+    ),
+    "common/testing/check_ac_index.py": (
+        "tests/tooling/test_ac_index_consistency.py"
+        "::test_AC8_13_140_update_floor_raises_floors"
     ),
     "common/testing/check_cassette_graded_eval.py": (
         "tests/tooling/test_s4_gate_contracts.py"
@@ -148,6 +151,14 @@ def _is_argument_sequence(node: ast.expr) -> bool:
     )
 
 
+def _is_monotonic_mutation_flag(value: str | None) -> bool:
+    return value == UPDATE_FLAG or bool(value and value.startswith(f"{UPDATE_FLAG}-"))
+
+
+def _is_mutation_flag(value: str | None) -> bool:
+    return _is_monotonic_mutation_flag(value) or value == REWRITE_FLAG
+
+
 def _mutation_flags(tree: ast.Module) -> set[str]:
     constants = _module_string_constants(tree)
     flags: set[str] = set()
@@ -160,11 +171,11 @@ def _mutation_flags(tree: ast.Module) -> set[str]:
             flags.update(
                 value
                 for arg in node.args
-                if (value := _string_value(arg, constants)) in MUTATION_FLAGS
+                if _is_mutation_flag(value := _string_value(arg, constants))
             )
         elif isinstance(node, ast.Compare):
             value = _string_value(node.left, constants)
-            if value not in MUTATION_FLAGS:
+            if not _is_mutation_flag(value):
                 continue
             if any(
                 isinstance(operator, (ast.In, ast.NotIn))
@@ -186,7 +197,7 @@ def monotonic_update_paths(repo_root: Path) -> set[str]:
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             if (
-                UPDATE_FLAG in _mutation_flags(tree)
+                any(_is_monotonic_mutation_flag(flag) for flag in _mutation_flags(tree))
                 and _declared_mode(tree) in MONOTONIC_MODES
             ):
                 paths.add(path.relative_to(repo_root).as_posix())
@@ -222,6 +233,17 @@ def declaration_violations(repo_root: Path) -> list[str]:
             if UPDATE_FLAG in flags and mode not in MONOTONIC_MODES:
                 findings.append(
                     f"{relative}: rewrite mode must use --rewrite-baseline, not --update"
+                )
+            specialized = {
+                flag
+                for flag in flags
+                if flag != UPDATE_FLAG and _is_monotonic_mutation_flag(flag)
+            }
+            if specialized and mode not in MONOTONIC_MODES:
+                findings.append(
+                    f"{relative}: monotonic mutation flag(s) "
+                    f"{', '.join(sorted(specialized))} require "
+                    "BASELINE_UPDATE_MODE = 'raise-only' or 'shrink-only'"
                 )
             if REWRITE_FLAG in flags and mode != REWRITE_MODE:
                 findings.append(
@@ -295,14 +317,59 @@ def _updater_aliases(
     return aliases
 
 
-def _proof_exercises_updater(
-    tree: ast.Module, function: TestFunction, source_path: str
-) -> bool:
+_OBSERVER_BUILTINS = frozenset(
+    {
+        "all",
+        "any",
+        "bool",
+        "bytes",
+        "dict",
+        "frozenset",
+        "int",
+        "len",
+        "list",
+        "set",
+        "str",
+        "tuple",
+    }
+)
+
+
+def _literal_local_names(function: TestFunction) -> set[str]:
+    names: set[str] = set()
+    for node in function.body:
+        target: ast.expr | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign):
+            target, value = node.target, node.value
+        if isinstance(target, ast.Name) and isinstance(value, ast.Constant):
+            names.add(target.id)
+    return names
+
+
+def _observer_uses_runtime_state(observer: ast.expr, function: TestFunction) -> bool:
+    lambda_arguments: set[str] = set()
+    if isinstance(observer, ast.Lambda):
+        lambda_arguments = {argument.arg for argument in observer.args.args}
+    referenced = {node.id for node in ast.walk(observer) if isinstance(node, ast.Name)}
+    referenced -= lambda_arguments | _OBSERVER_BUILTINS | _literal_local_names(function)
+    return bool(referenced)
+
+
+def _proof_status(
+    tree: ast.Module,
+    function: TestFunction,
+    source_path: str,
+    mutation_flags: set[str],
+) -> str:
     module_name = Path(source_path).with_suffix("").as_posix().replace("/", ".")
     updater_aliases = _updater_aliases(tree, function, module_name)
     harness_aliases = _updater_aliases(tree, function, PROOF_HARNESS_MODULE)
     if not updater_aliases or not harness_aliases:
-        return False
+        return "missing-harness"
+    saw_bound_updater = False
     for harness_call in ast.walk(function):
         if not isinstance(harness_call, ast.Call):
             continue
@@ -323,6 +390,7 @@ def _proof_exercises_updater(
         )
         if update_argument is None:
             continue
+        updater_is_bound = False
         for call in ast.walk(update_argument):
             if not isinstance(call, ast.Call):
                 continue
@@ -334,11 +402,26 @@ def _proof_exercises_updater(
             ):
                 continue
             if any(
-                isinstance(node, ast.Constant) and node.value == UPDATE_FLAG
+                isinstance(node, ast.Constant) and node.value in mutation_flags
                 for node in ast.walk(call)
             ):
-                return True
-    return False
+                updater_is_bound = True
+                break
+        if not updater_is_bound:
+            continue
+        saw_bound_updater = True
+        observers = {
+            keyword.arg: keyword.value
+            for keyword in harness_call.keywords
+            if keyword.arg in {"regression_debt_present", "baseline_state"}
+        }
+        if all(
+            name in observers
+            and _observer_uses_runtime_state(observers[name], function)
+            for name in ("regression_debt_present", "baseline_state")
+        ):
+            return "valid"
+    return "vacuous-observers" if saw_bound_updater else "missing-harness"
 
 
 def proof_violations(repo_root: Path) -> list[str]:
@@ -360,10 +443,24 @@ def proof_violations(repo_root: Path) -> list[str]:
         if test_node is None:
             findings.append(f"{path}: behavioral proof node does not exist: {node_id}")
             continue
-        if not _proof_exercises_updater(*test_node, path):
+        source_tree = ast.parse(
+            (repo_root / path).read_text(encoding="utf-8"), filename=path
+        )
+        mutation_flags = {
+            flag
+            for flag in _mutation_flags(source_tree)
+            if _is_monotonic_mutation_flag(flag)
+        }
+        proof_status = _proof_status(*test_node, path, mutation_flags)
+        if proof_status == "missing-harness":
             findings.append(
                 f"{path}: behavioral proof does not exercise synthetic regression "
                 f"debt through the refusal harness: {node_id}"
+            )
+        elif proof_status == "vacuous-observers":
+            findings.append(
+                f"{path}: behavioral proof uses constant or vacuous "
+                f"regression-debt observers: {node_id}"
             )
     return findings
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -592,6 +592,34 @@ def _has_arguments(function: TestFunction | ast.Lambda) -> bool:
     )
 
 
+def _expanded_function_references(
+    names: set[str], observer_function: TestFunction | None
+) -> set[str]:
+    if observer_function is None:
+        return names
+    dependencies: dict[str, set[str]] = {}
+    for node in observer_function.body:
+        target: ast.expr | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign):
+            target, value = node.target, node.value
+        if not isinstance(target, ast.Name) or value is None:
+            continue
+        dependencies[target.id] = {
+            child.id for child in ast.walk(value) if isinstance(child, ast.Name)
+        }
+    expanded = set(names)
+    pending = list(names)
+    while pending:
+        name = pending.pop()
+        for dependency in dependencies.get(name, set()) - expanded:
+            expanded.add(dependency)
+            pending.append(dependency)
+    return expanded
+
+
 def _expression_uses_runtime_state(
     expression: ast.expr,
     tree: ast.Module,
@@ -599,6 +627,7 @@ def _expression_uses_runtime_state(
     *,
     observer_function: TestFunction | None = None,
     include_unmutated_containers: bool = False,
+    required_names: frozenset[str] | None = None,
     seen_functions: frozenset[tuple[int, int]] = frozenset(),
 ) -> bool:
     if _static_result(expression) is not _UNKNOWN_RESULT:
@@ -629,12 +658,17 @@ def _expression_uses_runtime_state(
         )
         | _literal_module_names(tree)
     )
-    return bool(referenced) or any(
+    referenced = _expanded_function_references(referenced, observer_function)
+    directly_uses_state = bool(
+        referenced if required_names is None else referenced & required_names
+    )
+    return directly_uses_state or any(
         _function_uses_runtime_state(
             called_function,
             tree,
             function,
             include_unmutated_containers=include_unmutated_containers,
+            required_names=required_names,
             seen_functions=seen_functions,
         )
         for called_function in named_calls.values()
@@ -647,6 +681,7 @@ def _function_uses_runtime_state(
     function: TestFunction,
     *,
     include_unmutated_containers: bool,
+    required_names: frozenset[str] | None = None,
     seen_functions: frozenset[tuple[int, int]] = frozenset(),
 ) -> bool:
     function_key = (observer_function.lineno, observer_function.col_offset)
@@ -661,6 +696,7 @@ def _function_uses_runtime_state(
             function,
             observer_function=observer_function,
             include_unmutated_containers=include_unmutated_containers,
+            required_names=required_names,
             seen_functions=next_seen,
         )
         for value in return_values
@@ -673,6 +709,7 @@ def _observer_uses_runtime_state(
     function: TestFunction,
     *,
     include_unmutated_containers: bool,
+    required_names: frozenset[str] | None = None,
 ) -> bool:
     if isinstance(observer, ast.Name):
         observer_function = _named_observer_function(observer.id, tree, function)
@@ -683,6 +720,7 @@ def _observer_uses_runtime_state(
             tree,
             function,
             include_unmutated_containers=include_unmutated_containers,
+            required_names=required_names,
         )
     if isinstance(observer, ast.Lambda) and _has_arguments(observer):
         return False
@@ -692,6 +730,7 @@ def _observer_uses_runtime_state(
         tree,
         function,
         include_unmutated_containers=include_unmutated_containers,
+        required_names=required_names,
     )
 
 
@@ -746,14 +785,18 @@ def _is_explicit_non_option_value(node: ast.expr) -> bool:
     )
 
 
-def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str] | None:
-    argv = (
+def _call_argv_node(call: ast.Call) -> ast.expr | None:
+    return (
         call.args[0]
         if call.args
         else next(
             (keyword.value for keyword in call.keywords if keyword.arg == "argv"), None
         )
     )
+
+
+def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str] | None:
+    argv = _call_argv_node(call)
     if not isinstance(argv, (ast.List, ast.Tuple)):
         return None
     values: list[str] = []
@@ -764,6 +807,53 @@ def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> list[str] |
         elif not _is_explicit_non_option_value(element):
             return None
     return values
+
+
+def _node_names(node: ast.AST) -> set[str]:
+    return {child.id for child in ast.walk(node) if isinstance(child, ast.Name)}
+
+
+def _updater_baseline_names(
+    function: TestFunction,
+    updater_call: ast.Call,
+    updater_aliases: set[str],
+    constants: dict[str, str],
+) -> frozenset[str]:
+    names: set[str] = set()
+    argv = _call_argv_node(updater_call)
+    if isinstance(argv, (ast.List, ast.Tuple)):
+        for option_node, value_node in zip(argv.elts, argv.elts[1:]):
+            option = _executed_string_value(option_node, constants)
+            if option is not None and any(
+                token in option.lower() for token in ("baseline", "floor")
+            ):
+                names.update(_node_names(value_node))
+
+    mutated_names = _mutated_local_names(function)
+    for call in ast.walk(function):
+        if not (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "setattr"
+            and len(call.args) >= 3
+            and isinstance(call.args[0], ast.Name)
+            and call.args[0].id in updater_aliases
+        ):
+            continue
+        attribute = _executed_string_value(call.args[1], constants)
+        if attribute is None:
+            continue
+        value = call.args[2]
+        value_names = _node_names(value)
+        if isinstance(value, ast.Lambda):
+            value_names -= {argument.arg for argument in value.args.args}
+        attribute = attribute.lower()
+        if "baseline" in attribute or "floor" in attribute:
+            names.update(value_names)
+        elif attribute.startswith(("dump", "write")):
+            names.update(value_names & mutated_names)
+    names -= updater_aliases | _OBSERVER_BUILTINS | {"monkeypatch"}
+    return frozenset(names)
 
 
 def _proof_status(
@@ -802,7 +892,7 @@ def _proof_status(
         )
         if update_argument is None:
             continue
-        updater_is_bound = False
+        bound_updater_call: ast.Call | None = None
         for call in ast.walk(update_argument):
             if not isinstance(call, ast.Call):
                 continue
@@ -820,11 +910,17 @@ def _proof_status(
                 value for value in argv_strings if _is_monotonic_mutation_flag(value)
             ]
             if invocation_flags == [mutation_flag]:
-                updater_is_bound = True
+                bound_updater_call = call
                 break
-        if not updater_is_bound:
+        if bound_updater_call is None:
             continue
         saw_bound_updater = True
+        baseline_names = _updater_baseline_names(
+            function,
+            bound_updater_call,
+            updater_aliases,
+            proof_constants,
+        )
         observers = {
             keyword.arg: keyword.value
             for keyword in harness_call.keywords
@@ -837,6 +933,7 @@ def _proof_status(
                 tree,
                 function,
                 include_unmutated_containers=name == "baseline_state",
+                required_names=baseline_names if name == "baseline_state" else None,
             )
             for name in ("regression_debt_present", "baseline_state")
         ):

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -19,53 +19,54 @@ PROOF_HARNESS_MODULE = "common.testing.baseline_update_contract"
 PROOF_HARNESS_NAME = "assert_regression_debt_refused"
 
 Result = TypeVar("Result")
+UpdateCommand = tuple[str, str]
 
 MONOTONIC_UPDATE_PROOFS = {
-    "common/meta/extension/check_ac_tier_baseline.py": (
+    ("common/meta/extension/check_ac_tier_baseline.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
-    "common/meta/extension/check_app_boundary.py": (
+    ("common/meta/extension/check_app_boundary.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
-    "common/testing/api_surface_ratchet.py": (
+    ("common/testing/api_surface_ratchet.py", UPDATE_FLAG): (
         "tests/tooling/test_api_surface_ratchet.py"
         "::test_router_ratchet_rejects_new_file_and_update_cannot_adopt_it"
     ),
-    "common/testing/check_ac_score_baseline.py": (
+    ("common/testing/check_ac_score_baseline.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
-    "common/testing/check_ac_index.py": (
+    ("common/testing/check_ac_index.py", f"{UPDATE_FLAG}-floor"): (
         "tests/tooling/test_ac_index_consistency.py"
         "::test_AC8_13_140_update_floor_raises_floors"
     ),
-    "common/testing/check_cassette_graded_eval.py": (
+    ("common/testing/check_cassette_graded_eval.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
-    "common/testing/check_critical_value_proof.py": (
+    ("common/testing/check_critical_value_proof.py", UPDATE_FLAG): (
         "tests/tooling/test_critical_value_proof_ratchet.py"
         "::test_baseline_only_shrinks_never_grows"
     ),
-    "common/testing/fe_api_handmock_ratchet.py": (
+    ("common/testing/fe_api_handmock_ratchet.py", UPDATE_FLAG): (
         "tests/tooling/test_fe_api_handmock_ratchet.py"
         "::test_AC_testing_fe_handmock_1_ratchet_is_locked_and_only_goes_down"
     ),
-    "common/testing/fe_fetch_ratchet.py": (
+    ("common/testing/fe_fetch_ratchet.py", UPDATE_FLAG): (
         "tests/tooling/test_fe_fetch_ratchet.py"
         "::test_AC_testing_fe_fetch_1_ratchet_is_locked_and_only_goes_down"
     ),
-    "common/testing/gate_main_contract.py": (
+    ("common/testing/gate_main_contract.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
-    "common/testing/mirror_ratchet.py": (
+    ("common/testing/mirror_ratchet.py", UPDATE_FLAG): (
         "tests/tooling/test_package_declaration_and_ratchet.py"
         "::test_AC8_24_3_mirror_assertion_ratchet_is_locked_and_only_goes_down"
     ),
-    "common/testing/tool_shim_contract.py": (
+    ("common/testing/tool_shim_contract.py", UPDATE_FLAG): (
         "tests/tooling/test_s4_gate_contracts.py"
         "::test_AC_testing_governance_21_real_updates_refuse_regression_debt"
     ),
@@ -186,22 +187,31 @@ def _mutation_flags(tree: ast.Module) -> set[str]:
     return flags
 
 
-def monotonic_update_paths(repo_root: Path) -> set[str]:
-    """Return every module that exposes a monotonic ``--update`` path."""
+def monotonic_update_commands(repo_root: Path) -> set[UpdateCommand]:
+    """Return every module/flag command in the monotonic mutation family."""
 
-    paths: set[str] = set()
+    commands: set[UpdateCommand] = set()
     for root_name in ("common", "tools"):
         root = repo_root / root_name
         if not root.exists():
             continue
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            if (
-                any(_is_monotonic_mutation_flag(flag) for flag in _mutation_flags(tree))
-                and _declared_mode(tree) in MONOTONIC_MODES
-            ):
-                paths.add(path.relative_to(repo_root).as_posix())
-    return paths
+            if _declared_mode(tree) not in MONOTONIC_MODES:
+                continue
+            relative = path.relative_to(repo_root).as_posix()
+            commands.update(
+                (relative, flag)
+                for flag in _mutation_flags(tree)
+                if _is_monotonic_mutation_flag(flag)
+            )
+    return commands
+
+
+def monotonic_update_paths(repo_root: Path) -> set[str]:
+    """Return modules exposing any monotonic ``--update``/``--update-*`` flag."""
+
+    return {path for path, _flag in monotonic_update_commands(repo_root)}
 
 
 def declaration_violations(repo_root: Path) -> list[str]:
@@ -349,12 +359,38 @@ def _literal_local_names(function: TestFunction) -> set[str]:
     return names
 
 
-def _observer_uses_runtime_state(observer: ast.expr, function: TestFunction) -> bool:
+def _literal_module_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        if value is None:
+            continue
+        try:
+            ast.literal_eval(value)
+        except (ValueError, TypeError):
+            continue
+        names.update(target.id for target in targets if isinstance(target, ast.Name))
+    return names
+
+
+def _observer_uses_runtime_state(
+    observer: ast.expr, tree: ast.Module, function: TestFunction
+) -> bool:
     lambda_arguments: set[str] = set()
     if isinstance(observer, ast.Lambda):
         lambda_arguments = {argument.arg for argument in observer.args.args}
     referenced = {node.id for node in ast.walk(observer) if isinstance(node, ast.Name)}
-    referenced -= lambda_arguments | _OBSERVER_BUILTINS | _literal_local_names(function)
+    referenced -= (
+        lambda_arguments
+        | _OBSERVER_BUILTINS
+        | _literal_local_names(function)
+        | _literal_module_names(tree)
+    )
     return bool(referenced)
 
 
@@ -362,7 +398,7 @@ def _proof_status(
     tree: ast.Module,
     function: TestFunction,
     source_path: str,
-    mutation_flags: set[str],
+    mutation_flag: str,
 ) -> str:
     module_name = Path(source_path).with_suffix("").as_posix().replace("/", ".")
     updater_aliases = _updater_aliases(tree, function, module_name)
@@ -402,7 +438,7 @@ def _proof_status(
             ):
                 continue
             if any(
-                isinstance(node, ast.Constant) and node.value in mutation_flags
+                isinstance(node, ast.Constant) and node.value == mutation_flag
                 for node in ast.walk(call)
             ):
                 updater_is_bound = True
@@ -417,7 +453,7 @@ def _proof_status(
         }
         if all(
             name in observers
-            and _observer_uses_runtime_state(observers[name], function)
+            and _observer_uses_runtime_state(observers[name], tree, function)
             for name in ("regression_debt_present", "baseline_state")
         ):
             return "valid"
@@ -425,41 +461,36 @@ def _proof_status(
 
 
 def proof_violations(repo_root: Path) -> list[str]:
-    """Return monotonic update paths without a live behavioral proof node."""
+    """Return monotonic mutation commands without an exact behavioral proof."""
 
-    update_paths = monotonic_update_paths(repo_root)
-    registered_paths = set(MONOTONIC_UPDATE_PROOFS)
+    update_commands = monotonic_update_commands(repo_root)
+    registered_commands = set(MONOTONIC_UPDATE_PROOFS)
     findings = [
-        f"{path}: monotonic --update path lacks a behavioral regression proof"
-        for path in sorted(update_paths - registered_paths)
+        f"{path} [{flag}]: monotonic mutation path lacks a behavioral regression proof"
+        for path, flag in sorted(update_commands - registered_commands)
     ]
     findings.extend(
-        f"{path}: behavioral proof is stale; no monotonic --update path exists"
-        for path in sorted(registered_paths - update_paths)
+        f"{path} [{flag}]: behavioral proof is stale; "
+        "no matching monotonic mutation command exists"
+        for path, flag in sorted(registered_commands - update_commands)
     )
-    for path in sorted(update_paths & registered_paths):
-        node_id = MONOTONIC_UPDATE_PROOFS[path]
+    for path, flag in sorted(update_commands & registered_commands):
+        node_id = MONOTONIC_UPDATE_PROOFS[(path, flag)]
         test_node = _test_node(repo_root, node_id)
         if test_node is None:
-            findings.append(f"{path}: behavioral proof node does not exist: {node_id}")
+            findings.append(
+                f"{path} [{flag}]: behavioral proof node does not exist: {node_id}"
+            )
             continue
-        source_tree = ast.parse(
-            (repo_root / path).read_text(encoding="utf-8"), filename=path
-        )
-        mutation_flags = {
-            flag
-            for flag in _mutation_flags(source_tree)
-            if _is_monotonic_mutation_flag(flag)
-        }
-        proof_status = _proof_status(*test_node, path, mutation_flags)
+        proof_status = _proof_status(*test_node, path, flag)
         if proof_status == "missing-harness":
             findings.append(
-                f"{path}: behavioral proof does not exercise synthetic regression "
-                f"debt through the refusal harness: {node_id}"
+                f"{path} [{flag}]: behavioral proof does not exercise synthetic "
+                f"regression debt through the refusal harness: {node_id}"
             )
         elif proof_status == "vacuous-observers":
             findings.append(
-                f"{path}: behavioral proof uses constant or vacuous "
+                f"{path} [{flag}]: behavioral proof uses constant or vacuous "
                 f"regression-debt observers: {node_id}"
             )
     return findings

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -431,6 +431,8 @@ def _literal_module_names(tree: ast.Module) -> set[str]:
 def _observer_uses_runtime_state(
     observer: ast.expr, tree: ast.Module, function: TestFunction
 ) -> bool:
+    if isinstance(observer, ast.Name):
+        return False
     lambda_arguments: set[str] = set()
     if isinstance(observer, ast.Lambda):
         lambda_arguments = {argument.arg for argument in observer.args.args}
@@ -444,6 +446,34 @@ def _observer_uses_runtime_state(
     return bool(referenced)
 
 
+def _executed_string_value(node: ast.expr, constants: dict[str, str]) -> str | None:
+    if isinstance(node, ast.IfExp):
+        try:
+            condition = ast.literal_eval(node.test)
+        except (ValueError, TypeError):
+            return None
+        selected = node.body if condition else node.orelse
+        return _executed_string_value(selected, constants)
+    return _string_value(node, constants)
+
+
+def _call_argv_strings(call: ast.Call, constants: dict[str, str]) -> set[str]:
+    argv = (
+        call.args[0]
+        if call.args
+        else next(
+            (keyword.value for keyword in call.keywords if keyword.arg == "argv"), None
+        )
+    )
+    if not isinstance(argv, (ast.List, ast.Tuple)):
+        return set()
+    return {
+        value
+        for element in argv.elts
+        if (value := _executed_string_value(element, constants)) is not None
+    }
+
+
 def _proof_status(
     tree: ast.Module,
     function: TestFunction,
@@ -455,6 +485,10 @@ def _proof_status(
     harness_aliases = _updater_aliases(tree, function, PROOF_HARNESS_MODULE)
     if not updater_aliases or not harness_aliases:
         return "missing-harness"
+    proof_constants = _module_string_constants(tree)
+    proof_constants.update(
+        _module_string_constants(ast.Module(body=function.body, type_ignores=[]))
+    )
     saw_bound_updater = False
     for harness_call in ast.walk(function):
         if not isinstance(harness_call, ast.Call):
@@ -487,10 +521,7 @@ def _proof_status(
                 and call.func.attr == "main"
             ):
                 continue
-            if any(
-                isinstance(node, ast.Constant) and node.value == mutation_flag
-                for node in ast.walk(call)
-            ):
+            if mutation_flag in _call_argv_strings(call, proof_constants):
                 updater_is_bound = True
                 break
         if not updater_is_bound:

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -383,9 +383,11 @@ def _destructured_literal_names(target: ast.expr, value: ast.expr) -> set[str]:
     }
 
 
-class _ScopedAssignmentVisitor(ast.NodeVisitor):
+class _FunctionScopeVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.assignments: list[ast.Assign | ast.AnnAssign] = []
+        self.functions: list[TestFunction] = []
+        self.return_values: list[ast.expr] = []
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.assignments.append(node)
@@ -396,10 +398,10 @@ class _ScopedAssignmentVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        return
+        self.functions.append(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        return
+        self.functions.append(node)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         return
@@ -407,18 +409,81 @@ class _ScopedAssignmentVisitor(ast.NodeVisitor):
     def visit_Lambda(self, node: ast.Lambda) -> None:
         return
 
+    def visit_Return(self, node: ast.Return) -> None:
+        if node.value is not None:
+            self.return_values.append(node.value)
+
+
+def _function_scope(function: TestFunction) -> _FunctionScopeVisitor:
+    visitor = _FunctionScopeVisitor()
+    for statement in function.body:
+        visitor.visit(statement)
+    return visitor
+
 
 def _scoped_assignments(
     function: TestFunction,
 ) -> list[ast.Assign | ast.AnnAssign]:
-    visitor = _ScopedAssignmentVisitor()
-    for statement in function.body:
-        visitor.visit(statement)
-    return visitor.assignments
+    return _function_scope(function).assignments
 
 
-def _literal_local_names(function: TestFunction) -> set[str]:
+_CONTAINER_MUTATORS = frozenset(
+    {
+        "add",
+        "append",
+        "clear",
+        "difference_update",
+        "discard",
+        "extend",
+        "insert",
+        "intersection_update",
+        "pop",
+        "popitem",
+        "remove",
+        "reverse",
+        "setdefault",
+        "sort",
+        "symmetric_difference_update",
+        "update",
+    }
+)
+
+
+def _root_name(node: ast.expr) -> str | None:
+    while isinstance(node, (ast.Attribute, ast.Subscript)):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _mutated_local_names(function: TestFunction) -> set[str]:
     names: set[str] = set()
+    for node in ast.walk(function):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _CONTAINER_MUTATORS
+        ):
+            if name := _root_name(node.func.value):
+                names.add(name)
+        elif isinstance(node, ast.AugAssign):
+            if name := _root_name(node.target):
+                names.add(name)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            names.update(
+                name
+                for target in targets
+                if isinstance(target, ast.Subscript)
+                and (name := _root_name(target)) is not None
+            )
+    return names
+
+
+def _literal_local_names(
+    function: TestFunction, *, include_unmutated_containers: bool = False
+) -> set[str]:
+    names: set[str] = set()
+    mutated_names = _mutated_local_names(function)
     for node in _scoped_assignments(function):
         if isinstance(node, ast.Assign):
             if len(node.targets) > 1:
@@ -431,16 +496,25 @@ def _literal_local_names(function: TestFunction) -> set[str]:
                 )
             elif isinstance(node.targets[0], (ast.List, ast.Tuple)):
                 names.update(_destructured_literal_names(node.targets[0], node.value))
-            elif isinstance(node.targets[0], ast.Name) and isinstance(
-                node.value, ast.Constant
+            elif isinstance(node.targets[0], ast.Name):
+                target_name = node.targets[0].id
+                try:
+                    ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    continue
+                if isinstance(node.value, ast.Constant) or (
+                    include_unmutated_containers and target_name not in mutated_names
+                ):
+                    names.add(target_name)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            try:
+                ast.literal_eval(node.value)
+            except (ValueError, TypeError):
+                continue
+            if isinstance(node.value, ast.Constant) or (
+                include_unmutated_containers and node.target.id not in mutated_names
             ):
-                names.add(node.targets[0].id)
-        elif (
-            isinstance(node, ast.AnnAssign)
-            and isinstance(node.target, ast.Name)
-            and isinstance(node.value, ast.Constant)
-        ):
-            names.add(node.target.id)
+                names.add(node.target.id)
     return names
 
 
@@ -463,25 +537,99 @@ def _literal_module_names(tree: ast.Module) -> set[str]:
     return names
 
 
-def _observer_uses_runtime_state(
-    observer: ast.expr, tree: ast.Module, function: TestFunction
+def _scoped_functions(function: TestFunction) -> list[TestFunction]:
+    return _function_scope(function).functions
+
+
+def _named_observer_function(
+    name: str, tree: ast.Module, function: TestFunction
+) -> TestFunction | None:
+    candidates = _scoped_functions(function)
+    candidates.extend(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    return next((candidate for candidate in candidates if candidate.name == name), None)
+
+
+def _return_values(function: TestFunction) -> list[ast.expr]:
+    return _function_scope(function).return_values
+
+
+def _has_arguments(function: TestFunction | ast.Lambda) -> bool:
+    arguments = function.args
+    return bool(
+        arguments.posonlyargs
+        or arguments.args
+        or arguments.kwonlyargs
+        or arguments.vararg
+        or arguments.kwarg
+    )
+
+
+def _expression_uses_runtime_state(
+    expression: ast.expr,
+    tree: ast.Module,
+    function: TestFunction,
+    *,
+    observer_function: TestFunction | None = None,
+    include_unmutated_containers: bool = False,
 ) -> bool:
-    if isinstance(observer, ast.Name):
-        return False
-    expression = observer.body if isinstance(observer, ast.Lambda) else observer
     if _static_result(expression) is not _UNKNOWN_RESULT:
         return False
-    lambda_arguments: set[str] = set()
-    if isinstance(observer, ast.Lambda):
-        lambda_arguments = {argument.arg for argument in observer.args.args}
-    referenced = {node.id for node in ast.walk(observer) if isinstance(node, ast.Name)}
+    referenced = {
+        node.id for node in ast.walk(expression) if isinstance(node, ast.Name)
+    }
+    literal_names: set[str] = set()
+    if observer_function is not None:
+        literal_names = _literal_local_names(
+            observer_function,
+            include_unmutated_containers=include_unmutated_containers,
+        )
     referenced -= (
-        lambda_arguments
+        literal_names
         | _OBSERVER_BUILTINS
-        | _literal_local_names(function)
+        | _literal_local_names(
+            function,
+            include_unmutated_containers=include_unmutated_containers,
+        )
         | _literal_module_names(tree)
     )
     return bool(referenced)
+
+
+def _observer_uses_runtime_state(
+    observer: ast.expr,
+    tree: ast.Module,
+    function: TestFunction,
+    *,
+    include_unmutated_containers: bool,
+) -> bool:
+    if isinstance(observer, ast.Name):
+        observer_function = _named_observer_function(observer.id, tree, function)
+        if observer_function is None or _has_arguments(observer_function):
+            return False
+        return_values = _return_values(observer_function)
+        return bool(return_values) and all(
+            _expression_uses_runtime_state(
+                value,
+                tree,
+                function,
+                observer_function=observer_function,
+                include_unmutated_containers=include_unmutated_containers,
+            )
+            for value in return_values
+        )
+    if isinstance(observer, ast.Lambda) and _has_arguments(observer):
+        return False
+    expression = observer.body if isinstance(observer, ast.Lambda) else observer
+    return _expression_uses_runtime_state(
+        expression,
+        tree,
+        function,
+        include_unmutated_containers=include_unmutated_containers,
+    )
 
 
 def _static_result(node: ast.expr) -> object:
@@ -621,7 +769,12 @@ def _proof_status(
         }
         if all(
             name in observers
-            and _observer_uses_runtime_state(observers[name], tree, function)
+            and _observer_uses_runtime_state(
+                observers[name],
+                tree,
+                function,
+                include_unmutated_containers=name == "baseline_state",
+            )
             for name in ("regression_debt_present", "baseline_state")
         ):
             return "valid"

--- a/common/testing/check_ac_index.py
+++ b/common/testing/check_ac_index.py
@@ -94,6 +94,7 @@ from common.testing.protection import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+BASELINE_UPDATE_MODE = "raise-only"
 
 
 def _escape_workflow_command(message: str) -> str:
@@ -122,7 +123,9 @@ def _real_test(repo_root: Path, file_rel: str, test_name: str) -> bool:
     except (OSError, SyntaxError):
         return False
     for node in ast.walk(module):
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and (node.name == test_name):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and (
+            node.name == test_name
+        ):
             return True
     return False
 
@@ -151,7 +154,9 @@ def _proof_obligations(graph: AcGraph) -> list[Obligation]:
     out: list[Obligation] = []
     for proof in graph.proofs:
         if not proof.ac_ids:
-            out.append(Obligation(False, f"proof {proof.proof_id!r}: declares no ac_ids"))
+            out.append(
+                Obligation(False, f"proof {proof.proof_id!r}: declares no ac_ids")
+            )
         for ac_id in proof.ac_ids:
             out.append(
                 Obligation(
@@ -343,7 +348,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args([] if argv is None else argv)
     repo_root = args.repo_root.resolve()
-    floor_file = args.floor_file or (repo_root / "common" / "testing" / "data" / "protection-floor.json")
+    floor_file = args.floor_file or (
+        repo_root / "common" / "testing" / "data" / "protection-floor.json"
+    )
 
     graph = build_ac_graph(repo_root)
 

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4040,9 +4040,10 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-testing.governance.21",
             statement=(
-                "Every real --update baseline mutation path is behaviorally driven "
-                "against synthetic regression debt and refuses to adopt it; the "
-                "contract census fails when a new monotonic updater lacks that proof."
+                "Every real monotonic baseline-mutation CLI path, including "
+                "specialized update flags, is behaviorally driven against synthetic "
+                "regression debt and refuses to adopt it; the contract census fails "
+                "when a new monotonic updater lacks non-vacuous state proof."
             ),
             test=(
                 "tests/tooling/test_s4_gate_contracts.py"

--- a/tests/tooling/test_ac_index_consistency.py
+++ b/tests/tooling/test_ac_index_consistency.py
@@ -36,6 +36,7 @@ import json
 from pathlib import Path
 
 from common.testing import (
+    baseline_update_contract,
     check_ac_index as gate,
     check_ac_score_baseline as ratchet,
     protection,
@@ -398,7 +399,7 @@ def test_AC8_13_140_count_floor_passes_when_protection_added(tmp_path) -> None:
     assert floor_file.read_text(encoding="utf-8") == before
 
 
-def test_AC8_13_140_update_floor_raises_floors(tmp_path) -> None:
+def test_AC8_13_140_update_floor_raises_floors(tmp_path, monkeypatch) -> None:
     """AC8.13.140: --update-floor raises floors to current counts (never lowers)."""
     floor_file = tmp_path / "protection-floor.json"
     protection.write_floor(floor_file, dict.fromkeys(protection.PROTECTION_TYPES, 0))
@@ -424,7 +425,28 @@ def test_AC8_13_140_update_floor_raises_floors(tmp_path) -> None:
             proof_ids=(),
             score=None,
         )
-    not_lowered = protection.update_floor(poorer, floor_file)
+    monkeypatch.setattr(gate, "build_ac_graph", lambda _repo_root: poorer)
+    assert (
+        baseline_update_contract.assert_regression_debt_refused(
+            regression_debt_present=lambda: any(
+                protection.count_protection_types(poorer)[ptype]
+                < protection.load_floor(floor_file)[ptype]
+                for ptype in protection.PROTECTION_TYPES
+            ),
+            baseline_state=floor_file.read_bytes,
+            update=lambda: gate.main(
+                [
+                    "--repo-root",
+                    str(tmp_path),
+                    "--floor-file",
+                    str(floor_file),
+                    "--update-floor",
+                ]
+            ),
+        )
+        == 0
+    )
+    not_lowered = protection.load_floor(floor_file)
     assert not_lowered["has_proof"] >= raised["has_proof"]
 
 

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -606,6 +606,25 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"
         "def test_missing():\n"
+        "    if True:\n"
+        "        debt = True\n"
+        "        baseline = b'baseline'\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: debt,\n"
+        "        baseline_state=lambda: baseline,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing():\n"
         "    debt = {'new-debt'}\n"
         "    _head, *baseline = (True, b'baseline')\n"
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
@@ -773,6 +792,32 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
         "exercise synthetic regression debt through the refusal harness: "
         "tests/tooling/test_multi_flag.py::test_update",
     ]
+
+    for extra_setup, invocation in (
+        ("    extra = build_flag()\n", '["--update", extra]'),
+        ("    extra = build_flags()\n", '["--update", *extra]'),
+    ):
+        proof.write_text(
+            "from common.testing import baseline_update_contract, multi_flag\n\n"
+            "def test_update(tmp_path):\n"
+            "    baseline = tmp_path / 'baseline'\n"
+            "    debt = {'new-debt'}\n"
+            f"{extra_setup}"
+            "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+            "        regression_debt_present=lambda: bool(debt),\n"
+            "        baseline_state=baseline.read_bytes,\n"
+            f"        update=lambda: multi_flag.main({invocation}),\n"
+            "    ) == 1\n",
+            encoding="utf-8",
+        )
+        assert baseline_update_contract.proof_violations(tmp_path) == [
+            "common/testing/multi_flag.py [--update]: behavioral proof does not "
+            "exercise synthetic regression debt through the refusal harness: "
+            "tests/tooling/test_multi_flag.py::test_update",
+            "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+            "exercise synthetic regression debt through the refusal harness: "
+            "tests/tooling/test_multi_flag.py::test_update",
+        ]
 
     proof.write_text(
         "from common.testing import baseline_update_contract, multi_flag\n\n"

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -538,6 +538,46 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "tests/tooling/test_missing.py::test_missing"
     ]
 
+    for assignment in (
+        "    always, baseline = True, b'baseline'\n",
+        "    always = baseline = True\n",
+        "    always, (baseline, dynamic) = True, (b'baseline', build_state())\n",
+    ):
+        proof_file.write_text(
+            "from common.testing import baseline_update_contract, synthetic\n\n"
+            "def test_missing():\n"
+            f"{assignment}"
+            "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+            "        regression_debt_present=lambda: always,\n"
+            "        baseline_state=lambda: baseline,\n"
+            '        update=lambda: synthetic.main(["--update"]),\n'
+            "    ) == 1\n",
+            encoding="utf-8",
+        )
+        assert baseline_update_contract.proof_violations(synthetic_root) == [
+            "common/testing/synthetic.py [--update]: behavioral proof uses constant "
+            "or vacuous regression-debt observers: "
+            "tests/tooling/test_missing.py::test_missing"
+        ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing():\n"
+        "    debt = {'new-debt'}\n"
+        "    _head, *baseline = (True, b'baseline')\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=lambda: baseline,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"
         "def test_missing(tmp_path):\n"
@@ -553,23 +593,26 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     )
     assert baseline_update_contract.proof_violations(synthetic_root) == []
 
-    proof_file.write_text(
-        "from common.testing import baseline_update_contract, synthetic\n\n"
-        "ALWAYS = True\n"
-        "BASELINE = b'baseline'\n\n"
-        "def test_missing():\n"
-        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
-        "        regression_debt_present=lambda: ALWAYS,\n"
-        "        baseline_state=lambda: BASELINE,\n"
-        '        update=lambda: synthetic.main(["--update"]),\n'
-        "    ) == 1\n",
-        encoding="utf-8",
-    )
-    assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
-        "vacuous regression-debt observers: "
-        "tests/tooling/test_missing.py::test_missing"
-    ]
+    for module_assignment in (
+        "ALWAYS = True\nBASELINE = b'baseline'\n",
+        "ALWAYS, *BASELINE = (True, b'baseline')\n",
+    ):
+        proof_file.write_text(
+            "from common.testing import baseline_update_contract, synthetic\n\n"
+            f"{module_assignment}\n"
+            "def test_missing():\n"
+            "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+            "        regression_debt_present=lambda: ALWAYS,\n"
+            "        baseline_state=lambda: BASELINE,\n"
+            '        update=lambda: synthetic.main(["--update"]),\n'
+            "    ) == 1\n",
+            encoding="utf-8",
+        )
+        assert baseline_update_contract.proof_violations(synthetic_root) == [
+            "common/testing/synthetic.py [--update]: behavioral proof uses constant "
+            "or vacuous regression-debt observers: "
+            "tests/tooling/test_missing.py::test_missing"
+        ]
 
 
 def test_AC_testing_governance_21_refusal_harness_enforces_its_preconditions() -> None:

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -538,6 +538,26 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "tests/tooling/test_missing.py::test_missing"
     ]
 
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def always():\n"
+        "    return True\n\n"
+        "def fixed():\n"
+        "    return b'baseline'\n\n"
+        "def test_missing():\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=always,\n"
+        "        baseline_state=fixed,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
     for assignment in (
         "    always, baseline = True, b'baseline'\n",
         "    always = baseline = True\n",
@@ -708,6 +728,55 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
             )
             for flag in ("--update", "--update-floor")
         },
+    )
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+        "exercise synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update"
+    ]
+
+    proof.write_text(
+        "from common.testing import baseline_update_contract, multi_flag\n\n"
+        "def test_update(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    debt = {'new-debt'}\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=baseline.read_bytes,\n"
+        "        update=lambda: multi_flag.main([\n"
+        '            "--update" if True else "--update-floor"\n'
+        "        ]),\n"
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+        "exercise synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update"
+    ]
+
+    dynamic_source = proof.read_text(encoding="utf-8").replace(
+        '"--update" if True else "--update-floor"',
+        '"--update" if choose_update else "--update-floor"',
+    )
+    proof.write_text(dynamic_source, encoding="utf-8")
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update]: behavioral proof does not exercise "
+        "synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update",
+        "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+        "exercise synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update",
+    ]
+
+    proof.write_text(
+        dynamic_source.replace(
+            "multi_flag.main([\n"
+            '            "--update" if choose_update else "--update-floor"\n'
+            "        ])",
+            'multi_flag.main(argv=["--update"])',
+        ),
+        encoding="utf-8",
     )
     assert baseline_update_contract.proof_violations(tmp_path) == [
         "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -596,6 +596,25 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=lambda: bool(debt),\n"
         "        baseline_state=lambda: baseline,\n"
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing():\n"
+        "    debt = build_state()\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=lambda: debt,\n"
         '        update=lambda: synthetic.main(["--update"]),\n'
         "    ) == 1\n",
         encoding="utf-8",
@@ -619,7 +638,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=lambda: bool(debt),\n"
         "        baseline_state=read_baseline,\n"
-        '        update=lambda: synthetic.main(["--update"]),\n'
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
         "    ) == 1\n",
         encoding="utf-8",
     )
@@ -643,7 +664,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=debt_present,\n"
         "        baseline_state=read_baseline,\n"
-        '        update=lambda: synthetic.main(["--update"]),\n'
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
         "    ) == 1\n",
         encoding="utf-8",
     )
@@ -717,7 +740,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=lambda: bool(debt),\n"
         "        baseline_state=baseline.read_bytes,\n"
-        '        update=lambda: synthetic.main(["--update"]),\n'
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
         "    ) == 1\n",
         encoding="utf-8",
     )
@@ -810,7 +835,9 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=lambda: bool(debt),\n"
         "        baseline_state=baseline.read_bytes,\n"
-        '        update=lambda: multi_flag.main(["--update"]),\n'
+        "        update=lambda: multi_flag.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
         "    ) == 1\n",
         encoding="utf-8",
     )
@@ -847,8 +874,12 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
 
     proof.write_text(
         proof.read_text(encoding="utf-8").replace(
-            'multi_flag.main(["--update"])',
-            'multi_flag.main(["--update", "--update-floor"])',
+            "multi_flag.main(\n"
+            '            ["--baseline", str(baseline), "--update"]\n'
+            "        )",
+            "multi_flag.main(\n"
+            '            ["--baseline", str(baseline), "--update", "--update-floor"]\n'
+            "        )",
         ),
         encoding="utf-8",
     )
@@ -896,6 +927,7 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
         "        regression_debt_present=lambda: bool(debt),\n"
         "        baseline_state=baseline.read_bytes,\n"
         "        update=lambda: multi_flag.main([\n"
+        '            "--baseline", str(baseline),\n'
         '            "--update" if True else "--update-floor"\n'
         "        ]),\n"
         "    ) == 1\n",
@@ -924,9 +956,12 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
     proof.write_text(
         dynamic_source.replace(
             "multi_flag.main([\n"
+            '            "--baseline", str(baseline),\n'
             '            "--update" if choose_update else "--update-floor"\n'
             "        ])",
-            'multi_flag.main(argv=["--update"])',
+            "multi_flag.main(\n"
+            '            argv=["--baseline", str(baseline), "--update"]\n'
+            "        )",
         ),
         encoding="utf-8",
     )

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -571,7 +571,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
             "def always():\n"
             "    return True\n\n"
             "def fixed():\n"
-            "    return b'baseline'\n\n"
+            "    state = build_state()\n"
+            "    state = b'baseline'\n"
+            "    return state\n\n"
             "def test_missing():\n"
             "    assert baseline_update_contract.assert_regression_debt_refused(\n"
             f"        regression_debt_present={debt_observer},\n"
@@ -609,10 +611,35 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "def test_missing(tmp_path):\n"
         "    baseline = tmp_path / 'baseline'\n"
         "    debt = build_state()\n"
+        "    def read_baseline():\n"
+        "        state = b''\n"
+        "        if should_read():\n"
+        "            state = baseline.read_bytes()\n"
+        "        return state\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=read_baseline,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    debt = build_state()\n"
         "    def debt_present():\n"
         "        return bool(debt)\n"
         "    def read_baseline():\n"
-        "        return baseline.read_bytes()\n"
+        "        state = b''\n"
+        "        state = baseline.read_bytes()\n"
+        "        return state\n"
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"
         "        regression_debt_present=debt_present,\n"
         "        baseline_state=read_baseline,\n"

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -454,6 +454,7 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "common/meta/extension/check_ac_tier_baseline.py",
         "common/meta/extension/check_app_boundary.py",
         "common/testing/api_surface_ratchet.py",
+        "common/testing/check_ac_index.py",
         "common/testing/check_ac_score_baseline.py",
         "common/testing/check_cas" + "sette_graded_eval.py",
         "common/testing/check_critical_value_proof.py",
@@ -522,6 +523,24 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "    ) == 1\n",
         encoding="utf-8",
     )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py: behavioral proof uses constant or vacuous "
+        "regression-debt observers: tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    baseline.write_bytes(b'before')\n"
+        "    debt = {'new-debt'}\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=baseline.read_bytes,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
     assert baseline_update_contract.proof_violations(synthetic_root) == []
 
 
@@ -548,3 +567,18 @@ def test_AC_testing_governance_21_refusal_harness_enforces_its_preconditions() -
             update=mutate_baseline,
         )
     assert state == {"baseline": b"after", "called": True}
+
+
+def test_AC_testing_governance_21_specialized_mutation_flags_are_censused(
+    tmp_path: Path,
+) -> None:
+    updater = tmp_path / "common/testing/specialized.py"
+    updater.parent.mkdir(parents=True)
+    updater.write_text(
+        'BASELINE_UPDATE_MODE = "raise-only"\nparser.add_argument("--update-floor")\n',
+        encoding="utf-8",
+    )
+
+    assert baseline_update_contract.monotonic_update_paths(tmp_path) == {
+        "common/testing/specialized.py"
+    }

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -543,6 +543,7 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         ("lambda: bool(debt)", "lambda: b'fixed' if debt else b'fixed'"),
         ("lambda: False and debt", "lambda: debt"),
         ("lambda: bool(debt)", "lambda: b'fixed' if True else debt"),
+        ("lambda fixed=True: fixed", "lambda fixed=b'fixed': fixed"),
     ):
         proof_file.write_text(
             "from common.testing import baseline_update_contract, synthetic\n\n"
@@ -580,6 +581,42 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "vacuous regression-debt observers: "
         "tests/tooling/test_missing.py::test_missing"
     ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing():\n"
+        "    debt = build_state()\n"
+        "    baseline = []\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=lambda: baseline,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    debt = build_state()\n"
+        "    def debt_present():\n"
+        "        return bool(debt)\n"
+        "    def read_baseline():\n"
+        "        return baseline.read_bytes()\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=debt_present,\n"
+        "        baseline_state=read_baseline,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == []
 
     for assignment in (
         "    always, baseline = True, b'baseline'\n",

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -538,6 +538,29 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "tests/tooling/test_missing.py::test_missing"
     ]
 
+    for debt_observer, baseline_observer in (
+        ("lambda: True or debt", "lambda: b'fixed' if debt else b'fixed'"),
+        ("lambda: bool(debt)", "lambda: b'fixed' if debt else b'fixed'"),
+        ("lambda: False and debt", "lambda: debt"),
+        ("lambda: bool(debt)", "lambda: b'fixed' if True else debt"),
+    ):
+        proof_file.write_text(
+            "from common.testing import baseline_update_contract, synthetic\n\n"
+            "def test_missing():\n"
+            "    debt = {'new-debt'}\n"
+            "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+            f"        regression_debt_present={debt_observer},\n"
+            f"        baseline_state={baseline_observer},\n"
+            '        update=lambda: synthetic.main(["--update"]),\n'
+            "    ) == 1\n",
+            encoding="utf-8",
+        )
+        assert baseline_update_contract.proof_violations(synthetic_root) == [
+            "common/testing/synthetic.py [--update]: behavioral proof uses constant "
+            "or vacuous regression-debt observers: "
+            "tests/tooling/test_missing.py::test_missing"
+        ]
+
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"
         "def always():\n"
@@ -733,6 +756,22 @@ def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
         "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
         "exercise synthetic regression debt through the refusal harness: "
         "tests/tooling/test_multi_flag.py::test_update"
+    ]
+
+    proof.write_text(
+        proof.read_text(encoding="utf-8").replace(
+            'multi_flag.main(["--update"])',
+            'multi_flag.main(["--update", "--update-floor"])',
+        ),
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update]: behavioral proof does not exercise "
+        "synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update",
+        "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+        "exercise synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update",
     ]
 
     proof.write_text(

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -464,7 +464,12 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         "common/testing/mirror_ratchet.py",
         "common/testing/tool_shim_contract.py",
     }
-    assert set(baseline_update_contract.MONOTONIC_UPDATE_PROOFS) == update_paths
+    assert {
+        path for path, _flag in baseline_update_contract.MONOTONIC_UPDATE_PROOFS
+    } == update_paths
+    assert set(
+        baseline_update_contract.MONOTONIC_UPDATE_PROOFS
+    ) == baseline_update_contract.monotonic_update_commands(ROOT)
     assert baseline_update_contract.proof_violations(ROOT) == []
 
     synthetic_root = tmp_path / "proof-contract"
@@ -478,17 +483,21 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     )
     monkeypatch.setattr(baseline_update_contract, "MONOTONIC_UPDATE_PROOFS", {})
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: monotonic --update path lacks a behavioral "
-        "regression proof"
+        "common/testing/synthetic.py [--update]: monotonic mutation path lacks a "
+        "behavioral regression proof"
     ]
 
     monkeypatch.setattr(
         baseline_update_contract,
         "MONOTONIC_UPDATE_PROOFS",
-        {"common/testing/synthetic.py": "tests/tooling/test_missing.py::test_missing"},
+        {
+            ("common/testing/synthetic.py", "--update"): (
+                "tests/tooling/test_missing.py::test_missing"
+            )
+        },
     )
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: behavioral proof node does not exist: "
+        "common/testing/synthetic.py [--update]: behavioral proof node does not exist: "
         "tests/tooling/test_missing.py::test_missing"
     ]
 
@@ -496,8 +505,8 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
     proof_file.parent.mkdir(parents=True)
     proof_file.write_text("def test_missing():\n    assert True\n", encoding="utf-8")
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: behavioral proof does not exercise synthetic "
-        "regression debt through the refusal harness: "
+        "common/testing/synthetic.py [--update]: behavioral proof does not exercise "
+        "synthetic regression debt through the refusal harness: "
         "tests/tooling/test_missing.py::test_missing"
     ]
 
@@ -508,7 +517,7 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         encoding="utf-8",
     )
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: behavioral proof does not exercise "
+        "common/testing/synthetic.py [--update]: behavioral proof does not exercise "
         "synthetic regression debt through the refusal harness: "
         "tests/tooling/test_missing.py::test_missing"
     ]
@@ -524,8 +533,9 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         encoding="utf-8",
     )
     assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py: behavioral proof uses constant or vacuous "
-        "regression-debt observers: tests/tooling/test_missing.py::test_missing"
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
     ]
 
     proof_file.write_text(
@@ -542,6 +552,24 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
         encoding="utf-8",
     )
     assert baseline_update_contract.proof_violations(synthetic_root) == []
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "ALWAYS = True\n"
+        "BASELINE = b'baseline'\n\n"
+        "def test_missing():\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: ALWAYS,\n"
+        "        baseline_state=lambda: BASELINE,\n"
+        '        update=lambda: synthetic.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
 
 
 def test_AC_testing_governance_21_refusal_harness_enforces_its_preconditions() -> None:
@@ -582,3 +610,64 @@ def test_AC_testing_governance_21_specialized_mutation_flags_are_censused(
     assert baseline_update_contract.monotonic_update_paths(tmp_path) == {
         "common/testing/specialized.py"
     }
+    assert baseline_update_contract.monotonic_update_commands(tmp_path) == {
+        ("common/testing/specialized.py", "--update-floor")
+    }
+
+
+def test_AC_testing_governance_21_each_mutation_flag_requires_its_own_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updater = tmp_path / "common/testing/multi_flag.py"
+    updater.parent.mkdir(parents=True)
+    updater.write_text(
+        'BASELINE_UPDATE_MODE = "raise-only"\n'
+        'parser.add_argument("--update")\n'
+        'parser.add_argument("--update-floor")\n',
+        encoding="utf-8",
+    )
+    proof = tmp_path / "tests/tooling/test_multi_flag.py"
+    proof.parent.mkdir(parents=True)
+    proof.write_text(
+        "from common.testing import baseline_update_contract, multi_flag\n\n"
+        "def test_update(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    debt = {'new-debt'}\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=lambda: bool(debt),\n"
+        "        baseline_state=baseline.read_bytes,\n"
+        '        update=lambda: multi_flag.main(["--update"]),\n'
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        baseline_update_contract,
+        "MONOTONIC_UPDATE_PROOFS",
+        {
+            ("common/testing/multi_flag.py", "--update"): (
+                "tests/tooling/test_multi_flag.py::test_update"
+            )
+        },
+    )
+
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update-floor]: monotonic mutation path "
+        "lacks a behavioral regression proof"
+    ]
+
+    monkeypatch.setattr(
+        baseline_update_contract,
+        "MONOTONIC_UPDATE_PROOFS",
+        {
+            ("common/testing/multi_flag.py", flag): (
+                "tests/tooling/test_multi_flag.py::test_update"
+            )
+            for flag in ("--update", "--update-floor")
+        },
+    )
+    assert baseline_update_contract.proof_violations(tmp_path) == [
+        "common/testing/multi_flag.py [--update-floor]: behavioral proof does not "
+        "exercise synthetic regression debt through the refusal harness: "
+        "tests/tooling/test_multi_flag.py::test_update"
+    ]

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -562,25 +562,29 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
             "tests/tooling/test_missing.py::test_missing"
         ]
 
-    proof_file.write_text(
-        "from common.testing import baseline_update_contract, synthetic\n\n"
-        "def always():\n"
-        "    return True\n\n"
-        "def fixed():\n"
-        "    return b'baseline'\n\n"
-        "def test_missing():\n"
-        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
-        "        regression_debt_present=always,\n"
-        "        baseline_state=fixed,\n"
-        '        update=lambda: synthetic.main(["--update"]),\n'
-        "    ) == 1\n",
-        encoding="utf-8",
-    )
-    assert baseline_update_contract.proof_violations(synthetic_root) == [
-        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
-        "vacuous regression-debt observers: "
-        "tests/tooling/test_missing.py::test_missing"
-    ]
+    for debt_observer, baseline_observer in (
+        ("always", "fixed"),
+        ("lambda: always()", "lambda: fixed()"),
+    ):
+        proof_file.write_text(
+            "from common.testing import baseline_update_contract, synthetic\n\n"
+            "def always():\n"
+            "    return True\n\n"
+            "def fixed():\n"
+            "    return b'baseline'\n\n"
+            "def test_missing():\n"
+            "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+            f"        regression_debt_present={debt_observer},\n"
+            f"        baseline_state={baseline_observer},\n"
+            '        update=lambda: synthetic.main(["--update"]),\n'
+            "    ) == 1\n",
+            encoding="utf-8",
+        )
+        assert baseline_update_contract.proof_violations(synthetic_root) == [
+            "common/testing/synthetic.py [--update]: behavioral proof uses constant "
+            "or vacuous regression-debt observers: "
+            "tests/tooling/test_missing.py::test_missing"
+        ]
 
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"


### PR DESCRIPTION
## Summary
- census the full `--update` / `--update-*` monotonic mutation family, including `check_ac_index --update-floor`
- require registered proofs to use non-vacuous regression-debt and baseline-state observers
- prove the protection floor cannot be lowered through the real `check_ac_index.main` CLI path

## Context
Follow-up to #1885 for two Codex findings that arrived immediately before that PR was merged.

Part of #1867

## Verification
- `tools/preflight.py --tier=static --base origin/main`
- `moon run :lint`
- `tools/generate_ac_registry.py --check`
- 152 focused tooling tests passed; scoped coverage is 98% for both changed governance modules
- Full `moon run :test` was also attempted on the #1885 head: 3061 passed; three unchanged local-environment failures remained (user LLM key, MinIO port mapping, ignored `src/models/__pycache__`) plus the local aggregate coverage threshold. GitHub CI on #1885 passed all equivalent shards.