### PR TITLE
[finance_report_ui_wt_s2] Complete S2 API surface hygiene

### DIFF
--- a/apps/backend/src/counter/README.md
+++ b/apps/backend/src/counter/README.md
@@ -12,6 +12,6 @@ ubiquitous language, contract, roles, storage, and governance — lives in
 The code here converges into the package model's layers — `base/` (pure core:
 `types/` nouns + events, `ops/` verbs over the repository port,
 `repository.py` the `CounterRepository` port) and `extension/` (the impure
-edges: `sql.py` SQLAlchemy adapter, `api/` the thin async boundary) — and
+edges: `sql.py` SQLAlchemy adapter, `facade/` the thin programmatic boundary) — and
 publishes exactly its `__init__.__all__`, which must equal
 `contract.interface`.

--- a/apps/backend/src/counter/extension/__init__.py
+++ b/apps/backend/src/counter/extension/__init__.py
@@ -7,7 +7,7 @@ stays pure behind the ports this layer satisfies.
 
 from __future__ import annotations
 
-from src.counter.extension.api import read_count, record_increment
+from src.counter.extension.facade import read_count, record_increment
 from src.counter.extension.sql import CounterTally, SqlCounterRepository
 
 __all__ = ["CounterTally", "SqlCounterRepository", "read_count", "record_increment"]

--- a/apps/backend/src/counter/extension/facade/__init__.py
+++ b/apps/backend/src/counter/extension/facade/__init__.py
@@ -1,15 +1,15 @@
-"""Counter boundary — the thin async reads/writes over an ``AsyncSession``.
+"""Counter facade — thin programmatic reads/writes over an ``AsyncSession``.
 
 ``read_count`` bridges a session to a domain ``Count`` (the read for insight
 reports). ``record_increment`` is the atomic write: it bumps the tally and
-enqueues ``Incremented`` into the platform outbox in the same transaction. ``api``
+enqueues ``Incremented`` into the platform outbox in the same transaction. The facade
 is the only role that combines the session with the domain verbs and the platform
 bus; it stays minimal by design (no HTTP route until a transport need is real).
 """
 
 from __future__ import annotations
 
-from src.counter.extension.api.insight import read_count
-from src.counter.extension.api.write import record_increment
+from src.counter.extension.facade.insight import read_count
+from src.counter.extension.facade.write import record_increment
 
 __all__ = ["read_count", "record_increment"]

--- a/apps/backend/src/counter/extension/facade/insight.py
+++ b/apps/backend/src/counter/extension/facade/insight.py
@@ -5,10 +5,10 @@ This is the one thin, async read the package exposes for callers that hold an
 :class:`Count`. Reporting asks "how many times did X happen — overall, or for
 this user" by calling this with ``user_id=None`` (global) or a concrete user.
 
-We keep ``api`` deliberately minimal: the package's primary published language is
+We keep the facade deliberately minimal: the package's primary published language is
 the in-process verbs (``increment`` / ``get_count``) over the
 :class:`CounterRepository` port; no HTTP route is added until a transport need is
-real. ``api`` is the only place the async session meets the domain verbs.
+real. The facade is the only place the async session meets the domain verbs.
 """
 
 from __future__ import annotations

--- a/apps/backend/src/counter/extension/facade/write.py
+++ b/apps/backend/src/counter/extension/facade/write.py
@@ -7,7 +7,7 @@ transaction. The caller commits once: tally upsert + outbox row commit together,
 or — on rollback — neither persists. That single-session sharing is what makes
 the event atomic with the state change (the heart of the transactional outbox).
 
-``api`` is the only role that combines the session with the domain verbs and with
+The facade is the only role that combines the session with the domain verbs and with
 the platform bus; ``ops.increment`` stays a pure, session-free verb that the
 in-memory fake can unit-test. Dispatch is NOT done here — the row is left
 ``pending`` for the relay to deliver post-commit.

--- a/apps/backend/src/identity/extension/api/auth.py
+++ b/apps/backend/src/identity/extension/api/auth.py
@@ -195,8 +195,9 @@ async def login(
 @router.get("/me", response_model=AuthResponse)
 async def get_me(
     token: str | None = Depends(oauth2_scheme),
-    user_id: CurrentUserId = None,
-    db: DbSession = None,
+    *,
+    user_id: CurrentUserId,
+    db: DbSession,
 ) -> AuthResponse:
     """Get current authenticated user."""
     result = await db.execute(select(User).where(User.id == user_id))

--- a/apps/backend/src/identity/extension/api/users.py
+++ b/apps/backend/src/identity/extension/api/users.py
@@ -60,7 +60,8 @@ def _require_in_flight_parse_checker() -> InFlightParseChecker:
 @router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
 async def create_user(
     user_data: UserCreate,
-    user_id: CurrentUserId = None,
+    *,
+    user_id: CurrentUserId,
 ) -> UserResponse:
     """Deprecated user creation route.
 
@@ -75,8 +76,9 @@ async def create_user(
 async def list_users(
     limit: int = Query(50, ge=1, le=100, description="Maximum items to return"),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> UserListResponse:
     """List the authenticated user's profile only."""
     scoped_query = select(User).where(User.id == user_id)
@@ -95,8 +97,9 @@ async def list_users(
 @router.get("/{user_id}", response_model=UserResponse)
 async def get_user(
     user_id: UUID,
-    db: DbSession = None,
-    current_user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    current_user_id: CurrentUserId,
 ) -> UserResponse:
     """Get current user by ID without cross-user disclosure."""
     if user_id != current_user_id:
@@ -115,8 +118,9 @@ async def get_user(
 async def update_user(
     user_id: UUID,
     user_data: UserUpdate,
-    db: DbSession = None,
-    current_user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    current_user_id: CurrentUserId,
 ) -> UserResponse:
     """Update current user details without cross-user mutation."""
     if user_id != current_user_id:
@@ -144,8 +148,9 @@ async def update_user(
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_user(
     user_id: UUID,
-    db: DbSession = None,
-    current_user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    current_user_id: CurrentUserId,
 ) -> None:
     """Delete the authenticated user's own account."""
     if user_id != current_user_id:

--- a/apps/backend/src/main.py
+++ b/apps/backend/src/main.py
@@ -2,21 +2,17 @@
 """Finance Report Backend - FastAPI Application."""
 
 import asyncio
-import os
 import time
 import traceback
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
-from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
 import structlog
-from fastapi import Depends, FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from sqlalchemy import select, text
-from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 # Eagerly register every ORM model on Base.metadata at app startup so SQLAlchemy
@@ -27,7 +23,7 @@ from src.advisor import register_fx_conversion, register_fx_pairs_read
 from src.boot import Bootloader, BootMode
 from src.composition import market_data_scopes, observed_fx_pairs
 from src.config import settings
-from src.database import async_session_maker, engine, get_db, init_db
+from src.database import async_session_maker, engine, init_db
 from src.extraction import (
     find_in_flight_parse_id,
     find_uploaded_document_filename_by_hash,
@@ -47,8 +43,8 @@ from src.observability import (
     configure_database_pool_metrics,
     configure_logging,
     configure_otel_metrics,
+    current_request_id,
     get_logger,
-    get_observability_status,
     http_route_label_from_scope,
     log_observability_startup,
     log_security_warning,
@@ -62,11 +58,11 @@ from src.platform import (
     RateLimitConfig,
     RateLimiter,
     SubscriberRegistry,
+    platform_system_router,
     register_readiness_provider,
     register_statement_reader,
     register_uploaded_document_readers,
 )
-from src.platform.orm.ping_state import PingState
 from src.portfolio import PositionService
 from src.pricing import (
     PrefetchedFxRates,
@@ -108,8 +104,11 @@ from src.routers import (
     workflow,
 )
 from src.routers.reconciliation import router as reconciliation_router
-from src.runtime import register_known_storage_paths_provider, resolve_env_tier, run_storage_sweep
-from src.schemas import PingStateResponse
+from src.runtime import (
+    register_known_storage_paths_provider,
+    run_storage_sweep,
+    runtime_system_router,
+)
 from src.schemas.errors import (
     COMMON_ERROR_RESPONSES,
     ErrorCode,
@@ -459,14 +458,10 @@ async def global_rate_limit_middleware(request: Request, call_next: Any) -> Resp
     return await call_next(request)
 
 
-def _current_request_id() -> str | None:
-    return structlog.contextvars.get_contextvars().get("request_id")
-
-
 @app.exception_handler(BaseAppException)
 async def base_app_exception_handler(request: Request, exc: BaseAppException) -> JSONResponse:
     """Handle BaseAppException: return structured JSON with error_id and correct HTTP status."""
-    request_id = _current_request_id()
+    request_id = current_request_id()
     logger.warning(
         "Application exception",
         error_id=exc.error_id,
@@ -487,7 +482,7 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
     branch on a code instead of parsing ``detail`` text. ``detail`` is preserved as
     a human-readable string for display and back-compat with existing callers.
     """
-    request_id = _current_request_id()
+    request_id = current_request_id()
     # Preserve the original ``detail`` verbatim: most call sites pass a string, but a
     # few raise ``HTTPException(detail={...})`` with a structured body. We add
     # ``error_id``/``request_id`` around it rather than coercing it to a string, so
@@ -517,7 +512,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
         detail = "An internal server error occurred. Please try again later."
         trace = None
 
-    request_id = _current_request_id()
+    request_id = current_request_id()
     content: dict[str, Any] = ErrorResponse(
         error_id=ErrorCode.INTERNAL_ERROR.value,
         detail=detail,
@@ -566,120 +561,5 @@ app.include_router(user_settings.router, **_router_kwargs)
 app.include_router(llm.router, **_router_kwargs)
 app.include_router(portfolio.router, **_router_kwargs)
 app.include_router(workflow.router, **_router_kwargs)
-
-
-# --- Health & Demo Endpoints ---
-
-
-@app.get("/health")
-async def health_check(full: bool = False, db: AsyncSession = Depends(get_db)) -> Response:
-    """Check application health status with dependency checks.
-
-    Returns 200 if all critical services are healthy, 503 otherwise.
-    This endpoint is used by Docker healthcheck and deployment verification.
-
-    The default (frequent Docker healthcheck) stays light: database + S3.
-    ``?full=1`` asserts the FULL manifest-declared dependency set for this
-    environment's tier (smoke ↔ declaration parity, invariant 6 / #1578): every
-    dependency in ``DEPENDENCY_MANIFEST.required_for(tier)`` must be present or
-    the endpoint returns 503. The smoke test calls this form.
-    """
-    try:
-        # Use Bootloader's internal check methods to ensure consistency
-        # We don't use validate() here because we want granular report
-        checks = {}
-
-        # DB (Use session from dependency for consistency with request scope)
-        try:
-            await db.execute(text("SELECT 1"))
-            checks["database"] = True
-        except Exception:
-            checks["database"] = False
-
-        # S3
-        s3_res = await Bootloader._check_s3()
-        checks["s3"] = s3_res.status == "ok"
-
-        tier = None
-        if full:
-            tier = resolve_env_tier(
-                settings.environment, github_actions=os.getenv("GITHUB_ACTIONS", "").lower() == "true"
-            )
-            probed, unprobed = Bootloader._required_checks(tier)
-            names = sorted(probed.keys() - {"database", "object_storage"})
-            # Probe concurrently — latency is the slowest single probe, not the sum
-            # (each probe has its own ~5s timeout and never raises for an outage).
-            results = await asyncio.gather(*(getattr(Bootloader, probed[name])() for name in names))
-            for name, result in zip(names, results, strict=True):
-                checks[name] = result.status == "ok"
-            for name in unprobed:  # declared before its probe lands: visible, failing
-                checks[name] = False
-
-        all_healthy = all(checks.values())
-        status_code = 200 if all_healthy else 503
-
-        content = {
-            "status": "healthy" if all_healthy else "unhealthy",
-            "timestamp": datetime.now(UTC).isoformat(),
-            "version": settings.git_commit_sha,
-            "git_sha": settings.git_commit_sha,
-            "checks": checks,
-            "observability": get_observability_status(),
-        }
-        if tier is not None:
-            content["tier"] = tier.value
-            # #1828 G-staleness-watchdog-visible: informational only — computed
-            # AFTER the verdict, never in ``checks`` (the manifest-parity set)
-            # and never an input to ``all_healthy``. The out-of-band watchdog
-            # axis (#1653) reads it; boot semantics are unchanged.
-            content["vault_secrets"] = Bootloader.vault_secrets_snapshot()
-        return JSONResponse(status_code=status_code, content=content)
-    except Exception as e:
-        logger.error(
-            "Health check: Unexpected error in endpoint",
-            error=str(e),
-            error_type=type(e).__name__,
-            error_module=type(e).__module__,
-        )
-        return JSONResponse(
-            status_code=503,
-            content={
-                "status": "error",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "error": "Health check failed with unexpected error",
-                "error_type": type(e).__name__,
-            },
-        )
-
-
-@app.get("/ping", response_model=PingStateResponse)
-async def get_ping_state(db: AsyncSession = Depends(get_db)) -> PingStateResponse:
-    """Get current ping-pong state."""
-    result = await db.execute(select(PingState).order_by(PingState.id.desc()).limit(1))
-    state = result.scalar_one_or_none()
-
-    if state is None:
-        return PingStateResponse(state="ping", toggle_count=0, updated_at=None)
-
-    return PingStateResponse.model_validate(state)
-
-
-@app.post("/ping/toggle", response_model=PingStateResponse)
-async def toggle_ping_state(db: AsyncSession = Depends(get_db)) -> PingStateResponse:
-    """Toggle between ping and pong state."""
-    result = await db.execute(select(PingState).order_by(PingState.id.desc()).limit(1))
-    state = result.scalar_one_or_none()
-
-    if state is None:
-        new_state = PingState(state="pong", toggle_count=1)
-        db.add(new_state)
-        await db.commit()
-        await db.refresh(new_state)
-        return PingStateResponse.model_validate(new_state)
-
-    state.state = "pong" if state.state == "ping" else "ping"
-    state.toggle_count += 1
-    await db.commit()
-    await db.refresh(state)
-
-    return PingStateResponse.model_validate(state)
+app.include_router(runtime_system_router, **_router_kwargs)
+app.include_router(platform_system_router, **_router_kwargs)

--- a/apps/backend/src/observability/__init__.py
+++ b/apps/backend/src/observability/__init__.py
@@ -30,6 +30,7 @@ import src.config
 from src.observability.analytics import track
 from src.observability.audit import (
     current_request_id,
+    ensure_request_id,
     log_financial_mutation,
     log_security_warning,
     safe_error_message,
@@ -73,6 +74,7 @@ __all__ = [
     "configure_logging",
     "configure_otel_metrics",
     "current_request_id",
+    "ensure_request_id",
     "detect_pii",
     "get_logger",
     "get_observability_status",

--- a/apps/backend/src/observability/audit.py
+++ b/apps/backend/src/observability/audit.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 
@@ -53,6 +53,16 @@ def _redact_detected_pii(text: str) -> str:
 def current_request_id() -> str | None:
     value = structlog.contextvars.get_contextvars().get("request_id")
     return str(value) if value else None
+
+
+def ensure_request_id() -> str:
+    """Return the bound request id, creating and binding one when absent."""
+    value = current_request_id()
+    if value is not None:
+        return value
+    generated = str(uuid4())
+    structlog.contextvars.bind_contextvars(request_id=generated)
+    return generated
 
 
 def safe_error_message(message: object, *, limit: int = MAX_SAFE_ERROR_CHARS) -> str:

--- a/apps/backend/src/platform/__init__.py
+++ b/apps/backend/src/platform/__init__.py
@@ -71,6 +71,7 @@ _EXTENSION_EXPORTS = {
     "BaseAppException",
     "OutboxEventBus",
     "OutboxRelay",
+    "PingStateResponse",
     "RateLimitConfig",
     "RateLimiter",
     "RateLimitState",
@@ -93,6 +94,7 @@ _EXTENSION_EXPORTS = {
     "register_statement_reader",
     "register_uploaded_document_readers",
     "update_workflow_event_status",
+    "platform_system_router",
 }
 
 __all__ = [
@@ -106,6 +108,7 @@ __all__ = [
     "OutboxRelay",
     "OutboxRepository",
     "PingState",
+    "PingStateResponse",
     "RateLimitConfig",
     "RateLimitState",
     "RateLimiter",
@@ -151,6 +154,7 @@ __all__ = [
     "register_statement_reader",
     "register_uploaded_document_readers",
     "update_workflow_event_status",
+    "platform_system_router",
 ]
 
 
@@ -169,6 +173,7 @@ if TYPE_CHECKING:
         Outbox,
         OutboxEventBus,
         OutboxRelay,
+        PingStateResponse,
         RateLimitConfig,
         RateLimiter,
         RateLimitState,
@@ -178,6 +183,7 @@ if TYPE_CHECKING:
         get_workflow_status,
         list_workflow_events_response,
         paginate,
+        platform_system_router,
         raise_bad_request,
         raise_conflict,
         raise_gateway_timeout,

--- a/apps/backend/src/platform/extension/__init__.py
+++ b/apps/backend/src/platform/extension/__init__.py
@@ -14,6 +14,7 @@ satisfy.
 
 from __future__ import annotations
 
+from src.platform.extension.api import PingStateResponse, router as platform_system_router
 from src.platform.extension.bus import OutboxEventBus, RecordingEventBus
 from src.platform.extension.http_errors import (
     BaseAppException,
@@ -55,6 +56,7 @@ __all__ = [
     "Outbox",
     "OutboxEventBus",
     "OutboxRelay",
+    "PingStateResponse",
     "RateLimitConfig",
     "RateLimitState",
     "RateLimiter",
@@ -80,4 +82,5 @@ __all__ = [
     "register_statement_reader",
     "register_uploaded_document_readers",
     "update_workflow_event_status",
+    "platform_system_router",
 ]

--- a/apps/backend/src/platform/extension/api/__init__.py
+++ b/apps/backend/src/platform/extension/api/__init__.py
@@ -1,0 +1,5 @@
+"""Platform HTTP boundary."""
+
+from src.platform.extension.api.system import PingStateResponse, router
+
+__all__ = ["PingStateResponse", "router"]

--- a/apps/backend/src/platform/extension/api/system.py
+++ b/apps/backend/src/platform/extension/api/system.py
@@ -1,0 +1,54 @@
+"""System demo-state HTTP endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.database import get_db
+from src.platform.orm.ping_state import PingState
+
+router = APIRouter()
+
+
+class PingStateResponse(BaseModel):
+    """Ping demo-state response."""
+
+    state: str
+    toggle_count: int
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/ping", response_model=PingStateResponse)
+async def get_ping_state(db: AsyncSession = Depends(get_db)) -> PingStateResponse:
+    """Get current ping-pong state."""
+    result = await db.execute(select(PingState).order_by(PingState.id.desc()).limit(1))
+    state = result.scalar_one_or_none()
+    if state is None:
+        return PingStateResponse(state="ping", toggle_count=0, updated_at=None)
+    return PingStateResponse.model_validate(state)
+
+
+@router.post("/ping/toggle", response_model=PingStateResponse)
+async def toggle_ping_state(db: AsyncSession = Depends(get_db)) -> PingStateResponse:
+    """Toggle between ping and pong state."""
+    result = await db.execute(select(PingState).order_by(PingState.id.desc()).limit(1))
+    state = result.scalar_one_or_none()
+    if state is None:
+        new_state = PingState(state="pong", toggle_count=1)
+        db.add(new_state)
+        await db.commit()
+        await db.refresh(new_state)
+        return PingStateResponse.model_validate(new_state)
+
+    state.state = "pong" if state.state == "ping" else "ping"
+    state.toggle_count += 1
+    await db.commit()
+    await db.refresh(state)
+    return PingStateResponse.model_validate(state)

--- a/apps/backend/src/routers/chat.py
+++ b/apps/backend/src/routers/chat.py
@@ -42,8 +42,9 @@ SUGGESTIONS_CONTEXT_TIMEOUT_SECONDS = 2.0
 @router.post("", response_class=StreamingResponse)
 async def chat_message(
     payload: ChatRequest,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> StreamingResponse:
     """Send a chat message and stream the AI response."""
     service = AIAdvisorService()
@@ -105,8 +106,9 @@ async def chat_message(
 async def chat_history(
     session_id: UUID | None = Query(default=None),
     limit: int = Query(default=20, ge=1, le=200),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> ChatHistoryResponse:
     """Retrieve chat session history."""
     sessions: list[ChatSessionResponse] = []
@@ -217,8 +219,9 @@ async def chat_history(
 @router.delete("/session/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_session(
     session_id: UUID,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> None:
     """Soft-delete a chat session."""
     session = await get_owned_or_404(db, ChatSession, session_id, user_id, name="Chat session")
@@ -239,8 +242,9 @@ async def suggestions(
             ),
         ),
     ] = False,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> ChatSuggestionsResponse:
     """Return a suggested question list for the chat UI."""
     resolved_language = language or (detect_language(message) if message else "en")

--- a/apps/backend/src/routers/corrections.py
+++ b/apps/backend/src/routers/corrections.py
@@ -53,8 +53,9 @@ class CorrectionStatsResponse(BaseModel):
 @router.post("", response_model=CorrectionResponse, status_code=status.HTTP_201_CREATED)
 async def create_correction(
     body: CorrectionRequest,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> CorrectionResponse:
     """Record a user correction to an AI-suggested category.
 
@@ -81,8 +82,9 @@ async def create_correction(
 
 @router.get("/stats", response_model=CorrectionStatsResponse)
 async def correction_stats(
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> CorrectionStatsResponse:
     """Get correction statistics for the current user.
 

--- a/apps/backend/src/routers/journal.py
+++ b/apps/backend/src/routers/journal.py
@@ -61,8 +61,9 @@ async def list_journal_entries(
     end_date: date_type | None = None,
     limit: int = Query(50, ge=1, le=100, description="Maximum items to return"),
     offset: int = Query(0, ge=0, description="Number of items to skip"),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> JournalEntryListResponse:
     """List journal entries with pagination and filters."""
     query = select(JournalEntry).where(JournalEntry.user_id == user_id)
@@ -90,8 +91,9 @@ async def list_journal_entries(
 @router.get("/{entry_id}", response_model=JournalEntryResponse)
 async def get_journal_entry(
     entry_id: UUID,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> JournalEntryResponse:
     entry = await get_owned_or_404(
         db,
@@ -107,8 +109,9 @@ async def get_journal_entry(
 @router.post("/{entry_id}/postings", response_model=JournalEntryResponse)
 async def post_entry(
     entry_id: UUID,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> JournalEntryResponse:
     try:
         base_currency = await get_effective_base_currency(db)
@@ -138,8 +141,9 @@ async def post_entry(
 async def void_entry(
     entry_id: UUID,
     void_request: VoidJournalEntryRequest,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> JournalEntryResponse:
     try:
         base_currency = await get_effective_base_currency(db)
@@ -169,8 +173,9 @@ async def void_entry(
 @router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_journal_entry(
     entry_id: UUID,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> None:
     entry = await get_owned_or_404(db, JournalEntry, entry_id, user_id, name="Journal entry")
 

--- a/apps/backend/src/routers/portfolio.py
+++ b/apps/backend/src/routers/portfolio.py
@@ -41,7 +41,7 @@ from src.schemas.portfolio import (
     InvestmentPerformanceReportScheduleResponse,
     PortfolioSummaryDashboardResponse,
     PriceUpdateBatchResponse,
-    PriceUpdateRequest as SchemaPriceUpdateRequest,
+    PriceUpdateRequest,
     RealizedLotResponse,
 )
 
@@ -73,13 +73,6 @@ class PerformanceMetricsResponse(BaseModel):
     xirr: Decimal = Field(decimal_places=2)
     time_weighted_return: Decimal = Field(decimal_places=2)
     money_weighted_return: Decimal = Field(decimal_places=2)
-
-
-class PriceUpdateRequest(BaseModel):
-    asset_identifier: str
-    price: Decimal = Field(decimal_places=2)
-    currency: str = Field(min_length=3, max_length=3)
-    price_date: date
 
 
 class PriceUpdateBatchRequest(BaseModel):
@@ -529,21 +522,10 @@ async def update_prices(
         count=len(request.updates),
     )
 
-    # Map router request models to service schema models
-    schema_updates = [
-        SchemaPriceUpdateRequest(
-            asset_identifier=u.asset_identifier,
-            price_date=u.price_date,
-            price=u.price,
-            currency=u.currency,
-        )
-        for u in request.updates
-    ]
-
     results = await _portfolio_service.update_market_prices(
         db=db,
         user_id=user_id,
-        updates=schema_updates,
+        updates=request.updates,
     )
 
     await db.commit()

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -1,9 +1,8 @@
 """Reconciliation API router."""
 
 from decimal import Decimal
-from uuid import UUID, uuid4
+from uuid import UUID
 
-import structlog
 from fastapi import APIRouter, Query, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,7 +15,7 @@ from src.extraction import create_entry_from_txn
 from src.extraction.orm.layer2 import AtomicTransaction
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Direction, JournalEntry, ValidationError
-from src.observability import get_logger, log_financial_mutation, safe_error_message
+from src.observability import ensure_request_id, get_logger, log_financial_mutation, safe_error_message
 from src.platform import get_owned_or_404, raise_bad_request, raise_not_found
 from src.reconciliation import (
     MatchNotFoundError,
@@ -49,15 +48,6 @@ from src.schemas.reconciliation import (
 router = APIRouter(prefix="/reconciliation", tags=["reconciliation"])
 logger = get_logger(__name__)
 MAX_BATCH_CREATE_ALL = 200
-
-
-def _current_request_id() -> str:
-    value = structlog.contextvars.get_contextvars().get("request_id")
-    if value:
-        return str(value)
-    generated = str(uuid4())
-    structlog.contextvars.bind_contextvars(request_id=generated)
-    return generated
 
 
 def _unmatched_atomic_txn_query():
@@ -174,8 +164,9 @@ async def _load_transactions(
 @router.post("/runs", response_model=ReconciliationRunResponse, status_code=status.HTTP_200_OK)
 async def run_reconciliation(
     payload: ReconciliationRunRequest,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> ReconciliationRunResponse:
     statement: StatementSummary | None = None
     if payload.statement_id:
@@ -188,7 +179,7 @@ async def run_reconciliation(
         if statement is None:
             raise_not_found("Statement")
 
-    request_id = _current_request_id()
+    request_id = ensure_request_id()
     statement_id = str(payload.statement_id) if payload.statement_id else None
     logger.info(
         "reconciliation.run.started",
@@ -273,8 +264,9 @@ async def list_matches(
     status_filter: ReconciliationStatusEnum | None = Query(default=None, alias="status"),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> ReconciliationMatchListResponse:
     query = (
         select(ReconciliationMatch)
@@ -315,8 +307,9 @@ async def list_matches(
 async def pending_review_queue(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> ReconciliationMatchListResponse:
     matches = await get_pending_items(db, limit=limit, offset=offset, user_id=user_id)
     entry_summaries = await _load_entry_summaries(db, matches, user_id)

--- a/apps/backend/src/routers/reports.py
+++ b/apps/backend/src/routers/reports.py
@@ -81,6 +81,7 @@ from src.schemas.streaming import ExportStreamEnvelope, ExportStreamMediaType
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 logger = get_logger(__name__)
+DEFAULT_INCLUDE_RESTRICTED = False
 
 
 def _target_currency_pair(currency: str | None) -> list[str]:
@@ -140,7 +141,8 @@ async def _ensure_report_market_data_fresh(
 
 @router.get("/currencies", response_model=list[str])
 async def get_available_currencies(
-    db: DbSession = None,
+    *,
+    db: DbSession,
 ) -> list[str]:
     """Get list of currencies with FX data available."""
     base_stmt = select(FxRate.base_currency).distinct()
@@ -193,8 +195,9 @@ async def personal_report_package_readiness(
     start_date: date | None = None,
     end_date: date | None = None,
     as_of_date: date | None = None,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> PersonalReportPackageReadinessResponse:
     """Return deterministic readiness and blocker state for the personal package."""
     payload = await get_personal_report_package_readiness(
@@ -214,8 +217,9 @@ async def personal_report_package_framework_policy(
     start_date: date | None = None,
     end_date: date | None = None,
     as_of_date: date | None = None,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> FrameworkPolicyResult:
     """Return the selected framework policy result consumed by package assembly."""
     report_as_of = as_of_date or end_date or date.today()
@@ -242,8 +246,9 @@ async def personal_report_package_traceability(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
     as_of_date: date | None = Query(default=None),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> PersonalReportPackageTraceabilityResponse:
     """Return the package-level source-ledger-report traceability appendix."""
     payload = await build_personal_report_package_traceability_payload(
@@ -259,8 +264,9 @@ async def personal_report_package_traceability(
 @router.get("/package/annualized-income-schedule", response_model=AnnualizedIncomeScheduleResponse)
 async def annualized_income_schedule(
     as_of_date: date | None = Query(default=None),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> AnnualizedIncomeScheduleResponse:
     """Return report-ready annualized income and restricted compensation schedule."""
     return await generate_annualized_income_schedule(db, user_id, as_of_date=as_of_date)
@@ -420,41 +426,24 @@ async def _build_personal_report_package_snapshot_data(
 async def generate_personal_report_package_snapshot(
     db: DbSession,
     user_id: CurrentUserId,
-    request: PersonalReportPackageGenerateRequest | None = None,
-    framework_id: PersonalReportingFrameworkId = PersonalReportingFrameworkId.US_GAAP_LIKE,
-    start_date: date | None = None,
-    end_date: date | None = None,
-    as_of_date: date | None = None,
-    currency: str | None = Query(default=None, min_length=3, max_length=3),
-    include_restricted: bool = Query(default=False),
+    request: PersonalReportPackageGenerateRequest,
 ) -> PersonalReportPackageSnapshotResponse:
     """Generate and persist an immutable personal report package snapshot."""
-    if request is not None:
-        framework_id = request.framework_id
-        start_date = request.start_date
-        end_date = request.end_date
-        as_of_date = request.as_of_date
-        currency = request.currency
-        include_restricted = request.include_restricted
-    if not isinstance(currency, str):
-        currency = None
-    if not isinstance(include_restricted, bool):
-        include_restricted = False
     report_start, report_end, report_as_of = _package_dates(
-        start_date=start_date,
-        end_date=end_date,
-        as_of_date=as_of_date,
+        start_date=request.start_date,
+        end_date=request.end_date,
+        as_of_date=request.as_of_date,
     )
-    target_currency = _package_currency(currency)
+    target_currency = _package_currency(request.currency)
     snapshot_data = await _build_personal_report_package_snapshot_data(
         db=db,
         user_id=user_id,
-        framework_id=framework_id,
+        framework_id=request.framework_id,
         start_date=report_start,
         end_date=report_end,
         as_of_date=report_as_of,
         currency=target_currency,
-        include_restricted=include_restricted,
+        include_restricted=request.include_restricted,
     )
     snapshot = await ReportingSnapshotService().create_snapshot(
         db,
@@ -477,7 +466,7 @@ async def generate_personal_report_package_snapshot(
     # safe to call directly (tests) without a FastAPI BackgroundTasks instance.
     _track_analytics(
         "report_generated",
-        {"framework_id": framework_id.value, "currency": target_currency},
+        {"framework_id": request.framework_id.value, "currency": target_currency},
     )
     return _package_snapshot_response(snapshot)
 
@@ -548,9 +537,10 @@ async def export_personal_report_package_snapshot(
 async def balance_sheet(
     as_of_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    include_restricted: bool = Query(default=False),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    include_restricted: bool = Query(default=DEFAULT_INCLUDE_RESTRICTED),
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> BalanceSheetResponse:
     """Get balance sheet as of date."""
     try:
@@ -581,8 +571,9 @@ async def account_lineage(
     as_of_date: date | None = Query(default=None),
     start_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> AccountLineageResponse:
     """List the journal lines contributing to one account's report balance.
 
@@ -613,8 +604,9 @@ async def income_statement(
     currency: str | None = Query(default=None, min_length=3, max_length=3),
     tags: list[str] | None = Query(default=None, alias="tags"),
     account_type: AccountType | None = Query(default=None, alias="account_type"),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> IncomeStatementResponse:
     """Get income statement for a period with optional filtering."""
     try:
@@ -646,8 +638,9 @@ async def cash_flow(
     start_date: date = Query(...),
     end_date: date = Query(...),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> CashFlowResponse:
     """Get cash flow statement for a period."""
     try:
@@ -677,8 +670,9 @@ async def account_trend(
     account_id: UUID = Query(...),
     period: TrendPeriod = Query(default=TrendPeriod.MONTHLY),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> AccountTrendResponse:
     """Get account trend data."""
     try:
@@ -709,8 +703,9 @@ async def net_worth_timeseries(
     to_date: date = Query(..., alias="to"),
     granularity: NetWorthGranularity = Query(default=NetWorthGranularity.MONTHLY),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> NetWorthTimeSeriesResponse:
     """Get daily or monthly net worth time-series."""
     try:
@@ -741,9 +736,10 @@ async def net_worth_timeseries(
 async def net_worth_allocation(
     as_of_date: date | None = Query(default=None),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    include_restricted: bool = Query(default=True),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    include_restricted: bool = Query(default=DEFAULT_INCLUDE_RESTRICTED),
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> NetWorthAllocationResponse:
     """Get signed net-worth allocation grouped by asset class, liquidity, and source currency."""
     report_date = as_of_date or date.today()
@@ -774,8 +770,9 @@ async def category_breakdown(
     breakdown_type: BreakdownType = Query(..., alias="type"),
     period: BreakdownPeriod = Query(default=BreakdownPeriod.MONTHLY),
     currency: str | None = Query(default=None, min_length=3, max_length=3),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> CategoryBreakdownResponse:
     """Get income or expense category breakdown."""
     account_type = AccountType.INCOME if breakdown_type == BreakdownType.INCOME else AccountType.EXPENSE
@@ -811,8 +808,9 @@ async def export_report(
     currency: str | None = Query(default=None, min_length=3, max_length=3),
     include_restricted: bool = Query(default=False),
     framework_id: PersonalReportingFrameworkId | None = Query(default=None),
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> StreamingResponse:
     """Export reports in CSV format."""
     output = StringIO()
@@ -964,8 +962,9 @@ async def export_report(
 @router.get("/{report_type}/snapshots", response_model=list[ReportSnapshotSummary])
 async def list_report_snapshots(
     report_type: SnapshotReportType,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> list[ReportSnapshotSummary]:
     """List available report snapshots for a given report type.
 

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Annotated
 from uuid import UUID, uuid4
 
-import structlog
 from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile, status
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import Response
@@ -38,7 +37,7 @@ from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Account, AccountType
 from src.llm import LitellmCatalog, Modality
-from src.observability import ErrorIds, get_logger, safe_error_message
+from src.observability import ErrorIds, ensure_request_id, get_logger, safe_error_message
 from src.platform import (
     get_owned_or_404,
     raise_bad_request,
@@ -80,15 +79,6 @@ _BROKERAGE_IMPORT_SERVICE = BrokeragePositionImportService()
 def _track_task(task: asyncio.Task[None]) -> None:
     _PENDING_PARSE_TASKS.add(task)
     task.add_done_callback(_PENDING_PARSE_TASKS.discard)
-
-
-def _current_request_id() -> str | None:
-    value = structlog.contextvars.get_contextvars().get("request_id")
-    if value:
-        return str(value)
-    generated = str(uuid4())
-    structlog.contextvars.bind_contextvars(request_id=generated)
-    return generated
 
 
 async def _resolve_uploaded_document(
@@ -149,7 +139,7 @@ async def _queue_statement_reparse(
 
     storage = StorageService()
     content = await run_in_threadpool(storage.get_object, storage_key)
-    request_id = _current_request_id()
+    request_id = ensure_request_id()
     model_to_use = None if model == settings.ocr_model else model
     task = await submit_parse_pipeline(
         job=ParseJob(
@@ -232,8 +222,9 @@ async def upload_statement(
     institution: Annotated[str | None, Form()] = None,
     account_id: Annotated[UUID | None, Form()] = None,
     model: Annotated[str | None, Form()] = None,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> BankStatementResponse:
     """
     Upload a financial statement and enqueue parsing.
@@ -305,7 +296,7 @@ async def upload_statement(
                 raise_bad_request("Selected model does not support image/PDF inputs.")
 
     statement_id = uuid4()
-    request_id = _current_request_id()
+    request_id = ensure_request_id()
     model_to_use = None if model == settings.ocr_model else model
     logger.info(
         "statement.upload.accepted",
@@ -440,8 +431,9 @@ async def upload_statement(
 async def retry_statement_parsing(
     statement_id: UUID,
     request: RetryParsingRequest | None = None,
-    db: DbSession = None,
-    user_id: CurrentUserId = None,
+    *,
+    db: DbSession,
+    user_id: CurrentUserId,
 ) -> BankStatementResponse:
     """Retry parsing with a different model (e.g., stronger model for better accuracy)."""
     model_override = request.model if request else None
@@ -624,7 +616,7 @@ async def import_brokerage_statement_positions(
     payload = _brokerage_payload_from_persisted_extraction(statement=statement, uploaded_document=uploaded_document)
     if payload is None:
         payload = _brokerage_payload_from_statement(statement, transactions)
-    request_id = _current_request_id()
+    request_id = ensure_request_id()
     source_document_id = str(statement.uploaded_document_id or statement.id)
     logger.info(
         "statement.brokerage_import.started",

--- a/apps/backend/src/runtime/__init__.py
+++ b/apps/backend/src/runtime/__init__.py
@@ -10,6 +10,8 @@ cleanup phase (see `common/runtime/todo.md`).
 
 from __future__ import annotations
 
+from importlib import import_module
+
 from src.runtime.base.check import (
     DependencyCheck,
     DependencyStatus,
@@ -69,4 +71,14 @@ __all__ = [
     "register_known_storage_paths_provider",
     "resolve_env_tier",
     "run_storage_sweep",
+    "runtime_system_router",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Resolve the HTTP router lazily to avoid boot/runtime import cycles."""
+    if name != "runtime_system_router":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module("src.runtime.extension.api"), "router")
+    globals()[name] = value
+    return value

--- a/apps/backend/src/runtime/extension/api/__init__.py
+++ b/apps/backend/src/runtime/extension/api/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime HTTP boundary."""
+
+from src.runtime.extension.api.health import router
+
+__all__ = ["router"]

--- a/apps/backend/src/runtime/extension/api/__init__.py
+++ b/apps/backend/src/runtime/extension/api/__init__.py
@@ -1,5 +1,5 @@
 """Runtime HTTP boundary."""
 
-from src.runtime.extension.api.health import router
+from src.runtime.extension.api.health import health_check, router
 
-__all__ = ["router"]
+__all__ = ["health_check", "router"]

--- a/apps/backend/src/runtime/extension/api/health.py
+++ b/apps/backend/src/runtime/extension/api/health.py
@@ -1,0 +1,80 @@
+"""Application health HTTP endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.boot import Bootloader
+from src.config import settings
+from src.database import get_db
+from src.observability import get_logger, get_observability_status
+from src.runtime.base.tiers import resolve_env_tier
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+
+@router.get("/health")
+async def health_check(full: bool = False, db: AsyncSession = Depends(get_db)) -> Response:
+    """Return light or manifest-complete dependency health."""
+    try:
+        checks: dict[str, bool] = {}
+        try:
+            await db.execute(text("SELECT 1"))
+            checks["database"] = True
+        except Exception:
+            checks["database"] = False
+
+        s3_result = await Bootloader._check_s3()
+        checks["s3"] = s3_result.status == "ok"
+
+        tier = None
+        if full:
+            tier = resolve_env_tier(
+                settings.environment,
+                github_actions=os.getenv("GITHUB_ACTIONS", "").lower() == "true",
+            )
+            probed, unprobed = Bootloader._required_checks(tier)
+            names = sorted(probed.keys() - {"database", "object_storage"})
+            results = await asyncio.gather(*(getattr(Bootloader, probed[name])() for name in names))
+            for name, result in zip(names, results, strict=True):
+                checks[name] = result.status == "ok"
+            for name in unprobed:
+                checks[name] = False
+
+        all_healthy = all(checks.values())
+        content = {
+            "status": "healthy" if all_healthy else "unhealthy",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "version": settings.git_commit_sha,
+            "git_sha": settings.git_commit_sha,
+            "checks": checks,
+            "observability": get_observability_status(),
+        }
+        if tier is not None:
+            content["tier"] = tier.value
+            content["vault_secrets"] = Bootloader.vault_secrets_snapshot()
+        return JSONResponse(status_code=200 if all_healthy else 503, content=content)
+    except Exception as exc:  # noqa: BLE001 - health must always return a verdict
+        logger.error(
+            "Health check: Unexpected error in endpoint",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            error_module=type(exc).__module__,
+        )
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "error",
+                "timestamp": datetime.now(UTC).isoformat(),
+                "error": "Health check failed with unexpected error",
+                "error_type": type(exc).__name__,
+            },
+        )

--- a/apps/backend/src/schemas/account.py
+++ b/apps/backend/src/schemas/account.py
@@ -6,10 +6,10 @@ from enum import Enum
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from src.ledger import AccountType
-from src.schemas.base import BaseResponse, ListResponse, MoneyAmount
+from src.schemas.base import BaseResponse, CurrencyCode, ListResponse, MoneyAmount
 
 
 class OpeningBalanceRequest(BaseModel):
@@ -21,17 +21,8 @@ class OpeningBalanceRequest(BaseModel):
 
     entry_date: date
     balances: dict[UUID, Annotated[Decimal, Field(gt=Decimal("0"), decimal_places=2)]]
-    currency: Annotated[str, Field(min_length=3, max_length=3)] | None = None
+    currency: CurrencyCode | None = None
     memo: Annotated[str, Field(min_length=1, max_length=500)] = "Opening balances"
-
-    @field_validator("currency", mode="before")
-    @classmethod
-    def normalize_currency(cls, value: object) -> object:
-        # Strip + uppercase before the length check so " sgd " normalizes to "SGD",
-        # consistent with currency normalization elsewhere (e.g. reporting).
-        if isinstance(value, str):
-            return value.strip().upper()
-        return value
 
 
 class OpeningBalanceReadinessResponse(BaseModel):
@@ -54,7 +45,7 @@ class AccountBase(BaseModel):
     name: Annotated[str, Field(min_length=1, max_length=255)]
     code: Annotated[str | None, Field(None, max_length=50)]
     type: AccountType
-    currency: Annotated[str, Field(min_length=3, max_length=3)] = "SGD"
+    currency: CurrencyCode = "SGD"
     parent_id: UUID | None = None
     description: Annotated[str | None, Field(None, max_length=500)] = None
 
@@ -105,7 +96,7 @@ class AccountCoverageIssueType(str, Enum):
 class AccountCoverageIssue(BaseResponse):
     type: AccountCoverageIssueType
     severity: str
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     period_start: date
     period_end: date
     statement_id: UUID | None = None
@@ -118,7 +109,7 @@ class AccountCoverageIssue(BaseResponse):
 class AccountCoverageResponse(BaseResponse):
     account_id: UUID
     account_name: str
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     cadence: AccountCoverageCadence
     latest_source_date: date | None = None
     latest_confirmed_balance: MoneyAmount | None = None
@@ -139,7 +130,7 @@ class ProcessingSummaryResponse(BaseResponse):
     pending_count: int
     pending_total: MoneyAmount
     current_balance: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     oldest_pending_date: date | None = None
 
 
@@ -148,7 +139,7 @@ class ProcessingPendingItem(BaseResponse):
     from_account: str
     to_account: str
     amount: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     initiated_date: date
     days_outstanding: int
     description: str

--- a/apps/backend/src/schemas/assets.py
+++ b/apps/backend/src/schemas/assets.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import BaseModel, Field, computed_field, field_validator
+from pydantic import BaseModel, Field, computed_field
 
 from src.extraction.orm.layer3 import (
     ManualValuationBasis,
@@ -12,7 +12,7 @@ from src.extraction.orm.layer3 import (
     ManualValuationLiquidityClass,
     PositionStatus,
 )
-from src.schemas.base import BaseResponse, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Quantity
+from src.schemas.base import BaseResponse, CurrencyCode, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Quantity
 from src.schemas.provenance import DataProvenance
 
 
@@ -28,7 +28,7 @@ class ManagedPositionResponse(BaseResponse):
     acquisition_date: date
     disposal_date: date | None = None
     status: PositionStatus
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     position_metadata: dict | None = None
     created_at: datetime
     updated_at: datetime
@@ -39,7 +39,7 @@ class ManagedPositionResponse(BaseResponse):
     # Null when no FX rate is available — an FX failure must never 500 a read
     # (the #1388 lesson), so the reporting view degrades to null instead.
     reporting_cost_basis: MoneyAmount | None = None
-    reporting_currency: Annotated[str, Field(min_length=3, max_length=3)] | None = None
+    reporting_currency: CurrencyCode | None = None
 
     # Denormalized fields from related Account (optional)
     account_name: str | None = None
@@ -93,18 +93,13 @@ class ManualValuationSnapshotCreate(BaseModel):
     component_type: ManualValuationComponentType
     as_of_date: date
     value: NonNegativeMoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     source: Annotated[str, Field(min_length=1, max_length=120)]
     valuation_basis: ManualValuationBasis | None = None
     notes: str | None = None
     liquidity_class: ManualValuationLiquidityClass | None = None
     recurrence_days: Annotated[int, Field(ge=1, le=3660)] | None = None
     reminder_date: date | None = None
-
-    @field_validator("currency")
-    @classmethod
-    def normalize_currency(cls, value: str) -> str:
-        return value.upper()
 
 
 class ManualValuationSnapshotUpdate(BaseModel):
@@ -113,18 +108,13 @@ class ManualValuationSnapshotUpdate(BaseModel):
     component_type: ManualValuationComponentType | None = None
     as_of_date: date | None = None
     value: NonNegativeMoneyAmount | None = None
-    currency: Annotated[str, Field(min_length=3, max_length=3)] | None = None
+    currency: CurrencyCode | None = None
     source: Annotated[str, Field(min_length=1, max_length=120)] | None = None
     valuation_basis: ManualValuationBasis | None = None
     notes: str | None = None
     liquidity_class: ManualValuationLiquidityClass | None = None
     recurrence_days: Annotated[int, Field(ge=1, le=3660)] | None = None
     reminder_date: date | None = None
-
-    @field_validator("currency")
-    @classmethod
-    def normalize_currency(cls, value: str | None) -> str | None:
-        return value.upper() if value else value
 
 
 class ManualValuationSnapshotResponse(BaseResponse):
@@ -136,7 +126,7 @@ class ManualValuationSnapshotResponse(BaseResponse):
     liquidity_class: ManualValuationLiquidityClass
     as_of_date: date
     value: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     source: str
     valuation_basis: ManualValuationBasis | None = None
     notes: str | None = None
@@ -155,7 +145,7 @@ class ValuationComponentResponse(BaseModel):
     liquidity_class: ManualValuationLiquidityClass
     as_of_date: date
     value: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     source: str
     provenance: DataProvenance = "manual"
 
@@ -184,7 +174,7 @@ class RestrictedHoldingResponse(BaseModel):
     vesting_schedule: str | None = None
     unlock_date: date | None = None
     fair_value: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
 
 
 ManagedPositionListResponse = ListResponse[ManagedPositionResponse]

--- a/apps/backend/src/schemas/extraction.py
+++ b/apps/backend/src/schemas/extraction.py
@@ -7,10 +7,10 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.extraction.orm.statement_enums import BankStatementStatus
-from src.schemas.base import ListResponse
+from src.schemas.base import CurrencyCode, ListResponse
 
 if TYPE_CHECKING:
     from src.extraction import UploadedDocument
@@ -34,16 +34,11 @@ class CurrencyBalance(BaseModel):
     are out of scope here and tracked as follow-up.
     """
 
-    currency: str = Field(..., description="ISO currency code (normalized upper-case)")
+    currency: CurrencyCode = Field(description="ISO currency code (normalized upper-case)")
     opening: Decimal = Field(..., description="Opening balance in this currency")
     closing: Decimal = Field(..., description="Closing balance in this currency")
 
     model_config = ConfigDict(from_attributes=True)
-
-    @field_validator("currency")
-    @classmethod
-    def _normalize_currency(cls, value: str) -> str:
-        return value.strip().upper()
 
 
 # --- Request Schemas ---

--- a/apps/backend/src/schemas/journal.py
+++ b/apps/backend/src/schemas/journal.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from src.audit import JournalEntrySourceType, normalize_source_type
 from src.ledger import ConfidenceTier, Direction, JournalEntryStatus
-from src.schemas.base import BaseResponse, ListResponse
+from src.schemas.base import BaseResponse, CurrencyCode, ListResponse
 
 
 class JournalLineBase(BaseModel):
@@ -18,7 +18,7 @@ class JournalLineBase(BaseModel):
     account_id: UUID
     direction: Direction
     amount: Annotated[Decimal, Field(gt=0, decimal_places=2)]
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     fx_rate: Annotated[Decimal | None, Field(None, gt=0, decimal_places=6)] = None
     event_type: Annotated[str | None, Field(None, max_length=100)] = None
     tags: dict | None = None
@@ -27,7 +27,7 @@ class JournalLineBase(BaseModel):
 class JournalLineCreate(JournalLineBase):
     """Schema for creating a journal line."""
 
-    currency: Annotated[str | None, Field(min_length=3, max_length=3)] = None
+    currency: CurrencyCode | None = None
 
 
 class JournalLineResponse(JournalLineBase, BaseResponse):

--- a/apps/backend/src/schemas/ping.py
+++ b/apps/backend/src/schemas/ping.py
@@ -1,15 +1,5 @@
-"""Ping state schemas."""
+"""Compatibility re-export for the platform-owned ping wire response."""
 
-from datetime import datetime
+from src.platform import PingStateResponse
 
-from pydantic import BaseModel, ConfigDict
-
-
-class PingStateResponse(BaseModel):
-    """Schema for ping state response."""
-
-    state: str
-    toggle_count: int
-    updated_at: datetime | None = None
-
-    model_config = ConfigDict(from_attributes=True)
+__all__ = ["PingStateResponse"]

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -9,7 +9,15 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 
 from src.extraction import reject_json_floats
 from src.extraction.orm.layer3 import CostBasisMethod, PositionStatus
-from src.schemas.base import BaseResponse, ListResponse, MoneyAmount, NonNegativeMoneyAmount, Percent, Quantity
+from src.schemas.base import (
+    BaseResponse,
+    CurrencyCode,
+    ListResponse,
+    MoneyAmount,
+    NonNegativeMoneyAmount,
+    Percent,
+    Quantity,
+)
 from src.schemas.provenance import DataProvenance
 
 
@@ -25,12 +33,12 @@ class HoldingResponse(BaseResponse):
     market_value: MoneyAmount
     unrealized_pnl: MoneyAmount
     unrealized_pnl_percent: Percent
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     # #1098: pre-conversion native cost basis + currency, so a holding's base view
     # (cost_basis/currency) reconciles with the native view returned by
     # /assets/positions. These are the raw position values before convert_money.
     native_cost_basis: MoneyAmount
-    native_currency: Annotated[str, Field(min_length=3, max_length=3)]
+    native_currency: CurrencyCode
     acquisition_date: date
     disposal_date: date | None = None
     status: PositionStatus
@@ -116,7 +124,7 @@ class PriceUpdateRequest(BaseModel):
     asset_identifier: Annotated[str, Field(min_length=1, max_length=100)]
     price_date: Annotated[date, Field(description="Date of the price (default: today)")]
     price: NonNegativeMoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
 
 
 class PriceUpdateResponse(BaseModel):
@@ -164,7 +172,7 @@ class PortfolioSummaryResponse(BaseModel):
     holdings_count: int
     active_positions_count: int
     disposed_positions_count: int
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
 
 
 class PortfolioSummaryDashboardResponse(PortfolioSummaryResponse):
@@ -184,7 +192,7 @@ class InvestmentPerformanceHoldingRow(BaseModel):
     unrealized_pnl: MoneyAmount
     realized_pnl: MoneyAmount
     dividend_income: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
 
 
 class InvestmentPerformanceAllocationRow(BaseModel):
@@ -213,7 +221,7 @@ class InvestmentPerformanceReportScheduleResponse(BaseModel):
     period_start: date
     period_end: date
     as_of_date: date
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     xirr: Annotated[Decimal | None, Field(decimal_places=2)]
     time_weighted_return: Annotated[Decimal | None, Field(decimal_places=2)]
     money_weighted_return: Annotated[Decimal | None, Field(decimal_places=2)]
@@ -235,7 +243,7 @@ class DividendEventResponse(BaseModel):
     ex_date: date
     pay_date: date
     amount: MoneyAmount
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
     reinvested: bool = False
 
 
@@ -250,7 +258,7 @@ class RealizedLotResponse(BaseModel):
     proceeds: MoneyAmount
     gain_loss: MoneyAmount
     holding_period: int | None = None
-    currency: Annotated[str, Field(min_length=3, max_length=3)]
+    currency: CurrencyCode
 
 
 class CostBasisMethodUpdateRequest(BaseModel):

--- a/apps/backend/src/schemas/reporting.py
+++ b/apps/backend/src/schemas/reporting.py
@@ -15,6 +15,7 @@ from src.reporting.base.types import (
     PolicyDimension,
     ReportLineId as ReportLineId,
 )
+from src.schemas.base import CurrencyCode
 from src.schemas.provenance import DataProvenance
 
 _FRAMEWORK_POLICY_LINE_MAPPING_TARGETS = frozenset({"balance_sheet", "income_statement", "cash_flow", "notes"})
@@ -640,7 +641,7 @@ class PersonalReportPackageGenerateRequest(BaseModel):
     start_date: date | None = Field(default=None, description="Requested reporting period start date")
     end_date: date | None = Field(default=None, description="Requested reporting period end date")
     as_of_date: date | None = Field(default=None, description="Requested point-in-time report date")
-    currency: str | None = Field(
+    currency: CurrencyCode | None = Field(
         default=None,
         description="Requested presentation currency",
         min_length=3,

--- a/apps/backend/tests/ai/test_chat_router.py
+++ b/apps/backend/tests/ai/test_chat_router.py
@@ -13,7 +13,7 @@ async def test_chat_suggestions_en() -> None:
     """AC-advisor.suggestions.2: AC6.2.4 AC6.5.1: Chat suggestions endpoint returns English suggestions."""
     from src.routers.chat import suggestions
 
-    response = await suggestions(language="en")
+    response = await suggestions(language="en", db=MagicMock(), user_id=uuid4())
     assert response.suggestions
     assert "What are my expenses" in response.suggestions[0]
 
@@ -22,7 +22,7 @@ async def test_chat_suggestions_zh() -> None:
     """AC-advisor.suggestions.1: AC6.2.3 AC6.5.2: Chat suggestions endpoint returns Chinese suggestions."""
     from src.routers.chat import suggestions
 
-    response = await suggestions(language="zh")
+    response = await suggestions(language="zh", db=MagicMock(), user_id=uuid4())
     assert response.suggestions
     assert "支出" in response.suggestions[0]
 
@@ -31,7 +31,7 @@ async def test_chat_suggestions_auto_detect_zh() -> None:
     """AC-advisor.language.3: AC6.2.5: Auto-detect Chinese language from message."""
     from src.routers.chat import suggestions
 
-    response = await suggestions(language=None, message="这个月花了多少钱")
+    response = await suggestions(language=None, message="这个月花了多少钱", db=MagicMock(), user_id=uuid4())
     assert response.suggestions
     assert response.suggestions[0].startswith("这个月")
 
@@ -40,7 +40,7 @@ async def test_chat_suggestions_auto_detect_en() -> None:
     """AC-advisor.language.4: AC6.2.6: Auto-detect English language from message."""
     from src.routers.chat import suggestions
 
-    response = await suggestions(message="What are my expenses?")
+    response = await suggestions(message="What are my expenses?", db=MagicMock(), user_id=uuid4())
     assert response.suggestions
     assert "What are my expenses" in response.suggestions[0]
 
@@ -162,7 +162,7 @@ async def test_chat_error_api_key_unavailable() -> None:
         payload.model = None
 
         with pytest.raises(HTTPException) as exc_info:
-            await chat_message(payload, mock_db, mock_user_id)
+            await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert exc_info.value.status_code == 503
         assert "temporarily unavailable" in exc_info.value.detail.lower()
@@ -188,7 +188,7 @@ async def test_chat_error_session_not_found() -> None:
         payload.model = None
 
         with pytest.raises(HTTPException) as exc_info:
-            await chat_message(payload, mock_db, mock_user_id)
+            await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert exc_info.value.status_code == 404
 
@@ -212,7 +212,7 @@ async def test_chat_error_bad_request() -> None:
         payload.session_id = None
 
         with pytest.raises(HTTPException) as exc_info:
-            await chat_message(payload, mock_db, mock_user_id)
+            await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert exc_info.value.status_code == 400
 
@@ -242,7 +242,7 @@ async def test_chat_with_model_name_header() -> None:
         payload.session_id = None
         payload.model = None
 
-        response = await chat_message(payload, mock_db, mock_user_id)
+        response = await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert response.headers.get("X-Model-Name") == "gpt-4"
         assert "X-Model-Name" in response.headers.get("Access-Control-Expose-Headers", "")
@@ -295,7 +295,7 @@ async def test_AC22_14_1_chat_response_exposes_grounding_metadata_header() -> No
         payload.session_id = None
         payload.model = None
 
-        response = await chat_message(payload, mock_db, mock_user_id)
+        response = await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
     assert response.headers.get("X-Advisor-Metadata") is not None
     assert "X-Advisor-Metadata" in response.headers.get("Access-Control-Expose-Headers", "")
@@ -326,7 +326,7 @@ async def test_chat_without_model_name_header() -> None:
         payload.session_id = None
         payload.model = None
 
-        response = await chat_message(payload, mock_db, mock_user_id)
+        response = await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert response.headers.get("X-Model-Name") is None
 
@@ -343,7 +343,7 @@ async def test_delete_session_not_found() -> None:
     session_id = uuid4()
 
     with pytest.raises(HTTPException) as exc_info:
-        await delete_session(session_id, mock_db, mock_user_id)
+        await delete_session(session_id, db=mock_db, user_id=mock_user_id)
 
     assert exc_info.value.status_code == 404
 
@@ -361,7 +361,7 @@ async def test_delete_session_success() -> None:
     mock_user_id = uuid4()
     session_id = uuid4()
 
-    await delete_session(session_id, mock_db, mock_user_id)
+    await delete_session(session_id, db=mock_db, user_id=mock_user_id)
 
     assert mock_session.status == ChatSessionStatus.DELETED
     mock_db.commit.assert_awaited_once()
@@ -517,7 +517,7 @@ async def test_chat_with_allowed_model():
         payload.session_id = None
         payload.model = "allowed_model"
 
-        response = await chat_message(payload, mock_db, mock_user_id)
+        response = await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert response.headers.get("X-Model-Name") == "allowed_model"
         # An allowed model never hits the catalogue.
@@ -559,7 +559,7 @@ async def test_chat_with_known_external_model():
         payload.session_id = None
         payload.model = "external_model"
 
-        response = await chat_message(payload, mock_db, mock_user_id)
+        response = await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert response.headers.get("X-Model-Name") == "external_model"
         mock_get.assert_called_once_with("external_model")
@@ -593,7 +593,7 @@ async def test_chat_with_unknown_external_model():
         payload.model = "unknown_model"
 
         with pytest.raises(HTTPException) as exc_info:
-            await chat_message(payload, mock_db, mock_user_id)
+            await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert exc_info.value.status_code == 400
         assert "Invalid model selection" in exc_info.value.detail
@@ -627,7 +627,7 @@ async def test_chat_with_model_validation_error():
         payload.model = "unknown_model"
 
         with pytest.raises(HTTPException) as exc_info:
-            await chat_message(payload, mock_db, mock_user_id)
+            await chat_message(payload, db=mock_db, user_id=mock_user_id)
 
         assert exc_info.value.status_code == 503
         assert "Unable to validate requested model" in exc_info.value.detail

--- a/apps/backend/tests/ai/test_streaming_contract.py
+++ b/apps/backend/tests/ai/test_streaming_contract.py
@@ -188,7 +188,7 @@ async def test_AC6_33_7_chat_router_uses_envelope_media_type_and_headers() -> No
         payload.session_id = None
         payload.model = None
 
-        response = await chat_message(payload, mock_db, uuid4())
+        response = await chat_message(payload, db=mock_db, user_id=uuid4())
 
     assert response.media_type == ChatStreamMediaType.TEXT_PLAIN.value
     assert response.headers["X-Session-Id"] == str(session_id)

--- a/apps/backend/tests/api/test_api_surface_consistency.py
+++ b/apps/backend/tests/api/test_api_surface_consistency.py
@@ -16,6 +16,7 @@ PR1 of the sweep (this file's AC-platform.29.4/.5):
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 from uuid import uuid4
@@ -27,9 +28,12 @@ from httpx import AsyncClient
 import src.routers as _routers_pkg
 from src.deps import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
 from src.main import app
+from src.routers.reports import DEFAULT_INCLUDE_RESTRICTED
 
 _ROUTER_DIR = Path(_routers_pkg.__file__).resolve().parent
 _RAW_STATUS_CODE = re.compile(r"status_code\s*=\s*\d")
+_BACKEND_SRC = _ROUTER_DIR.parent
+_DISHONEST_DEPENDENCY_DEFAULT = re.compile(r"(?:DbSession|CurrentUserId)\s*=\s*None")
 
 # The list endpoints #1099 named as unbounded; each must now accept bounded
 # limit/offset (AC-platform.29.2).
@@ -163,6 +167,103 @@ def test_AC12_29_2_named_unbounded_endpoints_are_bounded() -> None:
         )
         assert limit_schema.get("minimum") == 1
         assert params["offset"]["schema"].get("minimum") == 0
+
+
+def test_AC_platform_29_7_every_get_limit_has_an_upper_bound() -> None:
+    """AC-platform.29.7: every GET ``limit`` parameter has a finite maximum."""
+    offenders: list[str] = []
+    for path, path_item in app.openapi()["paths"].items():
+        operation = path_item.get("get")
+        if operation is None:
+            continue
+        for parameter in operation.get("parameters", []):
+            if parameter.get("in") != "query" or parameter.get("name") != "limit":
+                continue
+            maximum = parameter.get("schema", {}).get("maximum")
+            if not isinstance(maximum, int | float):
+                offenders.append(path)
+
+    assert not offenders, f"GET limit parameters without an explicit upper bound: {offenders}"
+
+
+def _top_level_model_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and any(
+            (isinstance(base, ast.Name) and base.id == "BaseModel")
+            or (isinstance(base, ast.Attribute) and base.attr == "BaseModel")
+            for base in node.bases
+        )
+    }
+
+
+def test_AC_platform_29_8_delivery_helpers_have_one_honest_home() -> None:
+    """AC-platform.29.8: delivery DTOs, dependencies, and helpers have one home."""
+    router_models: dict[str, list[str]] = {}
+    schema_models: dict[str, list[str]] = {}
+    dishonest_defaults: list[str] = []
+    normalize_currency_defs: list[str] = []
+    request_id_defs: list[str] = []
+
+    for path in sorted(_BACKEND_SRC.rglob("*.py")):
+        relative = path.relative_to(_BACKEND_SRC).as_posix()
+        source = path.read_text(encoding="utf-8")
+        for match in _DISHONEST_DEPENDENCY_DEFAULT.finditer(source):
+            dishonest_defaults.append(f"{relative}:{source.count(chr(10), 0, match.start()) + 1}")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if node.name == "normalize_currency" and relative != "schemas/base.py":
+                normalize_currency_defs.append(f"{relative}:{node.lineno}")
+            if "request_id" in node.name and node.name in {
+                "_current_request_id",
+                "current_request_id",
+                "ensure_request_id",
+            }:
+                request_id_defs.append(f"{relative}:{node.name}")
+
+    for path in sorted(_ROUTER_DIR.glob("*.py")):
+        for name in _top_level_model_names(path):
+            router_models.setdefault(name, []).append(path.name)
+    for path in sorted((_BACKEND_SRC / "schemas").glob("*.py")):
+        for name in _top_level_model_names(path):
+            schema_models.setdefault(name, []).append(path.name)
+
+    collisions = sorted(router_models.keys() & schema_models.keys())
+    assert not collisions, f"router/schema DTO name collisions: {collisions}"
+    assert not dishonest_defaults, f"dependency aliases defaulted to None: {dishonest_defaults}"
+    assert not normalize_currency_defs, f"ad-hoc schema currency normalizers: {normalize_currency_defs}"
+    assert request_id_defs == [
+        "observability/audit.py:current_request_id",
+        "observability/audit.py:ensure_request_id",
+    ]
+
+    utility_owners = {
+        route.path: route.endpoint.__module__
+        for route in _api_routes()
+        if route.path in {"/health", "/ping", "/ping/toggle"}
+    }
+    assert utility_owners == {
+        "/health": "src.runtime.extension.api.health",
+        "/ping": "src.platform.extension.api.system",
+        "/ping/toggle": "src.platform.extension.api.system",
+    }
+
+
+def test_AC_platform_29_9_report_wire_shape_and_policy_are_single() -> None:
+    """AC-platform.29.9: package generation is body-only and restrictions default off."""
+    paths = app.openapi()["paths"]
+    generation = paths["/reports/package/generate"]["post"]
+    assert generation.get("parameters", []) == []
+    assert generation["requestBody"]["required"] is True
+
+    for path in ("/reports/balance-sheet", "/reports/net-worth/allocation"):
+        params = {item["name"]: item for item in paths[path]["get"]["parameters"]}
+        assert params["include_restricted"]["schema"]["default"] is DEFAULT_INCLUDE_RESTRICTED
 
 
 async def test_AC12_29_3_pagination_convention_is_enforced(client: AsyncClient) -> None:

--- a/apps/backend/tests/api/test_corrections_router.py
+++ b/apps/backend/tests/api/test_corrections_router.py
@@ -86,7 +86,7 @@ async def test_create_correction_returns_404_when_transaction_is_missing(monkeyp
 
     with pytest.raises(HTTPException) as exc_info:
         await corrections.create_correction(
-            corrections.CorrectionRequest(
+            body=corrections.CorrectionRequest(
                 transaction_id=uuid4(),
                 corrected_category="Office Supplies",
             ),

--- a/apps/backend/tests/api/test_personal_report_package_contract.py
+++ b/apps/backend/tests/api/test_personal_report_package_contract.py
@@ -62,7 +62,11 @@ from src.routers.reports import (
     personal_report_package_readiness,
     personal_report_package_traceability,
 )
-from src.schemas import PersonalReportingFrameworkId, PersonalReportPackageReadinessResponse
+from src.schemas import (
+    PersonalReportingFrameworkId,
+    PersonalReportPackageGenerateRequest,
+    PersonalReportPackageReadinessResponse,
+)
 from tests.factories import UserFactory
 
 
@@ -374,11 +378,13 @@ async def test_AC5_19_1_package_generate_creates_draft_or_trusted_snapshot(
     await _patch_package_snapshot_inputs(monkeypatch, readiness_state="blocked", blocking_count=1)
 
     draft = await generate_personal_report_package_snapshot(
-        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
-        start_date=date(2025, 1, 1),
-        end_date=date(2025, 12, 31),
-        as_of_date=date(2025, 12, 31),
-        currency="SGD",
+        request=PersonalReportPackageGenerateRequest(
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 12, 31),
+            as_of_date=date(2025, 12, 31),
+            currency="SGD",
+        ),
         db=db,
         user_id=test_user.id,
     )
@@ -395,11 +401,13 @@ async def test_AC5_19_1_package_generate_creates_draft_or_trusted_snapshot(
 
     await _patch_package_snapshot_inputs(monkeypatch, readiness_state="ready", blocking_count=0)
     trusted = await generate_personal_report_package_snapshot(
-        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
-        start_date=date(2025, 1, 1),
-        end_date=date(2025, 12, 31),
-        as_of_date=date(2025, 12, 31),
-        currency="SGD",
+        request=PersonalReportPackageGenerateRequest(
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 12, 31),
+            as_of_date=date(2025, 12, 31),
+            currency="SGD",
+        ),
         db=db,
         user_id=test_user.id,
     )
@@ -429,11 +437,13 @@ async def test_AC5_19_2_package_snapshot_get_is_user_scoped_and_immutable(
     """AC-reporting.package-snapshot.2: AC5.19.2: Package snapshots list/get by user and reopen the frozen payload."""
     await _patch_package_snapshot_inputs(monkeypatch, readiness_state="ready", blocking_count=0, section_label="Frozen")
     snapshot = await generate_personal_report_package_snapshot(
-        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
-        start_date=date(2025, 1, 1),
-        end_date=date(2025, 12, 31),
-        as_of_date=date(2025, 12, 31),
-        currency="SGD",
+        request=PersonalReportPackageGenerateRequest(
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 12, 31),
+            as_of_date=date(2025, 12, 31),
+            currency="SGD",
+        ),
         db=db,
         user_id=test_user.id,
     )
@@ -483,11 +493,13 @@ async def test_AC5_19_3_package_snapshot_exports_are_snapshot_derived(
         monkeypatch, readiness_state="ready", blocking_count=0, section_label="Frozen CSV"
     )
     snapshot = await generate_personal_report_package_snapshot(
-        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
-        start_date=date(2025, 1, 1),
-        end_date=date(2025, 12, 31),
-        as_of_date=date(2025, 12, 31),
-        currency="SGD",
+        request=PersonalReportPackageGenerateRequest(
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 12, 31),
+            as_of_date=date(2025, 12, 31),
+            currency="SGD",
+        ),
         db=db,
         user_id=test_user.id,
     )
@@ -1106,9 +1118,11 @@ async def test_AC19_9_1_package_readiness_reports_source_trust_summary(
     assert "manual_record" in trust["gap_source_classes"]
 
 
-async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors():
+async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_anchors(db: AsyncSession, test_user: User):
     """AC-reporting.package-traceability.1 · AC-reporting.trust-signals.3: AC5.13.1: Package traceability endpoint returns source-to-ledger anchors per report line."""
-    response = await personal_report_package_traceability()
+    response = await personal_report_package_traceability(
+        start_date=None, end_date=None, as_of_date=None, db=db, user_id=test_user.id
+    )
     payload = response.model_dump(mode="json")
 
     assert payload["section_id"] == "traceability_appendix"
@@ -1134,9 +1148,11 @@ async def test_AC5_13_1_package_traceability_endpoint_returns_section_line_ancho
     assert total_assets["anchor_count"] == 0
 
 
-async def test_AC5_13_2_package_traceability_declares_completeness_warnings():
+async def test_AC5_13_2_package_traceability_declares_completeness_warnings(db: AsyncSession, test_user: User):
     """AC-reporting.package-traceability.2: AC5.13.2: Traceability appendix exposes explicit completeness states where anchors are unavailable."""
-    response = await personal_report_package_traceability()
+    response = await personal_report_package_traceability(
+        start_date=None, end_date=None, as_of_date=None, db=db, user_id=test_user.id
+    )
     payload = response.model_dump(mode="json")
 
     lines = {line["line_id"]: line for line in payload["lines"]}

--- a/apps/backend/tests/api/test_reports_router.py
+++ b/apps/backend/tests/api/test_reports_router.py
@@ -420,7 +420,13 @@ class TestReportsEndpoints:
         today = date.today()
         start = today - timedelta(days=30)
         response = await client.post(
-            f"/reports/package/generate?start_date={start}&end_date={today}&as_of_date={today}&currency=SGD"
+            "/reports/package/generate",
+            json={
+                "start_date": start.isoformat(),
+                "end_date": today.isoformat(),
+                "as_of_date": today.isoformat(),
+                "currency": "SGD",
+            },
         )
         assert response.status_code == status.HTTP_200_OK
         body = response.json()

--- a/apps/backend/tests/counter/test_sql_store.py
+++ b/apps/backend/tests/counter/test_sql_store.py
@@ -12,7 +12,7 @@ import pytest
 from common.testing.ac_proof import ac_proof
 
 from src.counter import CounterKey, get_count, increment
-from src.counter.extension.api import read_count
+from src.counter.extension.facade import read_count
 from src.counter.extension.sql import SqlCounterRepository
 
 KEY = CounterKey("report.generated")

--- a/apps/backend/tests/extraction/test_statements_supervisor_errors.py
+++ b/apps/backend/tests/extraction/test_statements_supervisor_errors.py
@@ -153,7 +153,7 @@ async def test_statement_router_error_cases(db, test_user, monkeypatch):
     with pytest.raises(HTTPException) as exc:
         from src.schemas import RetryParsingRequest
 
-        await retry_statement_parsing(sid, RetryParsingRequest(model=None), db, uid)
+        await retry_statement_parsing(sid, RetryParsingRequest(model=None), db=db, user_id=uid)
     assert exc.value.status_code == 404
 
     # Retry invalid status
@@ -171,7 +171,7 @@ async def test_statement_router_error_cases(db, test_user, monkeypatch):
         mock_storage = mock_storage_cls.return_value
         mock_storage.get_object.return_value = b"content"
         with pytest.raises(HTTPException) as exc:
-            await retry_statement_parsing(sid, RetryParsingRequest(model=None), db, uid)
+            await retry_statement_parsing(sid, RetryParsingRequest(model=None), db=db, user_id=uid)
         assert exc.value.status_code == 400
 
     # Background parsing not found
@@ -357,7 +357,7 @@ async def test_retry_statement_parsing_error_paths(db, test_user):
         from src.schemas import RetryParsingRequest
 
         with pytest.raises(HTTPException) as exc:
-            await retry_statement_parsing(sid, RetryParsingRequest(model=None), db, uid)
+            await retry_statement_parsing(sid, RetryParsingRequest(model=None), db=db, user_id=uid)
         assert exc.value.status_code == 503
 
     # 2. ExtractionError in retry
@@ -370,7 +370,7 @@ async def test_retry_statement_parsing_error_paths(db, test_user):
         # To test pre-task failures, we can mock something earlier.
         # But wait, retry_statement_parsing now returns 200 if task starts.
         # Let's adjust expectations.
-        resp = await retry_statement_parsing(sid, RetryParsingRequest(model=None), db, uid)
+        resp = await retry_statement_parsing(sid, RetryParsingRequest(model=None), db=db, user_id=uid)
         assert resp.status == BankStatementStatus.PARSING
 
 

--- a/apps/backend/tests/infra/test_observability_contract.py
+++ b/apps/backend/tests/infra/test_observability_contract.py
@@ -351,8 +351,8 @@ def test_AC10_11_3_provider_error_body_logging_is_redacted() -> None:
 
 async def test_AC10_9_3_health_response_includes_redacted_observability_status(monkeypatch) -> None:
     """AC-observability.9.3: Health exposes the same redacted observability contract for deploy checks."""
-    from src import main
     from src.boot import Bootloader, ServiceStatus
+    from src.runtime.extension.api import health_check
 
     mock_db = AsyncMock()
     monkeypatch.setattr(
@@ -368,7 +368,7 @@ async def test_AC10_9_3_health_response_includes_redacted_observability_status(m
         "deployment.environment=production",
     )
 
-    response = await main.health_check(db=mock_db)
+    response = await health_check(db=mock_db)
     payload = json.loads(response.body)
 
     assert response.status_code == 200

--- a/apps/backend/tests/ledger/test_journal_service.py
+++ b/apps/backend/tests/ledger/test_journal_service.py
@@ -112,25 +112,25 @@ async def test_journal_router_direct(db: AsyncSession, test_user) -> None:
     )
     assert any(item.id == older.id for item in older_list.items)
 
-    fetched = await get_journal_entry(created.id, db, user_id=user_id)
+    fetched = await get_journal_entry(created.id, db=db, user_id=user_id)
     assert fetched.id == created.id
 
     with pytest.raises(HTTPException):
-        await get_journal_entry(uuid4(), db, user_id=user_id)
+        await get_journal_entry(uuid4(), db=db, user_id=user_id)
 
-    posted = await post_entry(created.id, db, user_id=user_id)
+    posted = await post_entry(created.id, db=db, user_id=user_id)
     assert posted.status == JournalEntryStatus.POSTED
 
     voided = await void_entry(
         created.id,
         VoidJournalEntryRequest(reason="Test void"),
-        db,
+        db=db,
         user_id=user_id,
     )
     assert voided.status == JournalEntryStatus.POSTED
 
     with pytest.raises(HTTPException):
-        await post_entry(uuid4(), db, user_id=user_id)
+        await post_entry(uuid4(), db=db, user_id=user_id)
 
     with pytest.raises(HTTPException):
-        await void_entry(uuid4(), VoidJournalEntryRequest(reason="Missing"), db, user_id=user_id)
+        await void_entry(uuid4(), VoidJournalEntryRequest(reason="Missing"), db=db, user_id=user_id)

--- a/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
+++ b/apps/backend/tests/reconciliation/test_reconciliation_router_additional.py
@@ -154,7 +154,7 @@ async def test_build_match_response_includes_entries(db: AsyncSession, test_user
 async def test_run_reconciliation_statement_not_found(db: AsyncSession, test_user) -> None:
     payload = ReconciliationRunRequest(statement_id=uuid4())
     with pytest.raises(HTTPException, match="Statement not found"):
-        await reconciliation_router.run_reconciliation(payload, db, test_user.id)
+        await reconciliation_router.run_reconciliation(payload, db=db, user_id=test_user.id)
 
 
 async def test_run_reconciliation_maps_processing_currency_conflict_to_400(
@@ -168,7 +168,7 @@ async def test_run_reconciliation_maps_processing_currency_conflict_to_400(
     monkeypatch.setattr(reconciliation_router, "execute_matching", fail_matching)
 
     with pytest.raises(HTTPException) as exc_info:
-        await reconciliation_router.run_reconciliation(ReconciliationRunRequest(), db, test_user.id)
+        await reconciliation_router.run_reconciliation(ReconciliationRunRequest(), db=db, user_id=test_user.id)
 
     assert exc_info.value.status_code == 400
     assert "Processing account currency is SGD" in exc_info.value.detail
@@ -202,7 +202,7 @@ async def test_run_reconciliation_filters_unmatched(
     monkeypatch.setattr(reconciliation_router, "execute_matching", fake_execute_matching)
 
     response = await reconciliation_router.run_reconciliation(
-        ReconciliationRunRequest(statement_id=statement.id), db, test_user.id
+        ReconciliationRunRequest(statement_id=statement.id), db=db, user_id=test_user.id
     )
 
     assert response.matches_created == 2
@@ -238,7 +238,7 @@ async def test_AC10_8_3_reconciliation_run_audit_checkpoints(
     monkeypatch.setattr(reconciliation_router.logger, "exception", mock_exception)
 
     response = await reconciliation_router.run_reconciliation(
-        ReconciliationRunRequest(statement_id=statement_id, limit=25), db, test_user.id
+        ReconciliationRunRequest(statement_id=statement_id, limit=25), db=db, user_id=test_user.id
     )
 
     calls = [(call.args[0], call.kwargs) for call in mock_info.call_args_list]
@@ -271,7 +271,9 @@ async def test_AC10_8_3_reconciliation_run_audit_checkpoints(
 
     with pytest.raises(RuntimeError, match="matching score service unavailable"):
         await reconciliation_router.run_reconciliation(
-            ReconciliationRunRequest(statement_id=statement_id, limit=25), db, test_user.id
+            ReconciliationRunRequest(statement_id=statement_id, limit=25),
+            db=db,
+            user_id=test_user.id,
         )
 
     failed = next(call.kwargs for call in mock_exception.call_args_list if call.args[0] == "reconciliation.run.failed")

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -7424,7 +7424,7 @@
         "type": "string"
       },
       "PingStateResponse": {
-        "description": "Schema for ping state response.",
+        "description": "Ping demo-state response.",
         "properties": {
           "state": {
             "title": "State",
@@ -7633,8 +7633,11 @@
         "type": "object"
       },
       "PriceUpdateRequest": {
+        "description": "Schema for manual price update request.",
         "properties": {
           "asset_identifier": {
+            "maxLength": 100,
+            "minLength": 1,
             "title": "Asset Identifier",
             "type": "string"
           },
@@ -7647,6 +7650,7 @@
           "price": {
             "anyOf": [
               {
+                "minimum": 0.0,
                 "type": "number"
               },
               {
@@ -7657,6 +7661,7 @@
             "title": "Price"
           },
           "price_date": {
+            "description": "Date of the price (default: today)",
             "format": "date",
             "title": "Price Date",
             "type": "string"
@@ -7664,9 +7669,9 @@
         },
         "required": [
           "asset_identifier",
+          "price_date",
           "price",
-          "currency",
-          "price_date"
+          "currency"
         ],
         "title": "PriceUpdateRequest",
         "type": "object"
@@ -14641,7 +14646,7 @@
     },
     "/health": {
       "get": {
-        "description": "Check application health status with dependency checks.\n\nReturns 200 if all critical services are healthy, 503 otherwise.\nThis endpoint is used by Docker healthcheck and deployment verification.\n\nThe default (frequent Docker healthcheck) stays light: database + S3.\n``?full=1`` asserts the FULL manifest-declared dependency set for this\nenvironment's tier (smoke ↔ declaration parity, invariant 6 / #1578): every\ndependency in ``DEPENDENCY_MANIFEST.required_for(tier)`` must be present or\nthe endpoint returns 503. The smoke test calls this form.",
+        "description": "Return light or manifest-complete dependency health.",
         "operationId": "health_check_health_get",
         "parameters": [
           {
@@ -14664,6 +14669,56 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -14673,6 +14728,26 @@
               }
             },
             "description": "Validation Error"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
           }
         },
         "summary": "Health Check"
@@ -17050,6 +17125,76 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
           }
         },
         "summary": "Get Ping State"
@@ -17069,6 +17214,76 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Too many requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
           }
         },
         "summary": "Toggle Ping State"
@@ -21490,7 +21705,7 @@
             "name": "include_restricted",
             "required": false,
             "schema": {
-              "default": true,
+              "default": false,
               "title": "Include Restricted",
               "type": "boolean"
             }
@@ -22174,112 +22389,15 @@
       "post": {
         "description": "Generate and persist an immutable personal report package snapshot.",
         "operationId": "generate_personal_report_package_snapshot_reports_package_generate_post",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "framework_id",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/PersonalReportingFrameworkId",
-              "default": "personal_us_gaap_like"
-            }
-          },
-          {
-            "in": "query",
-            "name": "start_date",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "format": "date",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Start Date"
-            }
-          },
-          {
-            "in": "query",
-            "name": "end_date",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "format": "date",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "End Date"
-            }
-          },
-          {
-            "in": "query",
-            "name": "as_of_date",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "format": "date",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "As Of Date"
-            }
-          },
-          {
-            "in": "query",
-            "name": "currency",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "maxLength": 3,
-                  "minLength": 3,
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Currency"
-            }
-          },
-          {
-            "in": "query",
-            "name": "include_restricted",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "Include Restricted",
-              "type": "boolean"
-            }
-          }
-        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/PersonalReportPackageGenerateRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Request"
+                "$ref": "#/components/schemas/PersonalReportPackageGenerateRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -617,16 +617,7 @@ export interface paths {
         };
         /**
          * Health Check
-         * @description Check application health status with dependency checks.
-         *
-         *     Returns 200 if all critical services are healthy, 503 otherwise.
-         *     This endpoint is used by Docker healthcheck and deployment verification.
-         *
-         *     The default (frequent Docker healthcheck) stays light: database + S3.
-         *     ``?full=1`` asserts the FULL manifest-declared dependency set for this
-         *     environment's tier (smoke ↔ declaration parity, invariant 6 / #1578): every
-         *     dependency in ``DEPENDENCY_MANIFEST.required_for(tier)`` must be present or
-         *     the endpoint returns 503. The smoke test calls this form.
+         * @description Return light or manifest-complete dependency health.
          */
         get: operations["health_check_health_get"];
         put?: never;
@@ -5769,7 +5760,7 @@ export interface components {
         PersonalReportingFrameworkId: "personal_us_gaap_like" | "personal_hkfrs_like";
         /**
          * PingStateResponse
-         * @description Schema for ping state response.
+         * @description Ping demo-state response.
          */
         PingStateResponse: {
             /** State */
@@ -5858,7 +5849,10 @@ export interface components {
              */
             updated_count: number;
         };
-        /** PriceUpdateRequest */
+        /**
+         * PriceUpdateRequest
+         * @description Schema for manual price update request.
+         */
         PriceUpdateRequest: {
             /** Asset Identifier */
             asset_identifier: string;
@@ -5869,6 +5863,7 @@ export interface components {
             /**
              * Price Date
              * Format: date
+             * @description Date of the price (default: today)
              */
             price_date: string;
         };
@@ -10296,6 +10291,51 @@ export interface operations {
                     "application/json": unknown;
                 };
             };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -10303,6 +10343,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -12162,6 +12220,69 @@ export interface operations {
                     "application/json": components["schemas"]["PingStateResponse"];
                 };
             };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     toggle_ping_state_ping_toggle_post: {
@@ -12180,6 +12301,69 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PingStateResponse"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Too many requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -15647,21 +15831,14 @@ export interface operations {
     };
     generate_personal_report_package_snapshot_reports_package_generate_post: {
         parameters: {
-            query?: {
-                framework_id?: components["schemas"]["PersonalReportingFrameworkId"];
-                start_date?: string | null;
-                end_date?: string | null;
-                as_of_date?: string | null;
-                currency?: string | null;
-                include_restricted?: boolean;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: {
+        requestBody: {
             content: {
-                "application/json": components["schemas"]["PersonalReportPackageGenerateRequest"] | null;
+                "application/json": components["schemas"]["PersonalReportPackageGenerateRequest"];
             };
         };
         responses: {

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -70,7 +70,7 @@ overall = get_count(repo, key=key)                             # global (all use
 **atomic** write — bump + outbox event in one transaction — and a thin read:
 
 ```python
-from src.counter.api import record_increment, read_count
+from src.counter import record_increment, read_count
 
 # write: bump the tally AND enqueue counter.Incremented into the platform outbox,
 # both in `db`'s transaction; the caller's single commit makes them atomic.
@@ -92,7 +92,7 @@ The implementation converges into the package model's internal layers
 | `base/ops/` | `increment` (publishes `Incremented` through an `EventBus`) and `get_count` (per-user/global), over the repository **port** |
 | `base/repository.py` | `CounterRepository` (a `typing.Protocol` port — mechanism B's base half) |
 | `extension/sql.py` | `SqlCounterRepository`/`CounterTally` (the SQLAlchemy adapter — the only module that touches the ORM) |
-| `extension/api/` | `read_count` (thin async read) and `record_increment` (atomic write: tally bump + outbox event in one transaction) |
+| `extension/facade/` | `read_count` (thin async read) and `record_increment` (atomic write: tally bump + outbox event in one transaction) |
 
 Dependency rule (DAG, down only): `extension → base` and never back, and the
 package depends downward on the `platform` package (the

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -60,6 +60,7 @@ CONTRACT = PackageContract(
         "configure_logging",
         "configure_otel_metrics",
         "current_request_id",
+        "ensure_request_id",
         "detect_pii",
         "get_logger",
         "get_observability_status",

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -218,6 +218,7 @@ CONTRACT = PackageContract(
         "Outbox",
         "OutboxEventBus",
         "OutboxRelay",
+        "PingStateResponse",
         "OutboxRepository",
         "PingState",
         "RateLimitConfig",
@@ -265,6 +266,7 @@ CONTRACT = PackageContract(
         "register_statement_reader",
         "register_uploaded_document_readers",
         "update_workflow_event_status",
+        "platform_system_router",
     ],
     events=[],
     invariants=[
@@ -703,6 +705,46 @@ CONTRACT = PackageContract(
             test=(
                 "apps/backend/tests/api/test_api_surface_consistency.py"
                 "::test_AC12_29_6_verb_in_path_urls_renamed_to_resources"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.29.7",
+            statement=(
+                "Every GET operation that exposes a limit query parameter declares "
+                "an explicit finite upper bound, with no route exemptions."
+            ),
+            test=(
+                "apps/backend/tests/api/test_api_surface_consistency.py"
+                "::test_AC_platform_29_7_every_get_limit_has_an_upper_bound"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.29.8",
+            statement=(
+                "The API delivery surface has no duplicate DTO names or dishonest "
+                "dependency defaults, and currency plus request-id normalization "
+                "each have one implementation home."
+            ),
+            test=(
+                "apps/backend/tests/api/test_api_surface_consistency.py"
+                "::test_AC_platform_29_8_delivery_helpers_have_one_honest_home"
+            ),
+            priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.29.9",
+            statement=(
+                "Personal report package generation accepts one body shape only, "
+                "and report surfaces share the named exclude-restricted default."
+            ),
+            test=(
+                "apps/backend/tests/api/test_api_surface_consistency.py"
+                "::test_AC_platform_29_9_report_wire_shape_and_policy_are_single"
             ),
             priority="P1",
             status="done",

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -69,6 +69,7 @@ CONTRACT = PackageContract(
         "register_known_storage_paths_provider",
         "resolve_env_tier",
         "run_storage_sweep",
+        "runtime_system_router",
     ],
     events=[],
     invariants=[

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -223,7 +223,7 @@ Paths below are backend OpenAPI paths. The production reverse proxy exposes them
 | `GET` | `/reports/package/annualized-income-schedule` | yes | `as_of_date` (query) | - | `200` `AnnualizedIncomeScheduleResponse` | Annualized Income Schedule |
 | `GET` | `/reports/package/contract` | no | `framework_id` (query) | - | `200` `PersonalReportPackageContractResponse` | Personal Report Package Contract |
 | `GET` | `/reports/package/framework-policy` | yes | `framework_id` (query), `start_date` (query), `end_date` (query), `as_of_date` (query) | - | `200` `FrameworkPolicyResult` | Personal Report Package Framework Policy |
-| `POST` | `/reports/package/generate` | yes | `framework_id` (query), `start_date` (query), `end_date` (query), `as_of_date` (query), `currency` (query), `include_restricted` (query) | `PersonalReportPackageGenerateRequest` \| null | `200` `PersonalReportPackageSnapshotResponse` | Generate Personal Report Package Snapshot |
+| `POST` | `/reports/package/generate` | yes | - | `PersonalReportPackageGenerateRequest` | `200` `PersonalReportPackageSnapshotResponse` | Generate Personal Report Package Snapshot |
 | `GET` | `/reports/package/notes` | no | - | - | `200` `PersonalReportPackageNotesResponse` | Personal Report Package Notes |
 | `GET` | `/reports/package/readiness` | yes | `framework_id` (query), `start_date` (query), `end_date` (query), `as_of_date` (query) | - | `200` `PersonalReportPackageReadinessResponse` | Personal Report Package Readiness |
 | `GET` | `/reports/package/snapshots` | yes | `limit` (query), `offset` (query) | - | `200` array[`PersonalReportPackageSnapshotSummary`] | List Personal Report Package Snapshots |

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -11,9 +11,9 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{account_id}` | `delete_account` | apps/backend/src/routers/accounts.py:274 |
 | `DELETE` | `/valuation-snapshots/{snapshot_id}` | `delete_valuation_snapshot` | apps/backend/src/routers/assets.py:238 |
 | `POST` | `` | `chat_message` | apps/backend/src/routers/chat.py:43 |
-| `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:218 |
-| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:170 |
-| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:525 |
-| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:805 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:542 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:690 |
+| `DELETE` | `/session/{session_id}` | `delete_session` | apps/backend/src/routers/chat.py:220 |
+| `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:174 |
+| `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:514 |
+| `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:802 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:534 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:682 |

--- a/tests/tooling/test_counter_package.py
+++ b/tests/tooling/test_counter_package.py
@@ -50,7 +50,8 @@ def test_AC_counter_1_1_counter_converges_by_layer():
     assert (COUNTER / "base/repository.py").exists()
     # extension: the ORM adapter + the async boundary.
     assert (COUNTER / "extension/sql.py").exists()
-    assert (COUNTER / "extension/api/write.py").exists()
+    assert (COUNTER / "extension/facade/write.py").exists()
+    assert not (COUNTER / "extension/api").exists()
     # the retired role dirs are gone.
     assert not (COUNTER / "types").exists() and not (COUNTER / "store").exists()
     exports = (COUNTER / "__init__.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- remove DTO twins, false-optional dependency defaults, duplicate currency/request-id helpers, and unbounded GET limits
- make report-package generation body-only and give compared report surfaces one `include_restricted=false` policy
- move health/ping HTTP adapters to owning package `extension/api` modules and rename counter's programmatic `extension/api` facade
- add structural route/API locks and regenerate OpenAPI, generated TypeScript types, API reference, and router maturity docs

## Goal

This is PR-C, the final implementation slice of #1865. It closes the remaining API surface-hygiene guarantees after the router/schema ratchets and vocabulary repatriation landed.

The removed query-only form of `POST /reports/package/generate` has no repository consumer. This is the planned contract cleanup recorded in #1865; the request body remains the single wire shape.

## Proof

- `DbSession = None`: 0
- `CurrentUserId = None`: 0
- one `PriceUpdateRequest`
- one currency normalization path
- canonical request-id read + ensure helpers only
- route-walk and ownership tests cover list bounds, wire/default policy, system routes, and counter facade naming

## Verification

- focused backend: `206 passed`
- tooling/common: `2188 passed`
- frontend: lint, `1075` coverage tests, production build
- app-boundary, package-contract, Ruff, OpenAPI/API-reference/router-contract generation: passed
- `preflight skipped: schema-validate remains red with the same 83 pre-existing missing-description warnings reproduced on clean main; all other selected static/full gates passed`

Closes #1865 after review and final acceptance reconciliation.