### PR TITLE
[finance_report_ui] Reject vacuous baseline proof observers

### DIFF
--- a/common/testing/README.md
+++ b/common/testing/README.md
@@ -80,10 +80,12 @@ deliberately louder `--rewrite-baseline` flag. The updater census recognizes bot
 module-level string constants in both forms. Every `(module, mutation flag)`
 command must map to a live test node that uses
 `assert_regression_debt_refused` with non-vacuous debt and baseline-state
-observers, invokes that updater's `main` with that exact flag, and proves the
-baseline remains unchanged. A new mutation command therefore cannot be covered
-by a declaration, another flag's proof, an unrelated test name, constant
-callbacks, or a happy-path call.
+observers. The debt observer must depend on state beyond the baseline path, and
+the baseline observer must read persisted contents (or a captured writer sink),
+not merely check that the path exists. The proof invokes that updater's `main`
+with the exact flag and proves the baseline remains unchanged. A new mutation
+command therefore cannot be covered by a declaration, another flag's proof, an
+unrelated test name, constant callbacks, or a happy-path call.
 
 Top-level `tools/*.py` files are command boundaries, not implementation homes.
 `tool_shim_contract.py` rejects a new entry point over 40 lines and requires

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -901,13 +901,29 @@ def _observer_depends_on_regression_state(
     function: TestFunction,
     baseline_names: frozenset[str],
 ) -> bool:
-    target = _observer_target(observer, tree, function)
-    if target is None:
-        return False
-    referenced = _node_names(target) - baseline_names - _OBSERVER_BUILTINS
-    if isinstance(observer, ast.Name):
-        referenced.discard(observer.id)
-        observer_function = _named_observer_function(observer.id, tree, function)
+    def state_names(
+        target: ast.AST,
+        *,
+        observer_function: TestFunction | None = None,
+        seen: frozenset[tuple[int, int]] = frozenset(),
+    ) -> set[str]:
+        referenced = _node_names(target)
+        for call in ast.walk(target):
+            if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Name)):
+                continue
+            called_function = _named_observer_function(call.func.id, tree, function)
+            if called_function is None:
+                continue
+            referenced.discard(call.func.id)
+            key = (called_function.lineno, called_function.col_offset)
+            if key not in seen:
+                referenced.update(
+                    state_names(
+                        ast.Module(body=called_function.body, type_ignores=[]),
+                        observer_function=called_function,
+                        seen=seen | {key},
+                    )
+                )
         if observer_function is not None:
             referenced -= {
                 name
@@ -919,6 +935,20 @@ def _observer_depends_on_regression_state(
                 )
                 for name in _bound_names(target_node)
             }
+        return referenced
+
+    target = _observer_target(observer, tree, function)
+    if target is None:
+        return False
+    observer_function = (
+        _named_observer_function(observer.id, tree, function)
+        if isinstance(observer, ast.Name)
+        else None
+    )
+    referenced = state_names(target, observer_function=observer_function)
+    referenced -= baseline_names | _OBSERVER_BUILTINS
+    if isinstance(observer, ast.Name):
+        referenced.discard(observer.id)
     return bool(referenced)
 
 

--- a/common/testing/baseline_update_contract.py
+++ b/common/testing/baseline_update_contract.py
@@ -818,8 +818,9 @@ def _updater_baseline_names(
     updater_call: ast.Call,
     updater_aliases: set[str],
     constants: dict[str, str],
-) -> frozenset[str]:
+) -> tuple[frozenset[str], frozenset[str]]:
     names: set[str] = set()
+    captured_names: set[str] = set()
     argv = _call_argv_node(updater_call)
     if isinstance(argv, (ast.List, ast.Tuple)):
         for option_node, value_node in zip(argv.elts, argv.elts[1:]):
@@ -850,10 +851,75 @@ def _updater_baseline_names(
         attribute = attribute.lower()
         if "baseline" in attribute or "floor" in attribute:
             names.update(value_names)
+            if isinstance(value, ast.Lambda):
+                captured_names.update(value_names & mutated_names)
         elif attribute.startswith(("dump", "write")):
-            names.update(value_names & mutated_names)
+            captured_names.update(value_names & mutated_names)
+            names.update(captured_names)
     names -= updater_aliases | _OBSERVER_BUILTINS | {"monkeypatch"}
-    return frozenset(names)
+    captured_names &= names
+    return frozenset(names), frozenset(captured_names)
+
+
+_PERSISTED_STATE_READERS = frozenset({"read_bytes", "read_text"})
+
+
+def _observer_target(
+    observer: ast.expr, tree: ast.Module, function: TestFunction
+) -> ast.AST | None:
+    if not isinstance(observer, ast.Name):
+        return observer
+    observer_function = _named_observer_function(observer.id, tree, function)
+    if observer_function is None:
+        return None
+    return ast.Module(body=observer_function.body, type_ignores=[])
+
+
+def _observer_reads_persisted_state(
+    observer: ast.expr,
+    tree: ast.Module,
+    function: TestFunction,
+    baseline_names: frozenset[str],
+    captured_names: frozenset[str],
+) -> bool:
+    target = _observer_target(observer, tree, function)
+    if target is None:
+        return False
+    if _node_names(target) & captured_names:
+        return True
+    return any(
+        isinstance(node, ast.Attribute)
+        and node.attr in _PERSISTED_STATE_READERS
+        and _root_name(node.value) in baseline_names
+        for node in ast.walk(target)
+    )
+
+
+def _observer_depends_on_regression_state(
+    observer: ast.expr,
+    tree: ast.Module,
+    function: TestFunction,
+    baseline_names: frozenset[str],
+) -> bool:
+    target = _observer_target(observer, tree, function)
+    if target is None:
+        return False
+    referenced = _node_names(target) - baseline_names - _OBSERVER_BUILTINS
+    if isinstance(observer, ast.Name):
+        referenced.discard(observer.id)
+        observer_function = _named_observer_function(observer.id, tree, function)
+        if observer_function is not None:
+            referenced -= {
+                name
+                for assignment in _scoped_assignments(observer_function)
+                for target_node in (
+                    assignment.targets
+                    if isinstance(assignment, ast.Assign)
+                    else [assignment.target]
+                )
+                for name in _bound_names(target_node)
+            }
+    return bool(referenced)
 
 
 def _proof_status(
@@ -915,7 +981,7 @@ def _proof_status(
         if bound_updater_call is None:
             continue
         saw_bound_updater = True
-        baseline_names = _updater_baseline_names(
+        baseline_names, captured_names = _updater_baseline_names(
             function,
             bound_updater_call,
             updater_aliases,
@@ -934,6 +1000,19 @@ def _proof_status(
                 function,
                 include_unmutated_containers=name == "baseline_state",
                 required_names=baseline_names if name == "baseline_state" else None,
+            )
+            and (
+                _observer_depends_on_regression_state(
+                    observers[name], tree, function, baseline_names
+                )
+                if name == "regression_debt_present"
+                else _observer_reads_persisted_state(
+                    observers[name],
+                    tree,
+                    function,
+                    baseline_names,
+                    captured_names,
+                )
             )
             for name in ("regression_debt_present", "baseline_state")
         ):

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -648,6 +648,29 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
 
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def constant_debt():\n"
+        "    return True\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=(\n"
+        "            lambda: baseline.exists() and constant_debt()\n"
+        "        ),\n"
+        "        baseline_state=baseline.read_bytes,\n"
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
         "def test_missing():\n"
         "    debt = build_state()\n"
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -610,6 +610,44 @@ def test_AC_testing_governance_21_real_updates_refuse_regression_debt(
 
     proof_file.write_text(
         "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=baseline.exists,\n"
+        "        baseline_state=baseline.exists,\n"
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
+        "def test_missing(tmp_path):\n"
+        "    baseline = tmp_path / 'baseline'\n"
+        "    assert baseline_update_contract.assert_regression_debt_refused(\n"
+        "        regression_debt_present=baseline.exists,\n"
+        "        baseline_state=baseline.read_bytes,\n"
+        "        update=lambda: synthetic.main(\n"
+        '            ["--baseline", str(baseline), "--update"]\n'
+        "        ),\n"
+        "    ) == 1\n",
+        encoding="utf-8",
+    )
+    assert baseline_update_contract.proof_violations(synthetic_root) == [
+        "common/testing/synthetic.py [--update]: behavioral proof uses constant or "
+        "vacuous regression-debt observers: "
+        "tests/tooling/test_missing.py::test_missing"
+    ]
+
+    proof_file.write_text(
+        "from common.testing import baseline_update_contract, synthetic\n\n"
         "def test_missing():\n"
         "    debt = build_state()\n"
         "    assert baseline_update_contract.assert_regression_debt_refused(\n"


### PR DESCRIPTION
## Summary

- require monotonic-updater debt observers to depend on state beyond the baseline path
- require baseline observers to read persisted contents or a captured writer sink
- reject both `baseline.exists`/`baseline.exists` and `baseline.exists`/`baseline.read_bytes` proof pairs

## Root cause

The late P2 review on #1891 showed that merely referencing the updater's baseline name counted as runtime-state observation. A proof could therefore establish only that the path existed, compare `True` before and after, and remain green even if the updater rewrote the baseline.

This follow-up binds each observer to the state it claims to prove: regression debt must come from state beyond the baseline path, while baseline state must be persisted content or the updater's captured writer output.

## Proof

- added two falsifying proof fixtures for path-existence observers
- retained valid file-backed and captured-writer proofs for every registered monotonic updater
- documented the stronger observer contract

## Verification

- focused S4/AC index: `30 passed`
- full diff-aware preflight: `2188 passed`; all relevant gates passed
- `tools/check_baseline_update_contract.py`: passed
- Ruff check/format and `git diff --check`: passed

Closes the unresolved late-review gap from #1891.
Part of #1867.

Review context: https://github.com/wangzitian0/finance_report/pull/1891#discussion_r3593662048
