### PR TITLE
[finance_report_audit_1894] Generate the DDD dependency impact plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,24 @@ jobs:
             --json-out "$RUNNER_TEMP/ssot-governance-report.json" \
             --markdown-out "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md"
           cat "$RUNNER_TEMP/SSOT-GOVERNANCE-REPORT.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: DDD Dependency Impact Report
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          base_sha="${BASE_SHA:-}"
+          head_sha="${HEAD_SHA:-}"
+          if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-parse HEAD^)"
+          fi
+
+          uv run --with pydantic python tools/report_ddd_dependencies.py \
+            --base-ref "$base_sha" \
+            --json-out "$RUNNER_TEMP/ddd-dependency-report.json" \
+            --markdown-out "$RUNNER_TEMP/DDD-DEPENDENCY-REPORT.md"
+          cat "$RUNNER_TEMP/DDD-DEPENDENCY-REPORT.md" >> "$GITHUB_STEP_SUMMARY"
       - name: Migration Risk Contract Check
         run: |
           uv run --with pyyaml python tools/check_migration_risk.py

--- a/common/meta/__init__.py
+++ b/common/meta/__init__.py
@@ -10,11 +10,12 @@ The meta package now follows the very layout it governs (the Layout-3 exemplar):
 
 * ``base``      — :mod:`common.meta.base.package_contract`: the ``PackageContract``
   aggregate root, its value objects, and the ``Kind`` / ``KIND_LAYER``
-  building-block taxonomy (pure model);
+  building-block taxonomy; :mod:`common.meta.base.dependency_graph` owns the
+  typed dependency vocabulary and pure graph policy;
 * ``extension`` — :mod:`common.meta.extension.check_package_contract`: the
   governance gate (the impure edge that walks the tree and validates);
-* ``data``      — :mod:`common.meta.data.projection`: ``contract_index`` and
-  ``ac_vision_index``, computed read-model projections.
+* ``data``      — :mod:`common.meta.data.projection`: ``contract_index``,
+  ``dependency_index``, and ``ac_vision_index`` computed read-model projections.
 
 Governance is *computed from contracts*, not hand-maintained: every package
 declares a :class:`PackageContract` in ``common/<pkg>/contract.py`` and
@@ -32,6 +33,8 @@ from __future__ import annotations
 __all__ = [
     "ACRecord",
     "ConceptRecord",
+    "DependencyEdge",
+    "DependencyKind",
     "Invariant",
     "Kind",
     "PackageContract",
@@ -39,6 +42,7 @@ __all__ = [
     "ac_vision_index",
     "concept_index",
     "contract_index",
+    "dependency_index",
 ]
 
 # Lazy re-export (PEP 562): common/meta/extension/ hosts several stdlib-only
@@ -48,18 +52,32 @@ __all__ = [
 # of the pydantic-backed base/data layers here would drag pydantic into every
 # one of those lightweight gates. __getattr__ defers the import until a caller
 # actually reaches for ACRecord/ConceptRecord/Invariant/Kind/PackageContract/
-# Unit/contract_index/concept_index/ac_vision_index, so check_package_contract.py
+# Unit/contract_index/concept_index/ac_vision_index/dependency_index, so
+# check_package_contract.py
 # (which does
 # need the model) still gets it, while the stdlib-only gates never pay the
 # cost. (check_manifest.py itself now needs the model too — #1799 — but reaches
 # it via a direct `common.meta.extension.check_package_contract` import rather
 # than through this lazy attribute, so its CI invocation adds `--with pydantic`
 # explicitly instead of relying on this shield.)
-_BASE_NAMES = {"ACRecord", "ConceptRecord", "Invariant", "Kind", "PackageContract", "Unit"}
+_BASE_NAMES = {
+    "ACRecord",
+    "ConceptRecord",
+    "DependencyEdge",
+    "DependencyKind",
+    "Invariant",
+    "Kind",
+    "PackageContract",
+    "Unit",
+}
 
 
 def __getattr__(name: str):
     if name in _BASE_NAMES:
+        if name in {"DependencyEdge", "DependencyKind"}:
+            from common.meta.base import dependency_graph
+
+            return getattr(dependency_graph, name)
         from common.meta.base import package_contract
 
         return getattr(package_contract, name)
@@ -75,4 +93,8 @@ def __getattr__(name: str):
         from common.meta.data.projection import ac_vision_index
 
         return ac_vision_index
+    if name == "dependency_index":
+        from common.meta.data.projection import dependency_index
+
+        return dependency_index
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/common/meta/base/__init__.py
+++ b/common/meta/base/__init__.py
@@ -2,7 +2,9 @@
 
 Holds :mod:`common.meta.base.package_contract`: the :class:`PackageContract`
 aggregate root plus its value objects (``ACRecord``, ``Invariant``, ``Unit``) and
-the building-block taxonomy (``Kind`` / ``KIND_LAYER``). Pure, stdlib + pydantic
-only — the downward-DAG core the gate (``extension``) and the projection
-(``data``) build on. ``base`` never imports ``extension`` or ``data``.
+the building-block taxonomy (``Kind`` / ``KIND_LAYER``). It also owns the typed
+dependency vocabulary and pure graph policy in
+:mod:`common.meta.base.dependency_graph`. Pure, stdlib + pydantic only — the
+downward-DAG core the gate (``extension``) and the projection (``data``) build
+on. ``base`` never imports ``extension`` or ``data``.
 """

--- a/common/meta/base/dependency_graph.py
+++ b/common/meta/base/dependency_graph.py
@@ -7,10 +7,17 @@ projection stays in ``data``.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from enum import StrEnum
+from typing import Protocol
 
-from common.meta.base.package_contract import PackageContract
+
+class DependencyDeclaration(Protocol):
+    """The contract facts required to construct the dependency graph."""
+
+    name: str
+    depends_on: Sequence[str]
 
 
 class DependencyKind(StrEnum):
@@ -88,10 +95,12 @@ def _find_cycle(providers: dict[str, tuple[str, ...]]) -> tuple[str, ...] | None
     return None
 
 
-def build_dependency_graph(contracts: list[PackageContract]) -> DependencyGraph:
+def build_dependency_graph(
+    contracts: Sequence[DependencyDeclaration],
+) -> DependencyGraph:
     """Validate contracts and compute direct plus transitive consumers."""
 
-    by_name: dict[str, PackageContract] = {}
+    by_name: dict[str, DependencyDeclaration] = {}
     for contract in contracts:
         if contract.name in by_name:
             raise ValueError(f"duplicate package {contract.name!r}")

--- a/common/meta/base/dependency_graph.py
+++ b/common/meta/base/dependency_graph.py
@@ -1,0 +1,149 @@
+"""Pure package dependency graph vocabulary and computation.
+
+The graph is built only from :class:`PackageContract` declarations. Filesystem
+discovery and Git ref handling stay in ``extension``; serializable read-model
+projection stays in ``data``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+
+from common.meta.base.package_contract import PackageContract
+
+
+class DependencyKind(StrEnum):
+    """A package-to-package dependency phase."""
+
+    COMPILE = "compile"
+
+
+@dataclass(frozen=True, order=True)
+class DependencyEdge:
+    """One directed edge from a consuming package to its provider."""
+
+    consumer: str
+    provider: str
+    kind: DependencyKind
+    detail: str
+
+    def as_dict(self) -> dict[str, str]:
+        """Return the stable JSON projection of this edge."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DependencyGraph:
+    """Validated dependency topology and its reverse-consumer views."""
+
+    edges: tuple[DependencyEdge, ...]
+    direct_consumers: dict[str, tuple[str, ...]]
+    transitive_consumers: dict[str, tuple[str, ...]]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return deterministic JSON-compatible graph data."""
+
+        return {
+            "edges": [edge.as_dict() for edge in self.edges],
+            "direct_consumers": {
+                name: list(consumers)
+                for name, consumers in self.direct_consumers.items()
+            },
+            "transitive_consumers": {
+                name: list(consumers)
+                for name, consumers in self.transitive_consumers.items()
+            },
+        }
+
+
+def _find_cycle(providers: dict[str, tuple[str, ...]]) -> tuple[str, ...] | None:
+    visited: set[str] = set()
+    active: list[str] = []
+    active_set: set[str] = set()
+
+    def visit(package: str) -> tuple[str, ...] | None:
+        if package in active_set:
+            start = active.index(package)
+            return (*active[start:], package)
+        if package in visited:
+            return None
+
+        active.append(package)
+        active_set.add(package)
+        for provider in providers[package]:
+            cycle = visit(provider)
+            if cycle is not None:
+                return cycle
+        active.pop()
+        active_set.remove(package)
+        visited.add(package)
+        return None
+
+    for package in sorted(providers):
+        cycle = visit(package)
+        if cycle is not None:
+            return cycle
+    return None
+
+
+def build_dependency_graph(contracts: list[PackageContract]) -> DependencyGraph:
+    """Validate contracts and compute direct plus transitive consumers."""
+
+    by_name: dict[str, PackageContract] = {}
+    for contract in contracts:
+        if contract.name in by_name:
+            raise ValueError(f"duplicate package {contract.name!r}")
+        by_name[contract.name] = contract
+
+    providers: dict[str, tuple[str, ...]] = {}
+    edges: list[DependencyEdge] = []
+    for name in sorted(by_name):
+        dependencies = by_name[name].depends_on
+        if len(dependencies) != len(set(dependencies)):
+            raise ValueError(f"package {name!r} declares a duplicate dependency")
+        for provider in sorted(dependencies):
+            if provider == name:
+                raise ValueError(f"package {name!r} cannot depend on itself")
+            if provider not in by_name:
+                raise ValueError(
+                    f"package {name!r} depends on unknown package {provider!r}"
+                )
+            edges.append(
+                DependencyEdge(
+                    consumer=name,
+                    provider=provider,
+                    kind=DependencyKind.COMPILE,
+                    detail="PackageContract.depends_on",
+                )
+            )
+        providers[name] = tuple(sorted(dependencies))
+
+    cycle = _find_cycle(providers)
+    if cycle is not None:
+        raise ValueError(f"dependency cycle: {' -> '.join(cycle)}")
+
+    direct: dict[str, list[str]] = {name: [] for name in sorted(by_name)}
+    for edge in edges:
+        direct[edge.provider].append(edge.consumer)
+
+    transitive: dict[str, tuple[str, ...]] = {}
+    for provider in sorted(by_name):
+        consumers: set[str] = set()
+        pending = list(direct[provider])
+        while pending:
+            consumer = pending.pop()
+            if consumer in consumers:
+                continue
+            consumers.add(consumer)
+            pending.extend(direct[consumer])
+        transitive[provider] = tuple(sorted(consumers))
+
+    return DependencyGraph(
+        edges=tuple(sorted(edges)),
+        direct_consumers={
+            name: tuple(sorted(consumers)) for name, consumers in direct.items()
+        },
+        transitive_consumers=transitive,
+    )

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -321,9 +321,10 @@ CONTRACT = PackageContract(
             statement=(
                 "A ref-isolated base-vs-HEAD dependency impact report shows typed "
                 "edge and public-boundary changes with every direct and transitive "
-                "consumer. Boundary fingerprints resolve root bindings, inherited "
-                "APIs, and named defaults without importing implementation modules; "
-                "unreadable discovery or ambiguous exports fail closed."
+                "consumer. Boundary fingerprints resolve root bindings, local "
+                "aliases, inherited APIs, and named defaults without importing "
+                "implementation modules; unreadable discovery or ambiguous exports "
+                "fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -321,10 +321,11 @@ CONTRACT = PackageContract(
             statement=(
                 "A ref-isolated base-vs-HEAD dependency impact report shows typed "
                 "edge and public-boundary changes with every direct and transitive "
-                "consumer. Boundary fingerprints resolve root bindings, local "
-                "aliases, inherited APIs, annotation aliases, and local or imported "
-                "named defaults at binding time without importing implementation "
-                "modules; unreadable discovery or ambiguous exports fail closed."
+                "consumer. Boundary fingerprints resolve root bindings, local or "
+                "module-qualified aliases, inherited APIs, TYPE_CHECKING annotation "
+                "aliases, and local or imported named defaults at binding time "
+                "without importing implementation modules; unreadable discovery or "
+                "ambiguous exports fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -322,9 +322,9 @@ CONTRACT = PackageContract(
                 "A ref-isolated base-vs-HEAD dependency impact report shows typed "
                 "edge and public-boundary changes with every direct and transitive "
                 "consumer. Boundary fingerprints resolve root bindings, local "
-                "aliases, inherited APIs, and named defaults without importing "
-                "implementation modules; unreadable discovery or ambiguous exports "
-                "fail closed."
+                "aliases, inherited APIs, annotation aliases, and local or imported "
+                "named defaults at binding time without importing implementation "
+                "modules; unreadable discovery or ambiguous exports fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -324,8 +324,9 @@ CONTRACT = PackageContract(
                 "consumer. Boundary fingerprints resolve root bindings, local or "
                 "module-qualified aliases, inherited APIs, TYPE_CHECKING annotation "
                 "aliases, and local or imported named defaults at binding time "
-                "without importing implementation modules; unreadable discovery or "
-                "ambiguous exports fail closed."
+                "without importing implementation modules. Referenced project "
+                "definitions and decorator bindings are fingerprinted too; unreadable "
+                "discovery or ambiguous exports fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -321,7 +321,9 @@ CONTRACT = PackageContract(
             statement=(
                 "A ref-isolated base-vs-HEAD dependency impact report shows typed "
                 "edge and public-boundary changes with every direct and transitive "
-                "consumer, and fails closed on unreadable or empty discovery."
+                "consumer. Boundary fingerprints resolve root bindings, inherited "
+                "APIs, and named defaults without importing implementation modules; "
+                "unreadable discovery or ambiguous exports fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -325,8 +325,9 @@ CONTRACT = PackageContract(
                 "module-qualified aliases, inherited APIs, TYPE_CHECKING annotation "
                 "aliases, and local or imported named defaults at binding time "
                 "without importing implementation modules. Referenced project "
-                "definitions and decorator bindings are fingerprinted too; unreadable "
-                "discovery or ambiguous exports fail closed."
+                "definitions, class-scope values, decorator bindings, and relative "
+                "lazy-import levels are fingerprinted too; unreadable discovery or "
+                "ambiguous exports fail closed."
             ),
             test=(
                 "tests/tooling/test_ddd_dependency_report.py"

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -10,8 +10,10 @@ meta is also the Layout-3 exemplar: it converges into the ``base`` / ``extension
 / ``data`` layers it governs, and declares its DDD building-block ``units`` (the
 ``PackageContract`` aggregate root + its value objects in ``base``, the gate as a
 ``domain-service`` in ``extension``, and ``contract_index`` as a ``projection`` in
-``data``). Its BE implementation is ``common/meta`` (the same directory): the
-published language is ``common/meta/__init__.py``'s ``__all__``.
+``data``). The pure dependency graph policy lives in ``base``; ``data`` exposes
+its computed projection and ``extension`` renders ref-isolated impact reports.
+Its BE implementation is ``common/meta`` (the same directory): the published
+language is ``common/meta/__init__.py``'s ``__all__``.
 """
 
 from __future__ import annotations
@@ -51,6 +53,16 @@ CONTRACT = PackageContract(
         ),
         Unit(name="Unit", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"),
         Unit(name="Kind", kind=Kind.VALUE_OBJECT, module="base/package_contract.py"),
+        Unit(
+            name="DependencyKind",
+            kind=Kind.VALUE_OBJECT,
+            module="base/dependency_graph.py",
+        ),
+        Unit(
+            name="DependencyEdge",
+            kind=Kind.VALUE_OBJECT,
+            module="base/dependency_graph.py",
+        ),
         # extension — the impure edge: the governance gate (a domain service that
         # walks the tree and validates every package against its contract).
         Unit(
@@ -58,14 +70,24 @@ CONTRACT = PackageContract(
             kind=Kind.DOMAIN_SERVICE,
             module="extension/check_package_contract.py",
         ),
+        Unit(
+            name="dependency_report",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/dependency_report.py",
+        ),
         # data — the read-model: the computed meta-index over all contracts.
         Unit(name="contract_index", kind=Kind.PROJECTION, module="data/projection.py"),
         Unit(name="ac_vision_index", kind=Kind.PROJECTION, module="data/projection.py"),
+        Unit(
+            name="dependency_index", kind=Kind.PROJECTION, module="data/projection.py"
+        ),
     ],
     implementations={"be": "common/meta", "fe": None},
     interface=[
         "ACRecord",
         "ConceptRecord",
+        "DependencyEdge",
+        "DependencyKind",
         "Invariant",
         "Kind",
         "PackageContract",
@@ -73,6 +95,7 @@ CONTRACT = PackageContract(
         "ac_vision_index",
         "concept_index",
         "contract_index",
+        "dependency_index",
     ],
     events=[],
     invariants=[
@@ -277,6 +300,34 @@ CONTRACT = PackageContract(
                 "::test_AC_meta_projection_1_contract_index_is_pure"
             ),
             priority="P1",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.dependency-governance.1",
+            statement=(
+                "The computed dependency index projects package contracts into "
+                "typed edges plus deterministic direct and transitive consumers, "
+                "and rejects duplicate, unknown, self, or cyclic package topology."
+            ),
+            test=(
+                "tests/tooling/test_ddd_dependency_report.py"
+                "::test_AC_meta_dependency_governance_1_projection_has_typed_edges_and_transitive_consumers"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-meta.dependency-governance.2",
+            statement=(
+                "A ref-isolated base-vs-HEAD dependency impact report shows typed "
+                "edge and public-boundary changes with every direct and transitive "
+                "consumer, and fails closed on unreadable or empty discovery."
+            ),
+            test=(
+                "tests/tooling/test_ddd_dependency_report.py"
+                "::test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers"
+            ),
+            priority="P0",
             status="done",
         ),
         ACRecord(

--- a/common/meta/data/__init__.py
+++ b/common/meta/data/__init__.py
@@ -4,7 +4,8 @@ Holds :mod:`common.meta.data.projection`: pure projections that fold a set of
 package contracts (see
 :class:`~common.meta.base.package_contract.PackageContract`) into the computed
 meta-index (registry, AC index, reverse-dependency consumers, and per-package unit
-fan-out by layer), the concept index, and the AC-to-vision-anchor index.
+fan-out by layer), the typed dependency graph with transitive consumers, the
+concept index, and the AC-to-vision-anchor index.
 
 ``data`` is a **sink**: it imports only ``base`` (the model) and is imported by no
 other layer — nothing in ``base`` or ``extension`` may depend on the read model.

--- a/common/meta/data/projection.py
+++ b/common/meta/data/projection.py
@@ -22,17 +22,25 @@ The index answers the questions the standard's ``data`` layer is meant to:
 Sibling projections answer the same computed-registry question for package
 declarations: :func:`concept_index` maps SSOT concepts to their metadata, while
 :func:`ac_vision_index` maps roadmap AC ids to their declared ``vision.md``
-anchors.
+anchors. :func:`dependency_index` is the reviewable dependency plane: typed
+contract edges plus deterministic direct and transitive consumers.
 """
 
 from __future__ import annotations
 
+from common.meta.base.dependency_graph import build_dependency_graph
 from common.meta.base.package_contract import (
     KIND_LAYER,
     SPLIT,
     ConceptRecord,
     PackageContract,
 )
+
+
+def dependency_index(contracts: list[PackageContract]) -> dict[str, object]:
+    """Project validated package contracts into the dependency read model."""
+
+    return build_dependency_graph(contracts).as_dict()
 
 
 def contract_index(contracts: list[PackageContract]) -> dict[str, dict]:

--- a/common/meta/extension/check_package_contract.py
+++ b/common/meta/extension/check_package_contract.py
@@ -83,6 +83,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from common.meta.base.gate_cli import run_gate
+from common.meta.base.dependency_graph import build_dependency_graph
 from common.meta.base.package_contract import (
     KIND_LAYER,
     LAYER_RANK,
@@ -686,32 +687,19 @@ def _check_cross_domain_fk(
 
 
 def _check_no_dependency_cycle(packages: list[DiscoveredPackage]) -> list[str]:
-    """Detect any cycle in the declared ``depends_on`` graph.
+    """Validate the declared graph with meta's single pure topology policy.
 
     Same-class (sideways) edges are allowed when declared, so the no-cycle rule is
     enforced globally here rather than by a strict rank ordering ("never up, never
-    sideways-cyclic"). A cycle in ``depends_on`` is a hard error.
+    sideways-cyclic"). The compatibility name remains because existing callers use
+    it, but duplicate/unknown/self dependencies now fail through the same graph
+    builder consumed by the data projection and impact report.
     """
-    graph = {p.name: list(p.contract.depends_on) for p in packages}
-    color = dict.fromkeys(graph, 0)  # 0=unvisited, 1=on-stack, 2=done
-    offenders: list[str] = []
-
-    def visit(node: str, path: list[str]) -> None:
-        color[node] = 1
-        for dep in graph.get(node, []):
-            if dep not in graph:
-                continue  # unregistered dep; the edge rule handles declared-ness
-            if color[dep] == 1:
-                cycle = path[path.index(dep) :] + [dep] if dep in path else [node, dep]
-                offenders.append("dependency cycle: " + " -> ".join(cycle))
-            elif color[dep] == 0:
-                visit(dep, path + [dep])
-        color[node] = 2
-
-    for name in sorted(graph):
-        if color[name] == 0:
-            visit(name, [name])
-    return sorted(set(offenders))
+    try:
+        build_dependency_graph([package.contract for package in packages])
+    except ValueError as exc:
+        return [str(exc)]
+    return []
 
 
 def _sibling_import_hit(node: ast.AST, prefix: str, sibling: str) -> str | None:

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -40,7 +40,24 @@ class _ResolvedExport:
     reexported: bool
 
 
+@dataclass(frozen=True)
+class _ImportedValue:
+    source: Path
+    symbol: str
+    binding: str
+
+
+@dataclass(frozen=True)
+class _ExpressionValue:
+    expression: str
+    dependencies: tuple[tuple[str, _ValueBinding], ...]
+
+
+type _ValueBinding = _ExpressionValue | _ImportedValue
+
+
 _ResolutionKey = tuple[Path, str, int | None]
+_ValueKey = tuple[Path, str]
 
 
 def _annotation(node: ast.expr | None) -> str:
@@ -60,84 +77,182 @@ def _type_parameters(
     return f"[{', '.join(ast.unparse(parameter) for parameter in parameters)}]"
 
 
-def _module_values(body: Sequence[ast.stmt]) -> dict[str, ast.expr]:
-    values: dict[str, ast.expr] = {}
+def _capture_expression(
+    node: ast.expr, values: dict[str, _ValueBinding]
+) -> _ExpressionValue:
+    references = sorted(
+        {
+            child.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Name) and child.id in values
+        }
+    )
+    return _ExpressionValue(
+        expression=ast.unparse(node),
+        dependencies=tuple((name, values[name]) for name in references),
+    )
+
+
+def _binding_fingerprint(
+    binding: _ValueBinding,
+    repo_root: Path,
+    seen: frozenset[_ValueKey] = frozenset(),
+) -> str:
+    if isinstance(binding, _ImportedValue):
+        fingerprint = _imported_value_fingerprint(
+            binding.source, binding.symbol, repo_root, seen
+        )
+        return (
+            f"{binding.binding} -> {fingerprint}"
+            if fingerprint is not None
+            else binding.binding
+        )
+    dependencies = [
+        f"{name}={_binding_fingerprint(value, repo_root, seen)}"
+        for name, value in binding.dependencies
+    ]
+    suffix = f" [{', '.join(dependencies)}]" if dependencies else ""
+    return f"{binding.expression}{suffix}"
+
+
+def _expression_fingerprint(
+    node: ast.expr, values: dict[str, _ValueBinding], repo_root: Path
+) -> str:
+    return _binding_fingerprint(_capture_expression(node, values), repo_root)
+
+
+def _imported_value_fingerprint(
+    source: Path,
+    symbol: str,
+    repo_root: Path,
+    seen: frozenset[_ValueKey],
+) -> str | None:
+    key = (source.resolve(), symbol)
+    if key in seen:
+        return None
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    values = _module_values(tree.body, source=source, repo_root=repo_root)
+    binding = values.get(symbol)
+    return (
+        _binding_fingerprint(binding, repo_root, seen | {key})
+        if binding is not None
+        else None
+    )
+
+
+def _module_values(
+    body: Sequence[ast.stmt],
+    *,
+    source: Path,
+    repo_root: Path,
+) -> dict[str, _ValueBinding]:
+    values: dict[str, _ValueBinding] = {}
     for node in body:
+        if isinstance(node, ast.ImportFrom):
+            target_source = _import_source(source, node, repo_root)
+            if target_source is None:
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                values[alias.asname or alias.name] = _ImportedValue(
+                    source=target_source,
+                    symbol=alias.name,
+                    binding=_import_binding(node, alias.name),
+                )
+            continue
+        if isinstance(node, ast.Assign):
+            binding = _capture_expression(node.value, values)
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    values[target.id] = binding
+            continue
         if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-        ):
-            values[node.targets[0].id] = node.value
-        elif (
             isinstance(node, ast.AnnAssign)
             and isinstance(node.target, ast.Name)
             and node.value is not None
         ):
-            values[node.target.id] = node.value
+            values[node.target.id] = _capture_expression(node.value, values)
+            continue
+        if isinstance(node, ast.TypeAlias) and isinstance(node.name, ast.Name):
+            values[node.name.id] = _capture_expression(node.value, values)
     return values
 
 
-def _value_fingerprint(
-    name: str, values: dict[str, ast.expr], seen: frozenset[str] = frozenset()
+def _resolved_references(
+    expressions: Iterable[ast.expr],
+    values: dict[str, _ValueBinding],
+    label: str,
+    repo_root: Path,
 ) -> str:
-    value = values[name]
     references = sorted(
         {
             child.id
-            for child in ast.walk(value)
-            if isinstance(child, ast.Name)
-            and child.id in values
-            and child.id not in seen
-            and child.id != name
-        }
-    )
-    dependencies = [
-        f"{reference}={_value_fingerprint(reference, values, seen | {name})}"
-        for reference in references
-    ]
-    suffix = f" [{', '.join(dependencies)}]" if dependencies else ""
-    return f"{ast.unparse(value)}{suffix}"
-
-
-def _resolved_default_values(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
-    values: dict[str, ast.expr],
-) -> str:
-    defaults = [*node.args.defaults]
-    defaults.extend(default for default in node.args.kw_defaults if default is not None)
-    references = sorted(
-        {
-            child.id
-            for default in defaults
-            for child in ast.walk(default)
+            for expression in expressions
+            for child in ast.walk(expression)
             if isinstance(child, ast.Name) and child.id in values
         }
     )
     if not references:
         return ""
     resolved = ", ".join(
-        f"{name}={_value_fingerprint(name, values)}" for name in references
+        f"{name}={_binding_fingerprint(values[name], repo_root)}" for name in references
     )
-    return f" [defaults: {resolved}]"
+    return f" [{label}: {resolved}]"
+
+
+def _resolved_default_values(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    values: dict[str, _ValueBinding],
+    repo_root: Path,
+) -> str:
+    defaults = [*node.args.defaults]
+    defaults.extend(default for default in node.args.kw_defaults if default is not None)
+    return _resolved_references(defaults, values, "defaults", repo_root)
+
+
+def _resolved_annotation_values(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    values: dict[str, _ValueBinding],
+    repo_root: Path,
+) -> str:
+    arguments = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+    if node.args.vararg is not None:
+        arguments.append(node.args.vararg)
+    if node.args.kwarg is not None:
+        arguments.append(node.args.kwarg)
+    annotations = [argument.annotation for argument in arguments if argument.annotation]
+    if node.returns is not None:
+        annotations.append(node.returns)
+    return _resolved_references(annotations, values, "annotations", repo_root)
 
 
 def _function_signature(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
-    values: dict[str, ast.expr] | None = None,
+    repo_root: Path,
+    values: dict[str, _ValueBinding] | None = None,
 ) -> str:
+    bindings = values or {}
     prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
     return (
         f"{_decorator_prefix(node.decorator_list)}{prefix}{_type_parameters(node)}"
         f"({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
-        f"{_resolved_default_values(node, values or {})}"
+        f"{_resolved_default_values(node, bindings, repo_root)}"
+        f"{_resolved_annotation_values(node, bindings, repo_root)}"
     )
 
 
-def _annotated_assignment_signature(node: ast.AnnAssign) -> str:
+def _annotated_assignment_signature(
+    node: ast.AnnAssign,
+    values: dict[str, _ValueBinding],
+    repo_root: Path,
+) -> str:
     signature = _annotation(node.annotation)
+    signature += _resolved_references(
+        [node.annotation], values, "annotations", repo_root
+    )
     if node.value is not None:
-        signature += f"={ast.unparse(node.value)}"
+        signature += f"={_expression_fingerprint(node.value, values, repo_root)}"
     return signature
 
 
@@ -190,7 +305,7 @@ def _class_signature(
     node: ast.ClassDef,
     *,
     module_body: list[ast.stmt],
-    values: dict[str, ast.expr],
+    values: dict[str, _ValueBinding],
     source: Path,
     repo_root: Path,
     seen: frozenset[_ResolutionKey],
@@ -225,16 +340,20 @@ def _class_signature(
             and not child.target.id.startswith("_")
         ):
             members.append(
-                f"{child.target.id}: {_annotated_assignment_signature(child)}"
+                f"{child.target.id}: "
+                f"{_annotated_assignment_signature(child, values, repo_root)}"
             )
         elif isinstance(child, ast.Assign):
             for target in child.targets:
                 if isinstance(target, ast.Name) and not target.id.startswith("_"):
-                    members.append(f"{target.id}={ast.unparse(child.value)}")
+                    members.append(
+                        f"{target.id}="
+                        f"{_expression_fingerprint(child.value, values, repo_root)}"
+                    )
         elif isinstance(
             child, (ast.FunctionDef, ast.AsyncFunctionDef)
         ) and _is_public_method(child.name):
-            signature = _function_signature(child, values)
+            signature = _function_signature(child, repo_root, values)
             marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
             members.append(signature.replace(marker, child.name, 1))
     body = "; ".join(members)
@@ -249,14 +368,18 @@ def _definition_signature(
     symbol: str,
     *,
     module_body: list[ast.stmt],
-    values: dict[str, ast.expr],
+    values: dict[str, _ValueBinding],
     source: Path,
     repo_root: Path,
     seen: frozenset[_ResolutionKey],
     definition_index: int,
 ) -> str | None:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return _function_signature(node, values) if node.name == symbol else None
+        return (
+            _function_signature(node, repo_root, values)
+            if node.name == symbol
+            else None
+        )
     if isinstance(node, ast.ClassDef):
         return (
             _class_signature(
@@ -276,11 +399,17 @@ def _definition_signature(
         and isinstance(node.target, ast.Name)
         and node.target.id == symbol
     ):
-        return f"value: {_annotated_assignment_signature(node)}"
+        return f"value: {_annotated_assignment_signature(node, values, repo_root)}"
     if isinstance(node, ast.Assign) and any(
         isinstance(target, ast.Name) and target.id == symbol for target in node.targets
     ):
-        return f"value={ast.unparse(node.value)}"
+        return f"value={_expression_fingerprint(node.value, values, repo_root)}"
+    if (
+        isinstance(node, ast.TypeAlias)
+        and isinstance(node.name, ast.Name)
+        and node.name.id == symbol
+    ):
+        return f"type={_expression_fingerprint(node.value, values, repo_root)}"
     return None
 
 
@@ -307,6 +436,21 @@ def _assigned_alias_target(node: ast.stmt, symbol: str) -> str | None:
     return value.id if isinstance(value, ast.Name) else None
 
 
+def _defines_symbol(node: ast.stmt, symbol: str) -> bool:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return node.name == symbol
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id == symbol
+    if isinstance(node, ast.Assign):
+        return any(
+            isinstance(target, ast.Name) and target.id == symbol
+            for target in node.targets
+        )
+    if isinstance(node, ast.TypeAlias) and isinstance(node.name, ast.Name):
+        return node.name.id == symbol
+    return False
+
+
 def _module_definition_signature(
     body: list[ast.stmt],
     index: int,
@@ -317,7 +461,7 @@ def _module_definition_signature(
     seen: frozenset[_ResolutionKey],
 ) -> str | None:
     node = body[index]
-    values = _module_values(body[:index])
+    values = _module_values(body[:index], source=source, repo_root=repo_root)
     signature = _definition_signature(
         node,
         symbol,
@@ -343,7 +487,7 @@ def _module_definition_signature(
     if _is_overload(node):
         definitions.append(node)
     return " | ".join(
-        _function_signature(definition, values) for definition in definitions
+        _function_signature(definition, repo_root, values) for definition in definitions
     )
 
 
@@ -679,42 +823,43 @@ def _resolve_export(
     # Reverse order reflects the binding left in the module namespace at runtime.
     for index in range(stop - 1, -1, -1):
         node = tree.body[index]
-        alias_target = _assigned_alias_target(node, symbol)
-        if alias_target is not None:
-            resolved = _resolve_export(
-                source,
-                alias_target,
-                repo_root,
-                next_seen,
-                before_index=index,
-            )
-            if resolved is None:
-                raise RuntimeError(
-                    f"{source}: cannot resolve alias {symbol!r} through "
-                    f"{alias_target!r}"
+        if _defines_symbol(node, symbol):
+            alias_target = _assigned_alias_target(node, symbol)
+            if alias_target is not None:
+                resolved = _resolve_export(
+                    source,
+                    alias_target,
+                    repo_root,
+                    next_seen,
+                    before_index=index,
                 )
-            return _ResolvedExport(
-                signature=resolved.signature,
-                binding=f"alias:{alias_target} -> {resolved.binding}",
-                source=resolved.source,
-                reexported=True,
-            )
-        signature = _module_definition_signature(
-            tree.body,
-            index,
-            symbol,
-            source=source,
-            repo_root=repo_root,
-            seen=next_seen,
-        )
-        if signature is not None:
-            relative = source.relative_to(repo_root).as_posix()
-            return _ResolvedExport(
-                signature=signature,
-                binding=f"{relative}::{symbol}",
+                if resolved is None:
+                    raise RuntimeError(
+                        f"{source}: cannot resolve alias {symbol!r} through "
+                        f"{alias_target!r}"
+                    )
+                return _ResolvedExport(
+                    signature=resolved.signature,
+                    binding=f"alias:{alias_target} -> {resolved.binding}",
+                    source=resolved.source,
+                    reexported=True,
+                )
+            signature = _module_definition_signature(
+                tree.body,
+                index,
+                symbol,
                 source=source,
-                reexported=False,
+                repo_root=repo_root,
+                seen=next_seen,
             )
+            if signature is not None:
+                relative = source.relative_to(repo_root).as_posix()
+                return _ResolvedExport(
+                    signature=signature,
+                    binding=f"{relative}::{symbol}",
+                    source=source,
+                    reexported=False,
+                )
         if not isinstance(node, ast.ImportFrom):
             continue
         for alias in reversed(node.names):

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -36,29 +36,67 @@ def _annotation(node: ast.expr | None) -> str:
     return ast.unparse(node) if node is not None else "Any"
 
 
+def _decorator_prefix(nodes: list[ast.expr]) -> str:
+    return "".join(f"@{ast.unparse(node)} " for node in nodes)
+
+
+def _type_parameters(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef,
+) -> str:
+    parameters = getattr(node, "type_params", [])
+    if not parameters:
+        return ""
+    return f"[{', '.join(ast.unparse(parameter) for parameter in parameters)}]"
+
+
 def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
-    return f"{prefix}({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
+    return (
+        f"{_decorator_prefix(node.decorator_list)}{prefix}{_type_parameters(node)}"
+        f"({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
+    )
+
+
+def _annotated_assignment_signature(node: ast.AnnAssign) -> str:
+    signature = _annotation(node.annotation)
+    if node.value is not None:
+        signature += f"={ast.unparse(node.value)}"
+    return signature
 
 
 def _class_signature(node: ast.ClassDef) -> str:
-    bases = ", ".join(ast.unparse(base) for base in node.bases)
+    bases = [ast.unparse(base) for base in node.bases]
+    bases.extend(
+        f"{keyword.arg}={ast.unparse(keyword.value)}"
+        if keyword.arg is not None
+        else f"**{ast.unparse(keyword.value)}"
+        for keyword in node.keywords
+    )
     members: list[str] = []
     for child in node.body:
-        if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
-            members.append(f"{child.target.id}: {_annotation(child.annotation)}")
+        if (
+            isinstance(child, ast.AnnAssign)
+            and isinstance(child.target, ast.Name)
+            and not child.target.id.startswith("_")
+        ):
+            members.append(
+                f"{child.target.id}: {_annotated_assignment_signature(child)}"
+            )
         elif isinstance(child, ast.Assign):
             for target in child.targets:
                 if isinstance(target, ast.Name) and not target.id.startswith("_"):
                     members.append(f"{target.id}={ast.unparse(child.value)}")
         elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
-            child.name == "__init__" or not child.name.startswith("_")
+            child.name in {"__init__", "__new__"} or not child.name.startswith("_")
         ):
             signature = _function_signature(child)
-            suffix = signature.removeprefix("async def").removeprefix("def")
-            members.append(f"{child.name}{suffix}")
+            marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
+            members.append(signature.replace(marker, child.name, 1))
     body = "; ".join(members)
-    return f"class({bases}){{{body}}}"
+    return (
+        f"{_decorator_prefix(node.decorator_list)}class{_type_parameters(node)}"
+        f"({', '.join(bases)}){{{body}}}"
+    )
 
 
 def _definition_signatures(
@@ -79,7 +117,7 @@ def _definition_signatures(
                 signature = _class_signature(node)
             elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
                 name = node.target.id
-                signature = f"value: {_annotation(node.annotation)}"
+                signature = f"value: {_annotated_assignment_signature(node)}"
             elif isinstance(node, ast.Assign):
                 names = [
                     target.id for target in node.targets if isinstance(target, ast.Name)

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -131,6 +131,36 @@ def _definition_signature(node: ast.stmt, symbol: str) -> str | None:
     return None
 
 
+def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return any(
+        (isinstance(decorator, ast.Name) and decorator.id == "overload")
+        or (isinstance(decorator, ast.Attribute) and decorator.attr == "overload")
+        for decorator in node.decorator_list
+    )
+
+
+def _module_definition_signature(
+    body: list[ast.stmt], index: int, symbol: str
+) -> str | None:
+    node = body[index]
+    signature = _definition_signature(node, symbol)
+    if signature is None or not isinstance(
+        node, (ast.FunctionDef, ast.AsyncFunctionDef)
+    ):
+        return signature
+    overloads = [
+        candidate
+        for candidate in body[:index]
+        if isinstance(candidate, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and candidate.name == symbol
+        and _is_overload(candidate)
+    ]
+    definitions = overloads if _is_overload(node) else [*overloads, node]
+    if _is_overload(node):
+        definitions.append(node)
+    return " | ".join(_function_signature(definition) for definition in definitions)
+
+
 def _module_source(base: Path) -> Path | None:
     source = base.with_suffix(".py")
     if source.is_file():
@@ -190,6 +220,32 @@ def _literal_value(node: ast.expr) -> object:
             except (ValueError, TypeError, SyntaxError):
                 pass
     return _UNKNOWN
+
+
+def _wildcard_exports(source: Path, symbol: str) -> bool:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    for node in reversed(tree.body):
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            value = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            value = node.value
+        if value is None:
+            continue
+        exported = _literal_value(value)
+        if not isinstance(exported, (list, tuple, set, frozenset)) or not all(
+            isinstance(item, str) for item in exported
+        ):
+            raise RuntimeError(f"{source}: wildcard target has non-literal __all__")
+        return symbol in exported
+    return not symbol.startswith("_")
 
 
 def _lazy_constants(
@@ -307,8 +363,15 @@ def _call_target(
         return f"{module}.{imported_name}", target_name
     if (
         isinstance(owner, ast.Call)
-        and isinstance(owner.func, ast.Name)
-        and owner.func.id == "import_module"
+        and (
+            (isinstance(owner.func, ast.Name) and owner.func.id == "import_module")
+            or (
+                isinstance(owner.func, ast.Attribute)
+                and isinstance(owner.func.value, ast.Name)
+                and owner.func.value.id == "importlib"
+                and owner.func.attr == "import_module"
+            )
+        )
         and len(owner.args) == 1
     ):
         module = _expression_value(owner.args[0], symbol, {}, strings)
@@ -426,8 +489,9 @@ def _resolve_export(
     next_seen = seen | {key}
 
     # Reverse order reflects the binding left in the module namespace at runtime.
-    for node in reversed(tree.body):
-        signature = _definition_signature(node, symbol)
+    for index in range(len(tree.body) - 1, -1, -1):
+        node = tree.body[index]
+        signature = _module_definition_signature(tree.body, index, symbol)
         if signature is not None:
             relative = source.relative_to(repo_root).as_posix()
             return _ResolvedExport(
@@ -445,17 +509,32 @@ def _resolve_export(
             imported_symbol = symbol if alias.name == "*" else alias.name
             binding = _import_binding(node, imported_symbol)
             target_source = _import_source(source, node, repo_root)
-            resolved = (
-                _resolve_export(target_source, imported_symbol, repo_root, next_seen)
-                if target_source is not None
-                else None
+            if target_source is None:
+                raise RuntimeError(
+                    f"{source}: cannot resolve export {symbol!r} through {binding}"
+                )
+            if alias.name == "*" and not _wildcard_exports(
+                target_source, imported_symbol
+            ):
+                continue
+            resolved = _resolve_export(
+                target_source, imported_symbol, repo_root, next_seen
             )
+            if resolved is None and target_source.name == "__init__.py":
+                submodule_source = _module_source(
+                    target_source.parent / imported_symbol
+                )
+                if submodule_source is not None:
+                    relative = submodule_source.relative_to(repo_root).as_posix()
+                    resolved = _ResolvedExport(
+                        signature=f"module:{relative}",
+                        binding=f"{relative}::{imported_symbol}",
+                        source=submodule_source,
+                        reexported=False,
+                    )
             if resolved is None:
-                return _ResolvedExport(
-                    signature=f"unresolved-reexport:{binding}",
-                    binding=binding,
-                    source=source,
-                    reexported=True,
+                raise RuntimeError(
+                    f"{source}: cannot resolve export {symbol!r} through {binding}"
                 )
             return _ResolvedExport(
                 signature=resolved.signature,
@@ -468,17 +547,14 @@ def _resolve_export(
         module, target_symbol = lazy_target
         binding = f"lazy:{module}.{target_symbol}"
         target_source = _absolute_module_source(source, module, repo_root)
-        resolved = (
-            _resolve_export(target_source, target_symbol, repo_root, next_seen)
-            if target_source is not None
-            else None
-        )
+        if target_source is None:
+            raise RuntimeError(
+                f"{source}: cannot resolve export {symbol!r} through {binding}"
+            )
+        resolved = _resolve_export(target_source, target_symbol, repo_root, next_seen)
         if resolved is None:
-            return _ResolvedExport(
-                signature=f"unresolved-reexport:{binding}",
-                binding=binding,
-                source=source,
-                reexported=True,
+            raise RuntimeError(
+                f"{source}: cannot resolve export {symbol!r} through {binding}"
             )
         return _ResolvedExport(
             signature=resolved.signature,

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -166,9 +166,14 @@ def _binding_fingerprint(
 
 
 def _expression_fingerprint(
-    node: ast.expr, values: dict[str, _ValueBinding], repo_root: Path
+    node: ast.expr,
+    values: dict[str, _ValueBinding],
+    repo_root: Path,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
-    return _binding_fingerprint(_capture_expression(node, values), repo_root)
+    return _binding_fingerprint(
+        _capture_expression(node, values), repo_root, value_seen
+    )
 
 
 def _imported_value_fingerprint(
@@ -183,11 +188,34 @@ def _imported_value_fingerprint(
     tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
     values = _module_values(tree.body, source=source, repo_root=repo_root)
     binding = values.get(symbol)
-    return (
-        _binding_fingerprint(binding, repo_root, seen | {key})
-        if binding is not None
-        else None
-    )
+    if binding is not None:
+        return _binding_fingerprint(binding, repo_root, seen | {key})
+    return _imported_definition_fingerprint(source, symbol, repo_root, seen | {key})
+
+
+def _imported_definition_fingerprint(
+    source: Path,
+    symbol: str,
+    repo_root: Path,
+    value_seen: frozenset[_ValueKey],
+) -> str | None:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    for index in range(len(tree.body) - 1, -1, -1):
+        node = tree.body[index]
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if node.name != symbol:
+            continue
+        return _module_definition_signature(
+            tree.body,
+            index,
+            symbol,
+            source=source,
+            repo_root=repo_root,
+            seen=frozenset(),
+            value_seen=value_seen,
+        )
+    return None
 
 
 def _is_type_checking_test(node: ast.expr) -> bool:
@@ -272,6 +300,7 @@ def _resolved_references(
     values: dict[str, _ValueBinding],
     label: str,
     repo_root: Path,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     dependencies = dict(
         dependency
@@ -281,7 +310,7 @@ def _resolved_references(
     if not dependencies:
         return ""
     resolved = ", ".join(
-        f"{name}={_binding_fingerprint(binding, repo_root)}"
+        f"{name}={_binding_fingerprint(binding, repo_root, value_seen)}"
         for name, binding in sorted(dependencies.items())
     )
     return f" [{label}: {resolved}]"
@@ -291,16 +320,18 @@ def _resolved_default_values(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     values: dict[str, _ValueBinding],
     repo_root: Path,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     defaults = [*node.args.defaults]
     defaults.extend(default for default in node.args.kw_defaults if default is not None)
-    return _resolved_references(defaults, values, "defaults", repo_root)
+    return _resolved_references(defaults, values, "defaults", repo_root, value_seen)
 
 
 def _resolved_annotation_values(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     values: dict[str, _ValueBinding],
     repo_root: Path,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     arguments = [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
     if node.args.vararg is not None:
@@ -310,21 +341,25 @@ def _resolved_annotation_values(
     annotations = [argument.annotation for argument in arguments if argument.annotation]
     if node.returns is not None:
         annotations.append(node.returns)
-    return _resolved_references(annotations, values, "annotations", repo_root)
+    return _resolved_references(
+        annotations, values, "annotations", repo_root, value_seen
+    )
 
 
 def _function_signature(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
     repo_root: Path,
     values: dict[str, _ValueBinding] | None = None,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     bindings = values or {}
     prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
     return (
         f"{_decorator_prefix(node.decorator_list)}{prefix}{_type_parameters(node)}"
         f"({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
-        f"{_resolved_default_values(node, bindings, repo_root)}"
-        f"{_resolved_annotation_values(node, bindings, repo_root)}"
+        f"{_resolved_default_values(node, bindings, repo_root, value_seen)}"
+        f"{_resolved_annotation_values(node, bindings, repo_root, value_seen)}"
+        f"{_resolved_references(node.decorator_list, bindings, 'decorators', repo_root, value_seen)}"
     )
 
 
@@ -332,13 +367,16 @@ def _annotated_assignment_signature(
     node: ast.AnnAssign,
     values: dict[str, _ValueBinding],
     repo_root: Path,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     signature = _annotation(node.annotation)
     signature += _resolved_references(
-        [node.annotation], values, "annotations", repo_root
+        [node.annotation], values, "annotations", repo_root, value_seen
     )
     if node.value is not None:
-        signature += f"={_expression_fingerprint(node.value, values, repo_root)}"
+        signature += (
+            f"={_expression_fingerprint(node.value, values, repo_root, value_seen)}"
+        )
     return signature
 
 
@@ -404,6 +442,7 @@ def _class_signature(
     repo_root: Path,
     seen: frozenset[_ResolutionKey],
     definition_index: int,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
     bases = [ast.unparse(base) for base in node.bases]
     bases.extend(
@@ -443,24 +482,28 @@ def _class_signature(
         ):
             members.append(
                 f"{child.target.id}: "
-                f"{_annotated_assignment_signature(child, values, repo_root)}"
+                f"{_annotated_assignment_signature(child, values, repo_root, value_seen)}"
             )
         elif isinstance(child, ast.Assign):
             for target in child.targets:
                 if isinstance(target, ast.Name) and not target.id.startswith("_"):
                     members.append(
                         f"{target.id}="
-                        f"{_expression_fingerprint(child.value, values, repo_root)}"
+                        f"{_expression_fingerprint(child.value, values, repo_root, value_seen)}"
                     )
         elif isinstance(
             child, (ast.FunctionDef, ast.AsyncFunctionDef)
         ) and _is_public_method(child.name):
-            signature = _function_signature(child, repo_root, values)
+            signature = _function_signature(child, repo_root, values, value_seen)
             marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
             members.append(signature.replace(marker, child.name, 1))
     body = "; ".join(members)
+    decorator_values = _resolved_references(
+        node.decorator_list, values, "decorators", repo_root, value_seen
+    )
     return (
-        f"{_decorator_prefix(node.decorator_list)}class{_type_parameters(node)}"
+        f"{_decorator_prefix(node.decorator_list)}{decorator_values}"
+        f"class{_type_parameters(node)}"
         f"({', '.join(bases)}){{{body}}}"
     )
 
@@ -475,10 +518,11 @@ def _definition_signature(
     repo_root: Path,
     seen: frozenset[_ResolutionKey],
     definition_index: int,
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str | None:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return (
-            _function_signature(node, repo_root, values)
+            _function_signature(node, repo_root, values, value_seen)
             if node.name == symbol
             else None
         )
@@ -492,6 +536,7 @@ def _definition_signature(
                 repo_root=repo_root,
                 seen=seen,
                 definition_index=definition_index,
+                value_seen=value_seen,
             )
             if node.name == symbol
             else None
@@ -501,17 +546,22 @@ def _definition_signature(
         and isinstance(node.target, ast.Name)
         and node.target.id == symbol
     ):
-        return f"value: {_annotated_assignment_signature(node, values, repo_root)}"
+        return (
+            "value: "
+            f"{_annotated_assignment_signature(node, values, repo_root, value_seen)}"
+        )
     if isinstance(node, ast.Assign) and any(
         isinstance(target, ast.Name) and target.id == symbol for target in node.targets
     ):
-        return f"value={_expression_fingerprint(node.value, values, repo_root)}"
+        return f"value={_expression_fingerprint(node.value, values, repo_root, value_seen)}"
     if (
         isinstance(node, ast.TypeAlias)
         and isinstance(node.name, ast.Name)
         and node.name.id == symbol
     ):
-        return f"type={_expression_fingerprint(node.value, values, repo_root)}"
+        return (
+            f"type={_expression_fingerprint(node.value, values, repo_root, value_seen)}"
+        )
     return None
 
 
@@ -561,6 +611,7 @@ def _module_definition_signature(
     source: Path,
     repo_root: Path,
     seen: frozenset[_ResolutionKey],
+    value_seen: frozenset[_ValueKey] = frozenset(),
 ) -> str | None:
     node = body[index]
     values = _module_values(body[:index], source=source, repo_root=repo_root)
@@ -573,6 +624,7 @@ def _module_definition_signature(
         repo_root=repo_root,
         seen=seen,
         definition_index=index,
+        value_seen=value_seen,
     )
     if signature is None or not isinstance(
         node, (ast.FunctionDef, ast.AsyncFunctionDef)
@@ -589,7 +641,8 @@ def _module_definition_signature(
     if _is_overload(node):
         definitions.append(node)
     return " | ".join(
-        _function_signature(definition, repo_root, values) for definition in definitions
+        _function_signature(definition, repo_root, values, value_seen)
+        for definition in definitions
     )
 
 

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -40,6 +40,9 @@ class _ResolvedExport:
     reexported: bool
 
 
+_ResolutionKey = tuple[Path, str, int | None]
+
+
 def _annotation(node: ast.expr | None) -> str:
     return ast.unparse(node) if node is not None else "Any"
 
@@ -153,11 +156,18 @@ def _project_base_signature(
     body: list[ast.stmt],
     base_name: str,
     repo_root: Path,
-    seen: frozenset[tuple[Path, str]],
+    seen: frozenset[_ResolutionKey],
+    before_index: int,
 ) -> str | None:
-    for node in reversed(body):
+    for node in reversed(body[:before_index]):
         if isinstance(node, ast.ClassDef) and node.name == base_name:
-            resolved = _resolve_export(source, base_name, repo_root, seen)
+            resolved = _resolve_export(
+                source,
+                base_name,
+                repo_root,
+                seen,
+                before_index=before_index,
+            )
             return resolved.signature if resolved is not None else None
         if not isinstance(node, ast.ImportFrom):
             continue
@@ -165,7 +175,13 @@ def _project_base_signature(
             continue
         if _import_source(source, node, repo_root) is None:
             return None
-        resolved = _resolve_export(source, base_name, repo_root, seen)
+        resolved = _resolve_export(
+            source,
+            base_name,
+            repo_root,
+            seen,
+            before_index=before_index,
+        )
         return resolved.signature if resolved is not None else None
     return None
 
@@ -177,7 +193,8 @@ def _class_signature(
     values: dict[str, ast.expr],
     source: Path,
     repo_root: Path,
-    seen: frozenset[tuple[Path, str]],
+    seen: frozenset[_ResolutionKey],
+    definition_index: int,
 ) -> str:
     bases = [ast.unparse(base) for base in node.bases]
     bases.extend(
@@ -191,7 +208,14 @@ def _class_signature(
         name = _base_name(base)
         if name is None:
             continue
-        signature = _project_base_signature(source, module_body, name, repo_root, seen)
+        signature = _project_base_signature(
+            source,
+            module_body,
+            name,
+            repo_root,
+            seen,
+            definition_index,
+        )
         if signature is not None:
             members.append(f"inherits[{ast.unparse(base)}]={signature}")
     for child in node.body:
@@ -228,7 +252,8 @@ def _definition_signature(
     values: dict[str, ast.expr],
     source: Path,
     repo_root: Path,
-    seen: frozenset[tuple[Path, str]],
+    seen: frozenset[_ResolutionKey],
+    definition_index: int,
 ) -> str | None:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return _function_signature(node, values) if node.name == symbol else None
@@ -241,6 +266,7 @@ def _definition_signature(
                 source=source,
                 repo_root=repo_root,
                 seen=seen,
+                definition_index=definition_index,
             )
             if node.name == symbol
             else None
@@ -266,6 +292,21 @@ def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     )
 
 
+def _assigned_alias_target(node: ast.stmt, symbol: str) -> str | None:
+    value: ast.expr | None = None
+    if isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == symbol for target in node.targets
+    ):
+        value = node.value
+    elif (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == symbol
+    ):
+        value = node.value
+    return value.id if isinstance(value, ast.Name) else None
+
+
 def _module_definition_signature(
     body: list[ast.stmt],
     index: int,
@@ -273,7 +314,7 @@ def _module_definition_signature(
     *,
     source: Path,
     repo_root: Path,
-    seen: frozenset[tuple[Path, str]],
+    seen: frozenset[_ResolutionKey],
 ) -> str | None:
     node = body[index]
     values = _module_values(body[:index])
@@ -285,6 +326,7 @@ def _module_definition_signature(
         source=source,
         repo_root=repo_root,
         seen=seen,
+        definition_index=index,
     )
     if signature is None or not isinstance(
         node, (ast.FunctionDef, ast.AsyncFunctionDef)
@@ -623,17 +665,40 @@ def _resolve_export(
     source: Path,
     symbol: str,
     repo_root: Path,
-    seen: frozenset[tuple[Path, str]] = frozenset(),
+    seen: frozenset[_ResolutionKey] = frozenset(),
+    *,
+    before_index: int | None = None,
 ) -> _ResolvedExport | None:
-    key = (source.resolve(), symbol)
+    key = (source.resolve(), symbol, before_index)
     if key in seen:
         return None
     tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
     next_seen = seen | {key}
+    stop = len(tree.body) if before_index is None else min(before_index, len(tree.body))
 
     # Reverse order reflects the binding left in the module namespace at runtime.
-    for index in range(len(tree.body) - 1, -1, -1):
+    for index in range(stop - 1, -1, -1):
         node = tree.body[index]
+        alias_target = _assigned_alias_target(node, symbol)
+        if alias_target is not None:
+            resolved = _resolve_export(
+                source,
+                alias_target,
+                repo_root,
+                next_seen,
+                before_index=index,
+            )
+            if resolved is None:
+                raise RuntimeError(
+                    f"{source}: cannot resolve alias {symbol!r} through "
+                    f"{alias_target!r}"
+                )
+            return _ResolvedExport(
+                signature=resolved.signature,
+                binding=f"alias:{alias_target} -> {resolved.binding}",
+                source=resolved.source,
+                reexported=True,
+            )
         signature = _module_definition_signature(
             tree.body,
             index,

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -48,12 +48,18 @@ class _ImportedValue:
 
 
 @dataclass(frozen=True)
+class _ImportedModule:
+    source: Path
+    binding: str
+
+
+@dataclass(frozen=True)
 class _ExpressionValue:
     expression: str
     dependencies: tuple[tuple[str, _ValueBinding], ...]
 
 
-type _ValueBinding = _ExpressionValue | _ImportedValue
+type _ValueBinding = _ExpressionValue | _ImportedModule | _ImportedValue
 
 
 _ResolutionKey = tuple[Path, str, int | None]
@@ -77,19 +83,61 @@ def _type_parameters(
     return f"[{', '.join(ast.unparse(parameter) for parameter in parameters)}]"
 
 
-def _capture_expression(
-    node: ast.expr, values: dict[str, _ValueBinding]
-) -> _ExpressionValue:
-    references = sorted(
-        {
-            child.id
-            for child in ast.walk(node)
-            if isinstance(child, ast.Name) and child.id in values
-        }
+def _attribute_parts(node: ast.expr) -> tuple[str, tuple[str, ...]] | None:
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return None
+    return node.id, tuple(reversed(parts))
+
+
+def _qualified_imported_value(
+    node: ast.expr,
+    values: dict[str, _ValueBinding],
+) -> _ImportedValue | None:
+    qualified = _attribute_parts(node)
+    if qualified is None:
+        return None
+    root, parts = qualified
+    binding = values.get(root)
+    if not isinstance(binding, _ImportedModule) or not parts:
+        return None
+    target_source = binding.source
+    if len(parts) > 1:
+        target_source = _module_source(target_source.parent.joinpath(*parts[:-1]))
+        if target_source is None:
+            return None
+    return _ImportedValue(
+        source=target_source,
+        symbol=parts[-1],
+        binding=f"{binding.binding}.{'.'.join(parts)}",
     )
+
+
+def _capture_expression(
+    node: ast.expr,
+    values: dict[str, _ValueBinding],
+) -> _ExpressionValue:
+    dependencies: dict[str, _ValueBinding] = {}
+
+    def visit(child: ast.AST) -> None:
+        if isinstance(child, ast.Attribute):
+            qualified = _qualified_imported_value(child, values)
+            if qualified is not None:
+                dependencies[ast.unparse(child)] = qualified
+                return
+        if isinstance(child, ast.Name) and child.id in values:
+            dependencies[child.id] = values[child.id]
+            return
+        for nested in ast.iter_child_nodes(child):
+            visit(nested)
+
+    visit(node)
     return _ExpressionValue(
         expression=ast.unparse(node),
-        dependencies=tuple((name, values[name]) for name in references),
+        dependencies=tuple(sorted(dependencies.items())),
     )
 
 
@@ -98,6 +146,8 @@ def _binding_fingerprint(
     repo_root: Path,
     seen: frozenset[_ValueKey] = frozenset(),
 ) -> str:
+    if isinstance(binding, _ImportedModule):
+        return binding.binding
     if isinstance(binding, _ImportedValue):
         fingerprint = _imported_value_fingerprint(
             binding.source, binding.symbol, repo_root, seen
@@ -140,14 +190,41 @@ def _imported_value_fingerprint(
     )
 
 
+def _is_type_checking_test(node: ast.expr) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING") or (
+        isinstance(node, ast.Attribute) and node.attr == "TYPE_CHECKING"
+    )
+
+
 def _module_values(
     body: Sequence[ast.stmt],
     *,
     source: Path,
     repo_root: Path,
+    initial: dict[str, _ValueBinding] | None = None,
 ) -> dict[str, _ValueBinding]:
-    values: dict[str, _ValueBinding] = {}
+    values = dict(initial or {})
     for node in body:
+        if isinstance(node, ast.If) and _is_type_checking_test(node.test):
+            values = _module_values(
+                node.body,
+                source=source,
+                repo_root=repo_root,
+                initial=values,
+            )
+            continue
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_name = alias.name if alias.asname else alias.name.split(".")[0]
+                target_source = _absolute_module_source(
+                    source, imported_name, repo_root
+                )
+                if target_source is not None:
+                    values[alias.asname or imported_name] = _ImportedModule(
+                        source=target_source,
+                        binding=alias.asname or imported_name,
+                    )
+            continue
         if isinstance(node, ast.ImportFrom):
             target_source = _import_source(source, node, repo_root)
             if target_source is None:
@@ -155,11 +232,22 @@ def _module_values(
             for alias in node.names:
                 if alias.name == "*":
                     continue
-                values[alias.asname or alias.name] = _ImportedValue(
-                    source=target_source,
-                    symbol=alias.name,
-                    binding=_import_binding(node, alias.name),
+                submodule_source = (
+                    _module_source(target_source.parent / alias.name)
+                    if target_source.name == "__init__.py"
+                    else None
                 )
+                if submodule_source is not None:
+                    values[alias.asname or alias.name] = _ImportedModule(
+                        source=submodule_source,
+                        binding=_import_binding(node, alias.name),
+                    )
+                else:
+                    values[alias.asname or alias.name] = _ImportedValue(
+                        source=target_source,
+                        symbol=alias.name,
+                        binding=_import_binding(node, alias.name),
+                    )
             continue
         if isinstance(node, ast.Assign):
             binding = _capture_expression(node.value, values)
@@ -185,18 +273,16 @@ def _resolved_references(
     label: str,
     repo_root: Path,
 ) -> str:
-    references = sorted(
-        {
-            child.id
-            for expression in expressions
-            for child in ast.walk(expression)
-            if isinstance(child, ast.Name) and child.id in values
-        }
+    dependencies = dict(
+        dependency
+        for expression in expressions
+        for dependency in _capture_expression(expression, values).dependencies
     )
-    if not references:
+    if not dependencies:
         return ""
     resolved = ", ".join(
-        f"{name}={_binding_fingerprint(values[name], repo_root)}" for name in references
+        f"{name}={_binding_fingerprint(binding, repo_root)}"
+        for name, binding in sorted(dependencies.items())
     )
     return f" [{label}: {resolved}]"
 
@@ -260,10 +346,18 @@ def _is_public_method(name: str) -> bool:
     return not name.startswith("_") or (name.startswith("__") and name.endswith("__"))
 
 
-def _base_name(node: ast.expr) -> str | None:
+def _base_target(
+    node: ast.expr, values: dict[str, _ValueBinding]
+) -> str | _ImportedValue | None:
     while isinstance(node, ast.Subscript):
         node = node.value
-    return node.id if isinstance(node, ast.Name) else None
+    qualified = _qualified_imported_value(node, values)
+    if qualified is not None:
+        return qualified
+    if not isinstance(node, ast.Name):
+        return None
+    imported = values.get(node.id)
+    return imported if isinstance(imported, _ImportedValue) else node.id
 
 
 def _project_base_signature(
@@ -320,17 +414,25 @@ def _class_signature(
     )
     members: list[str] = []
     for base in node.bases:
-        name = _base_name(base)
-        if name is None:
+        target = _base_target(base, values)
+        if target is None:
             continue
-        signature = _project_base_signature(
-            source,
-            module_body,
-            name,
-            repo_root,
-            seen,
-            definition_index,
-        )
+        if isinstance(target, _ImportedValue):
+            resolved = _resolve_export(target.source, target.symbol, repo_root, seen)
+            signature = (
+                f"{target.binding} -> {resolved.signature}"
+                if resolved is not None
+                else None
+            )
+        else:
+            signature = _project_base_signature(
+                source,
+                module_body,
+                target,
+                repo_root,
+                seen,
+                definition_index,
+            )
         if signature is not None:
             members.append(f"inherits[{ast.unparse(base)}]={signature}")
     for child in node.body:
@@ -421,7 +523,7 @@ def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     )
 
 
-def _assigned_alias_target(node: ast.stmt, symbol: str) -> str | None:
+def _assigned_alias_value(node: ast.stmt, symbol: str) -> ast.expr | None:
     value: ast.expr | None = None
     if isinstance(node, ast.Assign) and any(
         isinstance(target, ast.Name) and target.id == symbol for target in node.targets
@@ -433,7 +535,7 @@ def _assigned_alias_target(node: ast.stmt, symbol: str) -> str | None:
         and node.target.id == symbol
     ):
         value = node.value
-    return value.id if isinstance(value, ast.Name) else None
+    return value
 
 
 def _defines_symbol(node: ast.stmt, symbol: str) -> bool:
@@ -824,8 +926,21 @@ def _resolve_export(
     for index in range(stop - 1, -1, -1):
         node = tree.body[index]
         if _defines_symbol(node, symbol):
-            alias_target = _assigned_alias_target(node, symbol)
-            if alias_target is not None:
+            alias_value = _assigned_alias_value(node, symbol)
+            alias_target: str | _ImportedValue | None = None
+            if isinstance(alias_value, ast.Name):
+                alias_target = alias_value.id
+            elif isinstance(alias_value, ast.Attribute):
+                values = _module_values(
+                    tree.body[:index], source=source, repo_root=repo_root
+                )
+                alias_target = _qualified_imported_value(alias_value, values)
+                if alias_target is None:
+                    raise RuntimeError(
+                        f"{source}: cannot resolve qualified alias {symbol!r} "
+                        f"through {ast.unparse(alias_value)!r}"
+                    )
+            if isinstance(alias_target, str):
                 resolved = _resolve_export(
                     source,
                     alias_target,
@@ -841,6 +956,24 @@ def _resolve_export(
                 return _ResolvedExport(
                     signature=resolved.signature,
                     binding=f"alias:{alias_target} -> {resolved.binding}",
+                    source=resolved.source,
+                    reexported=True,
+                )
+            if isinstance(alias_target, _ImportedValue):
+                resolved = _resolve_export(
+                    alias_target.source,
+                    alias_target.symbol,
+                    repo_root,
+                    next_seen,
+                )
+                if resolved is None:
+                    raise RuntimeError(
+                        f"{source}: cannot resolve alias {symbol!r} through "
+                        f"{alias_target.binding!r}"
+                    )
+                return _ResolvedExport(
+                    signature=resolved.signature,
+                    binding=f"alias:{alias_target.binding} -> {resolved.binding}",
                     source=resolved.source,
                     reexported=True,
                 )

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -12,16 +12,24 @@ import ast
 import io
 import json
 import subprocess
+import sys
 import tarfile
 import tempfile
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from common.meta.base.dependency_graph import build_dependency_graph
-from common.meta.extension.check_package_contract import (
-    DiscoveredPackage,
-    discover_packages,
-)
+
+
+@dataclass(frozen=True)
+class SnapshotPackage:
+    """Neutral package facts read from a contract without importing its model."""
+
+    name: str
+    depends_on: tuple[str, ...]
+    interface: tuple[str, ...]
+    impl_dir: Path | None
 
 
 def _annotation(node: ast.expr | None) -> str:
@@ -39,9 +47,13 @@ def _class_signature(node: ast.ClassDef) -> str:
     for child in node.body:
         if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
             members.append(f"{child.target.id}: {_annotation(child.annotation)}")
-        elif isinstance(
-            child, (ast.FunctionDef, ast.AsyncFunctionDef)
-        ) and not child.name.startswith("_"):
+        elif isinstance(child, ast.Assign):
+            for target in child.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    members.append(f"{target.id}={ast.unparse(child.value)}")
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            child.name == "__init__" or not child.name.startswith("_")
+        ):
             signature = _function_signature(child)
             suffix = signature.removeprefix("async def").removeprefix("def")
             members.append(f"{child.name}{suffix}")
@@ -99,9 +111,9 @@ def _root_reexport(impl_dir: Path, symbol: str) -> str | None:
 
 
 def _public_symbol_records(
-    package: DiscoveredPackage, repo_root: Path
+    package: SnapshotPackage, repo_root: Path
 ) -> list[dict[str, str]]:
-    if not package.contract.interface:
+    if not package.interface:
         return []
     if package.impl_dir is None or not package.impl_dir.is_dir():
         raise RuntimeError(
@@ -111,7 +123,7 @@ def _public_symbol_records(
 
     definitions = _definition_signatures(package.impl_dir, repo_root)
     records: list[dict[str, str]] = []
-    for symbol in sorted(package.contract.interface):
+    for symbol in sorted(package.interface):
         matches = definitions.get(symbol, [])
         if matches:
             signatures = sorted({signature for _, _, signature in matches})
@@ -142,15 +154,95 @@ def _public_symbol_records(
     return records
 
 
+def _contract_call(contract_path: Path) -> ast.Call:
+    tree = ast.parse(
+        contract_path.read_text(encoding="utf-8"), filename=str(contract_path)
+    )
+    for node in tree.body:
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "CONTRACT"
+            for target in node.targets
+        ):
+            value = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "CONTRACT"
+        ):
+            value = node.value
+        if isinstance(value, ast.Call):
+            return value
+    raise RuntimeError(f"{contract_path}: no CONTRACT declaration found")
+
+
+def _literal_keyword(call: ast.Call, name: str, contract_path: Path) -> object:
+    for keyword in call.keywords:
+        if keyword.arg != name:
+            continue
+        try:
+            return ast.literal_eval(keyword.value)
+        except (ValueError, TypeError, SyntaxError) as exc:
+            raise RuntimeError(
+                f"{contract_path}: {name!r} must be a literal for dependency reporting"
+            ) from exc
+    raise RuntimeError(f"{contract_path}: missing {name!r} contract field")
+
+
+def _implementation_dir(be_path: object, repo_root: Path) -> Path | None:
+    if be_path is None:
+        return None
+    if not isinstance(be_path, str):
+        raise RuntimeError("contract implementations['be'] must be a string or null")
+    relative = Path(be_path)
+    if relative.is_absolute():
+        return None
+    resolved = (repo_root / relative).resolve()
+    if resolved != repo_root and repo_root not in resolved.parents:
+        return None
+    return resolved
+
+
+def _snapshot_packages(repo_root: Path) -> list[SnapshotPackage]:
+    packages: list[SnapshotPackage] = []
+    for contract_path in sorted(repo_root.glob("common/*/contract.py")):
+        call = _contract_call(contract_path)
+        name = _literal_keyword(call, "name", contract_path)
+        depends_on = _literal_keyword(call, "depends_on", contract_path)
+        interface = _literal_keyword(call, "interface", contract_path)
+        implementations = _literal_keyword(call, "implementations", contract_path)
+        if not isinstance(name, str):
+            raise RuntimeError(f"{contract_path}: 'name' must be a string")
+        if not isinstance(depends_on, list) or not all(
+            isinstance(value, str) for value in depends_on
+        ):
+            raise RuntimeError(f"{contract_path}: 'depends_on' must be a string list")
+        if not isinstance(interface, list) or not all(
+            isinstance(value, str) for value in interface
+        ):
+            raise RuntimeError(f"{contract_path}: 'interface' must be a string list")
+        if not isinstance(implementations, dict):
+            raise RuntimeError(f"{contract_path}: 'implementations' must be a mapping")
+        packages.append(
+            SnapshotPackage(
+                name=name,
+                depends_on=tuple(depends_on),
+                interface=tuple(interface),
+                impl_dir=_implementation_dir(implementations.get("be"), repo_root),
+            )
+        )
+    return packages
+
+
 def build_dependency_snapshot(repo_root: Path) -> dict[str, object]:
     """Build a deterministic dependency/public-boundary snapshot of a tree."""
 
     root = repo_root.resolve()
-    packages = discover_packages(root)
+    packages = _snapshot_packages(root)
     if not packages:
         raise RuntimeError(f"no package contracts discovered under {root}")
 
-    graph = build_dependency_graph([package.contract for package in packages])
+    graph = build_dependency_graph(packages)
     public_symbols = [
         record
         for package in sorted(packages, key=lambda item: item.name)
@@ -265,7 +357,45 @@ def _snapshot_git_ref(repo_root: Path, ref: str) -> dict[str, object]:
         base_root = Path(temp_dir)
         with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
             tar.extractall(base_root, filter="data")
-        return build_dependency_snapshot(base_root)
+        output_path = base_root / "dependency-snapshot.json"
+        current_root = Path(__file__).resolve().parents[3]
+        runner = """
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from common.meta.extension.dependency_report import build_dependency_snapshot
+
+snapshot = build_dependency_snapshot(Path(sys.argv[2]))
+Path(sys.argv[3]).write_text(json.dumps(snapshot), encoding="utf-8")
+"""
+        load = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                runner,
+                current_root.as_posix(),
+                base_root.as_posix(),
+                output_path.as_posix(),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if load.returncode != 0 or not output_path.is_file():
+            detail = load.stderr.strip() or load.stdout.strip() or "loader failed"
+            raise RuntimeError(f"cannot snapshot base ref {ref!r}: {detail}")
+        try:
+            snapshot = json.loads(output_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"invalid snapshot for base ref {ref!r}: {exc}") from exc
+        if not isinstance(snapshot, dict):
+            raise RuntimeError(
+                f"invalid snapshot for base ref {ref!r}: expected object"
+            )
+        return snapshot
 
 
 def build_impact_report(repo_root: Path, *, base_ref: str) -> dict[str, object]:

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -318,6 +318,21 @@ def _consumer_set(
     return sorted(consumers)
 
 
+def _providers_with_consumer_changes(
+    base: dict[str, object], head: dict[str, object]
+) -> set[str]:
+    changed: set[str] = set()
+    for field in ("direct_consumers", "transitive_consumers"):
+        base_index = base[field]
+        head_index = head[field]
+        assert isinstance(base_index, dict)
+        assert isinstance(head_index, dict)
+        for package in base_index.keys() | head_index.keys():
+            if base_index.get(package, []) != head_index.get(package, []):
+                changed.add(package)
+    return changed
+
+
 def compare_dependency_snapshots(
     base: dict[str, object], head: dict[str, object]
 ) -> dict[str, object]:
@@ -356,6 +371,7 @@ def compare_dependency_snapshots(
     }
     affected_packages.update(edge["provider"] for edge in added_edges)
     affected_packages.update(edge["provider"] for edge in removed_edges)
+    affected_packages.update(_providers_with_consumer_changes(base, head))
 
     affected_consumers: dict[str, dict[str, list[str]]] = {}
     for package in sorted(affected_packages):

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -57,11 +57,77 @@ def _type_parameters(
     return f"[{', '.join(ast.unparse(parameter) for parameter in parameters)}]"
 
 
-def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+def _module_values(body: Sequence[ast.stmt]) -> dict[str, ast.expr]:
+    values: dict[str, ast.expr] = {}
+    for node in body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            values[node.targets[0].id] = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            values[node.target.id] = node.value
+    return values
+
+
+def _value_fingerprint(
+    name: str, values: dict[str, ast.expr], seen: frozenset[str] = frozenset()
+) -> str:
+    value = values[name]
+    references = sorted(
+        {
+            child.id
+            for child in ast.walk(value)
+            if isinstance(child, ast.Name)
+            and child.id in values
+            and child.id not in seen
+            and child.id != name
+        }
+    )
+    dependencies = [
+        f"{reference}={_value_fingerprint(reference, values, seen | {name})}"
+        for reference in references
+    ]
+    suffix = f" [{', '.join(dependencies)}]" if dependencies else ""
+    return f"{ast.unparse(value)}{suffix}"
+
+
+def _resolved_default_values(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    values: dict[str, ast.expr],
+) -> str:
+    defaults = [*node.args.defaults]
+    defaults.extend(default for default in node.args.kw_defaults if default is not None)
+    references = sorted(
+        {
+            child.id
+            for default in defaults
+            for child in ast.walk(default)
+            if isinstance(child, ast.Name) and child.id in values
+        }
+    )
+    if not references:
+        return ""
+    resolved = ", ".join(
+        f"{name}={_value_fingerprint(name, values)}" for name in references
+    )
+    return f" [defaults: {resolved}]"
+
+
+def _function_signature(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    values: dict[str, ast.expr] | None = None,
+) -> str:
     prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
     return (
         f"{_decorator_prefix(node.decorator_list)}{prefix}{_type_parameters(node)}"
         f"({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
+        f"{_resolved_default_values(node, values or {})}"
     )
 
 
@@ -73,12 +139,46 @@ def _annotated_assignment_signature(node: ast.AnnAssign) -> str:
 
 
 def _is_public_method(name: str) -> bool:
-    return not name.startswith("_") or (
-        name.startswith("__") and name.endswith("__")
-    )
+    return not name.startswith("_") or (name.startswith("__") and name.endswith("__"))
 
 
-def _class_signature(node: ast.ClassDef) -> str:
+def _base_name(node: ast.expr) -> str | None:
+    while isinstance(node, ast.Subscript):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _project_base_signature(
+    source: Path,
+    body: list[ast.stmt],
+    base_name: str,
+    repo_root: Path,
+    seen: frozenset[tuple[Path, str]],
+) -> str | None:
+    for node in reversed(body):
+        if isinstance(node, ast.ClassDef) and node.name == base_name:
+            resolved = _resolve_export(source, base_name, repo_root, seen)
+            return resolved.signature if resolved is not None else None
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if not any((alias.asname or alias.name) == base_name for alias in node.names):
+            continue
+        if _import_source(source, node, repo_root) is None:
+            return None
+        resolved = _resolve_export(source, base_name, repo_root, seen)
+        return resolved.signature if resolved is not None else None
+    return None
+
+
+def _class_signature(
+    node: ast.ClassDef,
+    *,
+    module_body: list[ast.stmt],
+    values: dict[str, ast.expr],
+    source: Path,
+    repo_root: Path,
+    seen: frozenset[tuple[Path, str]],
+) -> str:
     bases = [ast.unparse(base) for base in node.bases]
     bases.extend(
         f"{keyword.arg}={ast.unparse(keyword.value)}"
@@ -87,6 +187,13 @@ def _class_signature(node: ast.ClassDef) -> str:
         for keyword in node.keywords
     )
     members: list[str] = []
+    for base in node.bases:
+        name = _base_name(base)
+        if name is None:
+            continue
+        signature = _project_base_signature(source, module_body, name, repo_root, seen)
+        if signature is not None:
+            members.append(f"inherits[{ast.unparse(base)}]={signature}")
     for child in node.body:
         if (
             isinstance(child, ast.AnnAssign)
@@ -103,7 +210,7 @@ def _class_signature(node: ast.ClassDef) -> str:
         elif isinstance(
             child, (ast.FunctionDef, ast.AsyncFunctionDef)
         ) and _is_public_method(child.name):
-            signature = _function_signature(child)
+            signature = _function_signature(child, values)
             marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
             members.append(signature.replace(marker, child.name, 1))
     body = "; ".join(members)
@@ -113,11 +220,31 @@ def _class_signature(node: ast.ClassDef) -> str:
     )
 
 
-def _definition_signature(node: ast.stmt, symbol: str) -> str | None:
+def _definition_signature(
+    node: ast.stmt,
+    symbol: str,
+    *,
+    module_body: list[ast.stmt],
+    values: dict[str, ast.expr],
+    source: Path,
+    repo_root: Path,
+    seen: frozenset[tuple[Path, str]],
+) -> str | None:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        return _function_signature(node) if node.name == symbol else None
+        return _function_signature(node, values) if node.name == symbol else None
     if isinstance(node, ast.ClassDef):
-        return _class_signature(node) if node.name == symbol else None
+        return (
+            _class_signature(
+                node,
+                module_body=module_body,
+                values=values,
+                source=source,
+                repo_root=repo_root,
+                seen=seen,
+            )
+            if node.name == symbol
+            else None
+        )
     if (
         isinstance(node, ast.AnnAssign)
         and isinstance(node.target, ast.Name)
@@ -140,10 +267,25 @@ def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
 
 
 def _module_definition_signature(
-    body: list[ast.stmt], index: int, symbol: str
+    body: list[ast.stmt],
+    index: int,
+    symbol: str,
+    *,
+    source: Path,
+    repo_root: Path,
+    seen: frozenset[tuple[Path, str]],
 ) -> str | None:
     node = body[index]
-    signature = _definition_signature(node, symbol)
+    values = _module_values(body[:index])
+    signature = _definition_signature(
+        node,
+        symbol,
+        module_body=body,
+        values=values,
+        source=source,
+        repo_root=repo_root,
+        seen=seen,
+    )
     if signature is None or not isinstance(
         node, (ast.FunctionDef, ast.AsyncFunctionDef)
     ):
@@ -158,7 +300,9 @@ def _module_definition_signature(
     definitions = overloads if _is_overload(node) else [*overloads, node]
     if _is_overload(node):
         definitions.append(node)
-    return " | ".join(_function_signature(definition) for definition in definitions)
+    return " | ".join(
+        _function_signature(definition, values) for definition in definitions
+    )
 
 
 def _module_source(base: Path) -> Path | None:
@@ -169,9 +313,7 @@ def _module_source(base: Path) -> Path | None:
     return init_source if init_source.is_file() else None
 
 
-def _absolute_module_source(
-    source: Path, module: str, repo_root: Path
-) -> Path | None:
+def _absolute_module_source(source: Path, module: str, repo_root: Path) -> Path | None:
     module_parts = module.split(".")
     anchor = source.parent
     while anchor == repo_root or repo_root in anchor.parents:
@@ -184,9 +326,7 @@ def _absolute_module_source(
     return None
 
 
-def _import_source(
-    source: Path, node: ast.ImportFrom, repo_root: Path
-) -> Path | None:
+def _import_source(source: Path, node: ast.ImportFrom, repo_root: Path) -> Path | None:
     module_parts = (node.module or "").split(".") if node.module else []
     if node.level:
         anchor = source.parent
@@ -393,7 +533,10 @@ def _evaluate_lazy_statements(
         if isinstance(node, ast.If):
             condition = _condition_value(node.test, symbol, collections, strings)
             if condition is None:
-                continue
+                raise RuntimeError(
+                    f"ambiguous lazy export {symbol!r}: cannot evaluate "
+                    f"{ast.unparse(node.test)!r}"
+                )
             branch = node.body if condition else node.orelse
             target, terminal = _evaluate_lazy_statements(
                 branch,
@@ -491,7 +634,14 @@ def _resolve_export(
     # Reverse order reflects the binding left in the module namespace at runtime.
     for index in range(len(tree.body) - 1, -1, -1):
         node = tree.body[index]
-        signature = _module_definition_signature(tree.body, index, symbol)
+        signature = _module_definition_signature(
+            tree.body,
+            index,
+            symbol,
+            source=source,
+            repo_root=repo_root,
+            seen=next_seen,
+        )
         if signature is not None:
             relative = source.relative_to(repo_root).as_posix()
             return _ResolvedExport(
@@ -580,7 +730,9 @@ def _public_symbol_records(
     records: list[dict[str, str]] = []
     for symbol in sorted(package.interface):
         resolved = (
-            _resolve_export(init_path, symbol, repo_root) if init_path.is_file() else None
+            _resolve_export(init_path, symbol, repo_root)
+            if init_path.is_file()
+            else None
         )
         if resolved is not None:
             records.append(

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -32,6 +32,14 @@ class SnapshotPackage:
     impl_dir: Path | None
 
 
+@dataclass(frozen=True)
+class _ResolvedExport:
+    signature: str
+    binding: str
+    source: Path
+    reexported: bool
+
+
 def _annotation(node: ast.expr | None) -> str:
     return ast.unparse(node) if node is not None else "Any"
 
@@ -64,6 +72,12 @@ def _annotated_assignment_signature(node: ast.AnnAssign) -> str:
     return signature
 
 
+def _is_public_method(name: str) -> bool:
+    return not name.startswith("_") or (
+        name.startswith("__") and name.endswith("__")
+    )
+
+
 def _class_signature(node: ast.ClassDef) -> str:
     bases = [ast.unparse(base) for base in node.bases]
     bases.extend(
@@ -86,9 +100,9 @@ def _class_signature(node: ast.ClassDef) -> str:
             for target in child.targets:
                 if isinstance(target, ast.Name) and not target.id.startswith("_"):
                     members.append(f"{target.id}={ast.unparse(child.value)}")
-        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
-            child.name in {"__init__", "__new__"} or not child.name.startswith("_")
-        ):
+        elif isinstance(
+            child, (ast.FunctionDef, ast.AsyncFunctionDef)
+        ) and _is_public_method(child.name):
             signature = _function_signature(child)
             marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
             members.append(signature.replace(marker, child.name, 1))
@@ -99,52 +113,379 @@ def _class_signature(node: ast.ClassDef) -> str:
     )
 
 
-def _definition_signatures(
-    impl_dir: Path, repo_root: Path
-) -> dict[str, list[tuple[str, int, str]]]:
-    definitions: dict[str, list[tuple[str, int, str]]] = {}
-    for source in sorted(impl_dir.rglob("*.py")):
-        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
-        relative = source.relative_to(repo_root).as_posix()
-        for node in tree.body:
-            name: str | None = None
-            signature: str | None = None
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                name = node.name
-                signature = _function_signature(node)
-            elif isinstance(node, ast.ClassDef):
-                name = node.name
-                signature = _class_signature(node)
-            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-                name = node.target.id
-                signature = f"value: {_annotated_assignment_signature(node)}"
-            elif isinstance(node, ast.Assign):
-                names = [
-                    target.id for target in node.targets if isinstance(target, ast.Name)
-                ]
-                if len(names) == 1:
-                    name = names[0]
-                    signature = f"value={ast.unparse(node.value)}"
-            if name is not None and signature is not None:
-                definitions.setdefault(name, []).append(
-                    (relative, node.lineno, signature)
-                )
-    return definitions
+def _definition_signature(node: ast.stmt, symbol: str) -> str | None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return _function_signature(node) if node.name == symbol else None
+    if isinstance(node, ast.ClassDef):
+        return _class_signature(node) if node.name == symbol else None
+    if (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == symbol
+    ):
+        return f"value: {_annotated_assignment_signature(node)}"
+    if isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == symbol for target in node.targets
+    ):
+        return f"value={ast.unparse(node.value)}"
+    return None
 
 
-def _root_reexport(impl_dir: Path, symbol: str) -> str | None:
-    init_path = impl_dir / "__init__.py"
-    if not init_path.is_file():
-        return None
-    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+def _module_source(base: Path) -> Path | None:
+    source = base.with_suffix(".py")
+    if source.is_file():
+        return source
+    init_source = base / "__init__.py"
+    return init_source if init_source.is_file() else None
+
+
+def _absolute_module_source(
+    source: Path, module: str, repo_root: Path
+) -> Path | None:
+    module_parts = module.split(".")
+    anchor = source.parent
+    while anchor == repo_root or repo_root in anchor.parents:
+        candidate = _module_source(anchor.joinpath(*module_parts))
+        if candidate is not None:
+            return candidate
+        if anchor == repo_root:
+            break
+        anchor = anchor.parent
+    return None
+
+
+def _import_source(
+    source: Path, node: ast.ImportFrom, repo_root: Path
+) -> Path | None:
+    module_parts = (node.module or "").split(".") if node.module else []
+    if node.level:
+        anchor = source.parent
+        for _ in range(node.level - 1):
+            anchor = anchor.parent
+        return _module_source(anchor.joinpath(*module_parts))
+    return _absolute_module_source(source, node.module or "", repo_root)
+
+
+def _import_binding(node: ast.ImportFrom, symbol: str) -> str:
+    module = "." * node.level + (node.module or "")
+    separator = "" if module.endswith(".") else "."
+    return f"{module}{separator}{symbol}"
+
+
+_UNKNOWN = object()
+
+
+def _literal_value(node: ast.expr) -> object:
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "frozenset"
+            and len(node.args) == 1
+        ):
+            try:
+                return frozenset(ast.literal_eval(node.args[0]))
+            except (ValueError, TypeError, SyntaxError):
+                pass
+    return _UNKNOWN
+
+
+def _lazy_constants(
+    tree: ast.Module,
+) -> tuple[dict[str, set[str]], dict[str, dict[str, str]]]:
+    collections: dict[str, set[str]] = {}
+    module_maps: dict[str, dict[str, str]] = {}
     for node in tree.body:
+        name: str | None = None
+        value: ast.expr | None = None
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            name = node.targets[0].id
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+            value = node.value
+        if name is None or value is None:
+            continue
+        literal = _literal_value(value)
+        if isinstance(literal, dict) and all(
+            isinstance(key, str) and isinstance(item, str)
+            for key, item in literal.items()
+        ):
+            module_maps[name] = dict(literal)
+        elif isinstance(literal, (set, frozenset, list, tuple)) and all(
+            isinstance(item, str) for item in literal
+        ):
+            collections[name] = set(literal)
+    return collections, module_maps
+
+
+def _expression_value(
+    node: ast.expr,
+    symbol: str,
+    collections: dict[str, set[str]],
+    strings: dict[str, str | None],
+) -> object:
+    if isinstance(node, ast.Name):
+        if node.id == "name":
+            return symbol
+        if node.id in collections:
+            return collections[node.id]
+        return strings.get(node.id, _UNKNOWN)
+    literal = _literal_value(node)
+    return literal
+
+
+def _condition_value(
+    node: ast.expr,
+    symbol: str,
+    collections: dict[str, set[str]],
+    strings: dict[str, str | None],
+) -> bool | None:
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        value = _condition_value(node.operand, symbol, collections, strings)
+        return None if value is None else not value
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        return None
+    left = _expression_value(node.left, symbol, collections, strings)
+    right = _expression_value(node.comparators[0], symbol, collections, strings)
+    if left is _UNKNOWN or right is _UNKNOWN:
+        return None
+    operator = node.ops[0]
+    if isinstance(operator, (ast.Eq, ast.Is)):
+        return left == right
+    if isinstance(operator, (ast.NotEq, ast.IsNot)):
+        return left != right
+    if isinstance(operator, ast.In):
+        return left in right  # type: ignore[operator]
+    if isinstance(operator, ast.NotIn):
+        return left not in right  # type: ignore[operator]
+    return None
+
+
+def _module_map_value(
+    node: ast.expr, symbol: str, module_maps: dict[str, dict[str, str]]
+) -> str | None | object:
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in module_maps
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "name"
+    ):
+        return _UNKNOWN
+    return module_maps[node.func.value.id].get(symbol)
+
+
+def _call_target(
+    node: ast.expr,
+    symbol: str,
+    imports: dict[str, tuple[str, str]],
+    strings: dict[str, str | None],
+) -> tuple[str, str] | None:
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) >= 2
+    ):
+        return None
+    target_name = _expression_value(node.args[1], symbol, {}, strings)
+    if not isinstance(target_name, str):
+        return None
+    owner = node.args[0]
+    if isinstance(owner, ast.Name) and owner.id in imports:
+        module, imported_name = imports[owner.id]
+        return f"{module}.{imported_name}", target_name
+    if (
+        isinstance(owner, ast.Call)
+        and isinstance(owner.func, ast.Name)
+        and owner.func.id == "import_module"
+        and len(owner.args) == 1
+    ):
+        module = _expression_value(owner.args[0], symbol, {}, strings)
+        if isinstance(module, str):
+            return module, target_name
+    return None
+
+
+def _evaluate_lazy_statements(
+    statements: list[ast.stmt],
+    symbol: str,
+    collections: dict[str, set[str]],
+    module_maps: dict[str, dict[str, str]],
+    imports: dict[str, tuple[str, str]],
+    strings: dict[str, str | None],
+    targets: dict[str, tuple[str, str]],
+) -> tuple[tuple[str, str] | None, bool]:
+    for node in statements:
+        if isinstance(node, ast.If):
+            condition = _condition_value(node.test, symbol, collections, strings)
+            if condition is None:
+                continue
+            branch = node.body if condition else node.orelse
+            target, terminal = _evaluate_lazy_statements(
+                branch,
+                symbol,
+                collections,
+                module_maps,
+                imports,
+                strings,
+                targets,
+            )
+            if target is not None or terminal:
+                return target, terminal
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                imports[alias.asname or alias.name] = (node.module, alias.name)
+            continue
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            if isinstance(node, ast.Assign):
+                if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                    continue
+                name = node.targets[0].id
+                value = node.value
+            else:
+                if not isinstance(node.target, ast.Name) or node.value is None:
+                    continue
+                name = node.target.id
+                value = node.value
+            target = _call_target(value, symbol, imports, strings)
+            if target is not None:
+                targets[name] = target
+                continue
+            mapped = _module_map_value(value, symbol, module_maps)
+            if mapped is not _UNKNOWN:
+                strings[name] = mapped  # type: ignore[assignment]
+                continue
+            literal = _literal_value(value)
+            if isinstance(literal, str):
+                strings[name] = literal
+            continue
+        if isinstance(node, ast.Return):
+            if node.value is None:
+                return None, True
+            target = _call_target(node.value, symbol, imports, strings)
+            if target is not None:
+                return target, True
+            if isinstance(node.value, ast.Name):
+                if node.value.id in targets:
+                    return targets[node.value.id], True
+                if node.value.id in imports:
+                    return imports[node.value.id], True
+            return None, True
+        if isinstance(node, ast.Raise):
+            return None, True
+    return None, False
+
+
+def _lazy_export_target(tree: ast.Module, symbol: str) -> tuple[str, str] | None:
+    getter = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "__getattr__"
+        ),
+        None,
+    )
+    if getter is None:
+        return None
+    collections, module_maps = _lazy_constants(tree)
+    target, _ = _evaluate_lazy_statements(
+        getter.body,
+        symbol,
+        collections,
+        module_maps,
+        {},
+        {},
+        {},
+    )
+    return target
+
+
+def _resolve_export(
+    source: Path,
+    symbol: str,
+    repo_root: Path,
+    seen: frozenset[tuple[Path, str]] = frozenset(),
+) -> _ResolvedExport | None:
+    key = (source.resolve(), symbol)
+    if key in seen:
+        return None
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    next_seen = seen | {key}
+
+    # Reverse order reflects the binding left in the module namespace at runtime.
+    for node in reversed(tree.body):
+        signature = _definition_signature(node, symbol)
+        if signature is not None:
+            relative = source.relative_to(repo_root).as_posix()
+            return _ResolvedExport(
+                signature=signature,
+                binding=f"{relative}::{symbol}",
+                source=source,
+                reexported=False,
+            )
         if not isinstance(node, ast.ImportFrom):
             continue
-        for alias in node.names:
+        for alias in reversed(node.names):
             public_name = alias.asname or alias.name
-            if public_name == symbol:
-                module = "." * node.level + (node.module or "")
-                return f"reexport:{module}.{alias.name}"
+            if public_name != symbol and alias.name != "*":
+                continue
+            imported_symbol = symbol if alias.name == "*" else alias.name
+            binding = _import_binding(node, imported_symbol)
+            target_source = _import_source(source, node, repo_root)
+            resolved = (
+                _resolve_export(target_source, imported_symbol, repo_root, next_seen)
+                if target_source is not None
+                else None
+            )
+            if resolved is None:
+                return _ResolvedExport(
+                    signature=f"unresolved-reexport:{binding}",
+                    binding=binding,
+                    source=source,
+                    reexported=True,
+                )
+            return _ResolvedExport(
+                signature=resolved.signature,
+                binding=f"{binding} -> {resolved.binding}",
+                source=resolved.source,
+                reexported=True,
+            )
+    lazy_target = _lazy_export_target(tree, symbol)
+    if lazy_target is not None:
+        module, target_symbol = lazy_target
+        binding = f"lazy:{module}.{target_symbol}"
+        target_source = _absolute_module_source(source, module, repo_root)
+        resolved = (
+            _resolve_export(target_source, target_symbol, repo_root, next_seen)
+            if target_source is not None
+            else None
+        )
+        if resolved is None:
+            return _ResolvedExport(
+                signature=f"unresolved-reexport:{binding}",
+                binding=binding,
+                source=source,
+                reexported=True,
+            )
+        return _ResolvedExport(
+            signature=resolved.signature,
+            binding=f"{binding} -> {resolved.binding}",
+            source=resolved.source,
+            reexported=True,
+        )
     return None
 
 
@@ -159,34 +500,31 @@ def _public_symbol_records(
             "BE implementation"
         )
 
-    definitions = _definition_signatures(package.impl_dir, repo_root)
+    init_path = package.impl_dir / "__init__.py"
     records: list[dict[str, str]] = []
     for symbol in sorted(package.interface):
-        matches = definitions.get(symbol, [])
-        if matches:
-            signatures = sorted({signature for _, _, signature in matches})
-            sources = sorted({source for source, _, _ in matches})
+        resolved = (
+            _resolve_export(init_path, symbol, repo_root) if init_path.is_file() else None
+        )
+        if resolved is not None:
             records.append(
                 {
                     "package": package.name,
                     "symbol": symbol,
-                    "signature": " | ".join(signatures),
-                    "resolution": "definition" if len(matches) == 1 else "ambiguous",
-                    "source": ",".join(sources),
+                    "signature": f"{resolved.binding} => {resolved.signature}",
+                    "resolution": "reexport" if resolved.reexported else "definition",
+                    "source": resolved.source.relative_to(repo_root).as_posix(),
                 }
             )
             continue
 
-        reexport = _root_reexport(package.impl_dir, symbol)
         records.append(
             {
                 "package": package.name,
                 "symbol": symbol,
-                "signature": reexport or "dynamic-export",
-                "resolution": "reexport" if reexport else "dynamic",
-                "source": package.impl_dir.joinpath("__init__.py")
-                .relative_to(repo_root)
-                .as_posix(),
+                "signature": "dynamic-export",
+                "resolution": "dynamic",
+                "source": init_path.relative_to(repo_root).as_posix(),
             }
         )
     return records

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -1,0 +1,408 @@
+"""Dependency topology and public-boundary impact reporting.
+
+This extension owns filesystem, AST, and Git-ref I/O. The dependency graph
+itself remains a pure ``base`` computation so both this report and the ``data``
+projection use one policy implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import json
+import subprocess
+import tarfile
+import tempfile
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from common.meta.base.dependency_graph import build_dependency_graph
+from common.meta.extension.check_package_contract import (
+    DiscoveredPackage,
+    discover_packages,
+)
+
+
+def _annotation(node: ast.expr | None) -> str:
+    return ast.unparse(node) if node is not None else "Any"
+
+
+def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+    return f"{prefix}({ast.unparse(node.args)}) -> {_annotation(node.returns)}"
+
+
+def _class_signature(node: ast.ClassDef) -> str:
+    bases = ", ".join(ast.unparse(base) for base in node.bases)
+    members: list[str] = []
+    for child in node.body:
+        if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
+            members.append(f"{child.target.id}: {_annotation(child.annotation)}")
+        elif isinstance(
+            child, (ast.FunctionDef, ast.AsyncFunctionDef)
+        ) and not child.name.startswith("_"):
+            signature = _function_signature(child)
+            suffix = signature.removeprefix("async def").removeprefix("def")
+            members.append(f"{child.name}{suffix}")
+    body = "; ".join(members)
+    return f"class({bases}){{{body}}}"
+
+
+def _definition_signatures(
+    impl_dir: Path, repo_root: Path
+) -> dict[str, list[tuple[str, int, str]]]:
+    definitions: dict[str, list[tuple[str, int, str]]] = {}
+    for source in sorted(impl_dir.rglob("*.py")):
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        relative = source.relative_to(repo_root).as_posix()
+        for node in tree.body:
+            name: str | None = None
+            signature: str | None = None
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                name = node.name
+                signature = _function_signature(node)
+            elif isinstance(node, ast.ClassDef):
+                name = node.name
+                signature = _class_signature(node)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                name = node.target.id
+                signature = f"value: {_annotation(node.annotation)}"
+            elif isinstance(node, ast.Assign):
+                names = [
+                    target.id for target in node.targets if isinstance(target, ast.Name)
+                ]
+                if len(names) == 1:
+                    name = names[0]
+                    signature = f"value={ast.unparse(node.value)}"
+            if name is not None and signature is not None:
+                definitions.setdefault(name, []).append(
+                    (relative, node.lineno, signature)
+                )
+    return definitions
+
+
+def _root_reexport(impl_dir: Path, symbol: str) -> str | None:
+    init_path = impl_dir / "__init__.py"
+    if not init_path.is_file():
+        return None
+    tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for alias in node.names:
+            public_name = alias.asname or alias.name
+            if public_name == symbol:
+                module = "." * node.level + (node.module or "")
+                return f"reexport:{module}.{alias.name}"
+    return None
+
+
+def _public_symbol_records(
+    package: DiscoveredPackage, repo_root: Path
+) -> list[dict[str, str]]:
+    if not package.contract.interface:
+        return []
+    if package.impl_dir is None or not package.impl_dir.is_dir():
+        raise RuntimeError(
+            f"package {package.name!r} publishes an interface but has no readable "
+            "BE implementation"
+        )
+
+    definitions = _definition_signatures(package.impl_dir, repo_root)
+    records: list[dict[str, str]] = []
+    for symbol in sorted(package.contract.interface):
+        matches = definitions.get(symbol, [])
+        if matches:
+            signatures = sorted({signature for _, _, signature in matches})
+            sources = sorted({source for source, _, _ in matches})
+            records.append(
+                {
+                    "package": package.name,
+                    "symbol": symbol,
+                    "signature": " | ".join(signatures),
+                    "resolution": "definition" if len(matches) == 1 else "ambiguous",
+                    "source": ",".join(sources),
+                }
+            )
+            continue
+
+        reexport = _root_reexport(package.impl_dir, symbol)
+        records.append(
+            {
+                "package": package.name,
+                "symbol": symbol,
+                "signature": reexport or "dynamic-export",
+                "resolution": "reexport" if reexport else "dynamic",
+                "source": package.impl_dir.joinpath("__init__.py")
+                .relative_to(repo_root)
+                .as_posix(),
+            }
+        )
+    return records
+
+
+def build_dependency_snapshot(repo_root: Path) -> dict[str, object]:
+    """Build a deterministic dependency/public-boundary snapshot of a tree."""
+
+    root = repo_root.resolve()
+    packages = discover_packages(root)
+    if not packages:
+        raise RuntimeError(f"no package contracts discovered under {root}")
+
+    graph = build_dependency_graph([package.contract for package in packages])
+    public_symbols = [
+        record
+        for package in sorted(packages, key=lambda item: item.name)
+        for record in _public_symbol_records(package, root)
+    ]
+    snapshot = graph.as_dict()
+    snapshot["public_symbols"] = public_symbols
+    return snapshot
+
+
+def _edge_key(edge: dict[str, str]) -> tuple[str, str, str, str]:
+    return (edge["consumer"], edge["provider"], edge["kind"], edge["detail"])
+
+
+def _symbol_map(snapshot: dict[str, object]) -> dict[tuple[str, str], dict[str, str]]:
+    records = snapshot["public_symbols"]
+    assert isinstance(records, list)
+    return {
+        (record["package"], record["symbol"]): record
+        for record in records
+        if isinstance(record, dict)
+    }
+
+
+def _consumer_set(
+    snapshots: Iterable[dict[str, object]], package: str, field: str
+) -> list[str]:
+    consumers: set[str] = set()
+    for snapshot in snapshots:
+        index = snapshot[field]
+        assert isinstance(index, dict)
+        values = index.get(package, [])
+        assert isinstance(values, list)
+        consumers.update(value for value in values if isinstance(value, str))
+    return sorted(consumers)
+
+
+def compare_dependency_snapshots(
+    base: dict[str, object], head: dict[str, object]
+) -> dict[str, object]:
+    """Compare two snapshots and compute the complete consumer fan-out."""
+
+    base_edges = {_edge_key(edge): edge for edge in base["edges"]}  # type: ignore[index]
+    head_edges = {_edge_key(edge): edge for edge in head["edges"]}  # type: ignore[index]
+    added_edges = [head_edges[key] for key in sorted(head_edges.keys() - base_edges)]
+    removed_edges = [base_edges[key] for key in sorted(base_edges.keys() - head_edges)]
+
+    base_symbols = _symbol_map(base)
+    head_symbols = _symbol_map(head)
+    added_symbols = [
+        head_symbols[key] for key in sorted(head_symbols.keys() - base_symbols)
+    ]
+    removed_symbols = [
+        base_symbols[key] for key in sorted(base_symbols.keys() - head_symbols)
+    ]
+    changed_symbols: list[dict[str, str]] = []
+    for key in sorted(base_symbols.keys() & head_symbols):
+        before = base_symbols[key]
+        after = head_symbols[key]
+        if before["signature"] != after["signature"]:
+            changed_symbols.append(
+                {
+                    "package": key[0],
+                    "symbol": key[1],
+                    "before": before["signature"],
+                    "after": after["signature"],
+                }
+            )
+
+    affected_packages = {
+        record["package"]
+        for record in (*added_symbols, *removed_symbols, *changed_symbols)
+    }
+    affected_packages.update(edge["provider"] for edge in added_edges)
+    affected_packages.update(edge["provider"] for edge in removed_edges)
+
+    affected_consumers: dict[str, dict[str, list[str]]] = {}
+    for package in sorted(affected_packages):
+        direct = _consumer_set((base, head), package, "direct_consumers")
+        transitive = _consumer_set((base, head), package, "transitive_consumers")
+        affected_consumers[package] = {
+            "direct": direct,
+            "transitive": transitive,
+            "indirect": sorted(set(transitive) - set(direct)),
+        }
+
+    return {
+        "base": base,
+        "head": head,
+        "added_edges": added_edges,
+        "removed_edges": removed_edges,
+        "added_public_symbols": added_symbols,
+        "removed_public_symbols": removed_symbols,
+        "changed_public_symbols": changed_symbols,
+        "affected_consumers": affected_consumers,
+        "errors": [],
+    }
+
+
+def _snapshot_git_ref(repo_root: Path, ref: str) -> dict[str, object]:
+    try:
+        archive = subprocess.run(
+            ["git", "-C", str(repo_root), "archive", "--format=tar", ref],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"cannot read base ref {ref!r}: {detail}") from exc
+
+    with tempfile.TemporaryDirectory(prefix="ddd-dependency-base-") as temp_dir:
+        base_root = Path(temp_dir)
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+            tar.extractall(base_root, filter="data")
+        return build_dependency_snapshot(base_root)
+
+
+def build_impact_report(repo_root: Path, *, base_ref: str) -> dict[str, object]:
+    """Compare the working tree with an archive isolated from ``base_ref``."""
+
+    root = repo_root.resolve()
+    head = build_dependency_snapshot(root)
+    base = _snapshot_git_ref(root, base_ref)
+    report = compare_dependency_snapshots(base, head)
+    report["base_ref"] = base_ref
+    return report
+
+
+def render_markdown(report: dict[str, object]) -> str:
+    """Render the high-level dependency impact for a CI step summary."""
+
+    added_edges = report["added_edges"]
+    removed_edges = report["removed_edges"]
+    added_symbols = report["added_public_symbols"]
+    removed_symbols = report["removed_public_symbols"]
+    changed_symbols = report["changed_public_symbols"]
+    affected = report["affected_consumers"]
+    assert isinstance(added_edges, list)
+    assert isinstance(removed_edges, list)
+    assert isinstance(added_symbols, list)
+    assert isinstance(removed_symbols, list)
+    assert isinstance(changed_symbols, list)
+    assert isinstance(affected, dict)
+
+    lines = [
+        "## DDD Dependency Impact",
+        "",
+        f"Base: `{report.get('base_ref', 'snapshot')}`",
+        "",
+        "| Change | Count |",
+        "|---|---:|",
+        f"| Added dependency edges | {len(added_edges)} |",
+        f"| Removed dependency edges | {len(removed_edges)} |",
+        f"| Added public symbols | {len(added_symbols)} |",
+        f"| Removed public symbols | {len(removed_symbols)} |",
+        f"| Changed public signatures | {len(changed_symbols)} |",
+        f"| Affected provider packages | {len(affected)} |",
+    ]
+    edge_changes = [
+        ("added", edge) for edge in added_edges if isinstance(edge, dict)
+    ] + [("removed", edge) for edge in removed_edges if isinstance(edge, dict)]
+    if edge_changes:
+        lines.extend(
+            [
+                "",
+                "### Dependency Edge Changes",
+                "",
+                "| Change | Consumer | Provider | Kind |",
+                "|---|---|---|---|",
+            ]
+        )
+        for change, edge in edge_changes:
+            lines.append(
+                f"| {change} | `{edge['consumer']}` | `{edge['provider']}` | "
+                f"`{edge['kind']}` |"
+            )
+
+    boundary_changes: list[tuple[str, dict[str, str]]] = [
+        ("added", record) for record in added_symbols if isinstance(record, dict)
+    ]
+    boundary_changes.extend(
+        ("removed", record) for record in removed_symbols if isinstance(record, dict)
+    )
+    boundary_changes.extend(
+        ("changed", record) for record in changed_symbols if isinstance(record, dict)
+    )
+    if boundary_changes:
+        lines.extend(
+            [
+                "",
+                "### Public Boundary Changes",
+                "",
+                "| Change | Package | Symbol | Before | After |",
+                "|---|---|---|---|---|",
+            ]
+        )
+        for change, record in boundary_changes:
+            before = str(
+                record.get(
+                    "before", "-" if change == "added" else record.get("signature", "-")
+                )
+            )
+            after = str(
+                record.get(
+                    "after",
+                    "-" if change == "removed" else record.get("signature", "-"),
+                )
+            )
+            before = before.replace("|", "\\|")
+            after = after.replace("|", "\\|")
+            lines.append(
+                f"| {change} | `{record['package']}` | `{record['symbol']}` | "
+                f"`{before}` | `{after}` |"
+            )
+    if affected:
+        lines.extend(
+            [
+                "",
+                "### Affected Consumers",
+                "",
+                "| Provider | Direct consumers | Indirect consumers |",
+                "|---|---|---|",
+            ]
+        )
+        for package, consumers in sorted(affected.items()):
+            assert isinstance(consumers, dict)
+            direct = ", ".join(consumers["direct"]) or "-"
+            indirect = ", ".join(consumers["indirect"]) or "-"
+            lines.append(f"| `{package}` | {direct} | {indirect} |")
+    return "\n".join(lines) + "\n"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    args = parser.parse_args(argv)
+
+    report = build_impact_report(args.repo_root, base_ref=args.base_ref)
+    json_text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    markdown = render_markdown(report)
+    if args.json_out:
+        _write(args.json_out, json_text)
+    if args.markdown_out:
+        _write(args.markdown_out, markdown)
+    if not args.json_out and not args.markdown_out:
+        print(json_text, end="")
+    return 0

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -54,12 +54,25 @@ class _ImportedModule:
 
 
 @dataclass(frozen=True)
+class _LocalDefinition:
+    source: Path
+    symbol: str
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+    values: tuple[tuple[str, _ValueBinding], ...]
+    body: tuple[ast.stmt, ...]
+    index: int
+    binding: str
+
+
+@dataclass(frozen=True)
 class _ExpressionValue:
     expression: str
     dependencies: tuple[tuple[str, _ValueBinding], ...]
 
 
-type _ValueBinding = _ExpressionValue | _ImportedModule | _ImportedValue
+type _ValueBinding = (
+    _ExpressionValue | _ImportedModule | _ImportedValue | _LocalDefinition
+)
 
 
 _ResolutionKey = tuple[Path, str, int | None]
@@ -148,6 +161,30 @@ def _binding_fingerprint(
 ) -> str:
     if isinstance(binding, _ImportedModule):
         return binding.binding
+    if isinstance(binding, _LocalDefinition):
+        key = (binding.source.resolve(), binding.symbol)
+        if key in seen:
+            return binding.binding
+        definition_seen = seen | {key}
+        if isinstance(binding.node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            signature = _function_signature(
+                binding.node,
+                repo_root,
+                dict(binding.values),
+                definition_seen,
+            )
+        else:
+            signature = _class_signature(
+                binding.node,
+                module_body=list(binding.body),
+                values=dict(binding.values),
+                source=binding.source,
+                repo_root=repo_root,
+                seen=frozenset(),
+                definition_index=binding.index,
+                value_seen=definition_seen,
+            )
+        return f"{binding.binding} -> {signature}"
     if isinstance(binding, _ImportedValue):
         fingerprint = _imported_value_fingerprint(
             binding.source, binding.symbol, repo_root, seen
@@ -189,7 +226,8 @@ def _imported_value_fingerprint(
     values = _module_values(tree.body, source=source, repo_root=repo_root)
     binding = values.get(symbol)
     if binding is not None:
-        return _binding_fingerprint(binding, repo_root, seen | {key})
+        binding_seen = seen if isinstance(binding, _LocalDefinition) else seen | {key}
+        return _binding_fingerprint(binding, repo_root, binding_seen)
     return _imported_definition_fingerprint(source, symbol, repo_root, seen | {key})
 
 
@@ -232,13 +270,26 @@ def _module_values(
     initial: dict[str, _ValueBinding] | None = None,
 ) -> dict[str, _ValueBinding]:
     values = dict(initial or {})
-    for node in body:
+    scope_body = tuple(body)
+    for index, node in enumerate(scope_body):
         if isinstance(node, ast.If) and _is_type_checking_test(node.test):
             values = _module_values(
                 node.body,
                 source=source,
                 repo_root=repo_root,
                 initial=values,
+            )
+            continue
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            relative = source.relative_to(repo_root).as_posix()
+            values[node.name] = _LocalDefinition(
+                source=source,
+                symbol=node.name,
+                node=node,
+                values=tuple(values.items()),
+                body=scope_body,
+                index=index,
+                binding=f"{relative}::{node.name}",
             )
             continue
         if isinstance(node, ast.Import):
@@ -474,7 +525,10 @@ def _class_signature(
             )
         if signature is not None:
             members.append(f"inherits[{ast.unparse(base)}]={signature}")
-    for child in node.body:
+    class_values = dict(values)
+    class_body = tuple(node.body)
+    relative = source.relative_to(repo_root).as_posix()
+    for child_index, child in enumerate(class_body):
         if (
             isinstance(child, ast.AnnAssign)
             and isinstance(child.target, ast.Name)
@@ -482,21 +536,55 @@ def _class_signature(
         ):
             members.append(
                 f"{child.target.id}: "
-                f"{_annotated_assignment_signature(child, values, repo_root, value_seen)}"
+                f"{_annotated_assignment_signature(child, class_values, repo_root, value_seen)}"
             )
         elif isinstance(child, ast.Assign):
             for target in child.targets:
                 if isinstance(target, ast.Name) and not target.id.startswith("_"):
                     members.append(
                         f"{target.id}="
-                        f"{_expression_fingerprint(child.value, values, repo_root, value_seen)}"
+                        f"{_expression_fingerprint(child.value, class_values, repo_root, value_seen)}"
                     )
         elif isinstance(
             child, (ast.FunctionDef, ast.AsyncFunctionDef)
         ) and _is_public_method(child.name):
-            signature = _function_signature(child, repo_root, values, value_seen)
+            signature = _function_signature(child, repo_root, class_values, value_seen)
             marker = "async def" if isinstance(child, ast.AsyncFunctionDef) else "def"
             members.append(signature.replace(marker, child.name, 1))
+        if isinstance(child, ast.Assign):
+            binding = _capture_expression(child.value, class_values)
+            for target in child.targets:
+                if isinstance(target, ast.Name):
+                    class_values[target.id] = binding
+        elif (
+            isinstance(child, ast.AnnAssign)
+            and isinstance(child.target, ast.Name)
+            and child.value is not None
+        ):
+            class_values[child.target.id] = _capture_expression(
+                child.value, class_values
+            )
+        elif isinstance(child, ast.TypeAlias) and isinstance(child.name, ast.Name):
+            class_values[child.name.id] = _capture_expression(child.value, class_values)
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            class_values[child.name] = _LocalDefinition(
+                source=source,
+                symbol=child.name,
+                node=child,
+                values=tuple(class_values.items()),
+                body=class_body,
+                index=child_index,
+                binding=f"{relative}::{node.name}.{child.name}",
+            )
+        elif isinstance(child, (ast.Import, ast.ImportFrom)) or (
+            isinstance(child, ast.If) and _is_type_checking_test(child.test)
+        ):
+            class_values = _module_values(
+                [child],
+                source=source,
+                repo_root=repo_root,
+                initial=class_values,
+            )
     body = "; ".join(members)
     decorator_values = _resolved_references(
         node.decorator_list, values, "decorators", repo_root, value_seen
@@ -665,6 +753,17 @@ def _absolute_module_source(source: Path, module: str, repo_root: Path) -> Path 
             break
         anchor = anchor.parent
     return None
+
+
+def _module_spec_source(source: Path, module: str, repo_root: Path) -> Path | None:
+    level = len(module) - len(module.lstrip("."))
+    if not level:
+        return _absolute_module_source(source, module, repo_root)
+    anchor = source.parent
+    for _ in range(level - 1):
+        anchor = anchor.parent
+    module_parts = module[level:].split(".") if module[level:] else []
+    return _module_source(anchor.joinpath(*module_parts))
 
 
 def _import_source(source: Path, node: ast.ImportFrom, repo_root: Path) -> Path | None:
@@ -841,7 +940,8 @@ def _call_target(
     owner = node.args[0]
     if isinstance(owner, ast.Name) and owner.id in imports:
         module, imported_name = imports[owner.id]
-        return f"{module}.{imported_name}", target_name
+        separator = "" if module.endswith(".") else "."
+        return f"{module}{separator}{imported_name}", target_name
     if (
         isinstance(owner, ast.Call)
         and (
@@ -891,9 +991,10 @@ def _evaluate_lazy_statements(
             if target is not None or terminal:
                 return target, terminal
             continue
-        if isinstance(node, ast.ImportFrom) and node.module:
+        if isinstance(node, ast.ImportFrom):
+            module = "." * node.level + (node.module or "")
             for alias in node.names:
-                imports[alias.asname or alias.name] = (node.module, alias.name)
+                imports[alias.asname or alias.name] = (module, alias.name)
             continue
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
             if isinstance(node, ast.Assign):
@@ -1091,8 +1192,9 @@ def _resolve_export(
     lazy_target = _lazy_export_target(tree, symbol)
     if lazy_target is not None:
         module, target_symbol = lazy_target
-        binding = f"lazy:{module}.{target_symbol}"
-        target_source = _absolute_module_source(source, module, repo_root)
+        separator = "" if module.endswith(".") else "."
+        binding = f"lazy:{module}{separator}{target_symbol}"
+        target_source = _module_spec_source(source, module, repo_root)
         if target_source is None:
             raise RuntimeError(
                 f"{source}: cannot resolve export {symbol!r} through {binding}"

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -167,10 +167,11 @@ builds that historical snapshot in a clean `python -I` subprocess before
 comparing it with the working tree. A historical contract is therefore never
 reinterpreted through HEAD's `PackageContract` model. The JSON report includes
 added/removed typed edges, changed public signatures, and the union of base/head
-direct and transitive consumers. Class signatures include their public class
-members and constructor. Every declared public symbol gets exactly one snapshot
-record; when AST inspection cannot statically resolve a lazy export, the record
-says so instead of silently dropping it. Unreadable refs, empty discovery,
+direct and transitive consumers. Public signatures preserve annotated values,
+decorators, generic type parameters, class construction, and public class
+members. Every declared public symbol gets exactly one snapshot record; when
+AST inspection cannot statically resolve a lazy export, the record says so
+instead of silently dropping it. Unreadable refs, empty discovery,
 duplicate/unknown/self edges, and cycles fail closed.
 
 The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -171,13 +171,14 @@ direct and transitive consumers. Public-boundary inspection starts at each
 implementation root and follows eager, chained, wildcard, and the repository's
 bounded lazy `__getattr__` export forms to the owning definition. Its signature
 retains that binding path plus overload declarations, annotated values,
-decorators, generic type parameters, class construction, public protocol dunder
-methods, and other public class members. Wildcard binding obeys the target's
-`__all__`; missing explicit or lazy targets fail closed. Every declared public
-symbol gets exactly one snapshot record, and the repository snapshot is
-ratcheted to zero unresolved dynamic exports; an unsupported future form is
-exposed as `dynamic-export` rather than silently matched to an unrelated
-same-named definition. Unreadable refs, empty discovery,
+decorators, generic type parameters, resolved named defaults, class construction,
+repository-owned inherited APIs, public protocol dunder methods, and other public
+class members. Wildcard binding obeys the target's `__all__`; missing explicit or
+lazy targets and ambiguous lazy control flow fail closed. Every declared public
+symbol gets exactly one snapshot record, and the repository snapshot is ratcheted
+to zero unresolved dynamic exports; a declaration with no statically visible
+binding is exposed as `dynamic-export` rather than silently matched to an
+unrelated same-named definition. Unreadable refs, empty discovery,
 duplicate/unknown/self edges, and cycles fail closed.
 
 The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -173,10 +173,12 @@ bounded lazy `__getattr__` export forms plus local assignment aliases to the
 owning definition. Its signature retains that binding path plus overload
 declarations, annotated values,
 decorators, generic type parameters, local and repository-imported named defaults,
-annotation aliases, class construction, repository-owned inherited APIs, public
-protocol dunder methods, and other public class members. Value bindings are
-fingerprinted at their assignment/import time, so later rebinding cannot rewrite a
-captured default or alias. Wildcard binding obeys the target's `__all__`; missing
+annotation aliases (including `TYPE_CHECKING` declarations), class construction,
+repository-owned inherited APIs, public protocol dunder methods, and other public
+class members. Bare and module-qualified project bindings use the same resolver.
+Value bindings are fingerprinted at their assignment/import time, so later
+rebinding cannot rewrite a captured default or alias. Wildcard binding obeys the
+target's `__all__`; missing
 explicit or lazy targets and ambiguous lazy control flow fail closed. Every declared public
 symbol gets exactly one snapshot record, and the repository snapshot is ratcheted
 to zero unresolved dynamic exports; a declaration with no statically visible

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -161,14 +161,17 @@ acyclic graph and computes direct plus transitive consumers; the pure
 is no authored dependency table alongside the contracts.
 
 `common/meta/extension/dependency_report.py` owns the impure review edge. It
-discovers contracts and public definitions from a checkout, archives the chosen
-Git base ref into an isolated temporary tree, then compares base with the working
-tree. The JSON report includes added/removed typed edges, changed public
-signatures, and the union of base/head direct and transitive consumers. Every
-declared public symbol gets exactly one snapshot record; when AST inspection
-cannot statically resolve a lazy export, the record says so instead of silently
-dropping it. Unreadable refs, empty discovery, duplicate/unknown/self edges, and
-cycles fail closed.
+reads only the dependency-relevant contract literals and public definitions via
+AST, archives the chosen Git base ref into an isolated temporary tree, and
+builds that historical snapshot in a clean `python -I` subprocess before
+comparing it with the working tree. A historical contract is therefore never
+reinterpreted through HEAD's `PackageContract` model. The JSON report includes
+added/removed typed edges, changed public signatures, and the union of base/head
+direct and transitive consumers. Class signatures include their public class
+members and constructor. Every declared public symbol gets exactly one snapshot
+record; when AST inspection cannot statically resolve a lazy export, the record
+says so instead of silently dropping it. Unreadable refs, empty discovery,
+duplicate/unknown/self edges, and cycles fail closed.
 
 The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends
 its Markdown view to `GITHUB_STEP_SUMMARY`, while the contracts remain the only

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -167,12 +167,16 @@ builds that historical snapshot in a clean `python -I` subprocess before
 comparing it with the working tree. A historical contract is therefore never
 reinterpreted through HEAD's `PackageContract` model. The JSON report includes
 added/removed typed edges, changed public signatures, and the union of base/head
-direct and transitive consumers. Public signatures preserve annotated values,
-decorators, generic type parameters, class construction, and public class
-members. Every declared public symbol gets exactly one snapshot record; when
-AST inspection cannot statically resolve a lazy export, the record says so
-instead of silently dropping it. Unreadable refs, empty discovery,
-duplicate/unknown/self edges, and cycles fail closed.
+direct and transitive consumers. Public-boundary inspection starts at each
+implementation root and follows eager, chained, wildcard, and the repository's
+bounded lazy `__getattr__` export forms to the owning definition. Its signature
+retains that binding path plus annotated values, decorators, generic type
+parameters, class construction, public protocol dunder methods, and other
+public class members. Every declared public symbol gets exactly one snapshot
+record, and the repository snapshot is ratcheted to zero unresolved dynamic
+exports; an unsupported future form is exposed as `dynamic-export` rather than
+silently matched to an unrelated same-named definition. Unreadable refs, empty
+discovery, duplicate/unknown/self edges, and cycles fail closed.
 
 The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends
 its Markdown view to `GITHUB_STEP_SUMMARY`, while the contracts remain the only

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -169,8 +169,9 @@ reinterpreted through HEAD's `PackageContract` model. The JSON report includes
 added/removed typed edges, changed public signatures, and the union of base/head
 direct and transitive consumers. Public-boundary inspection starts at each
 implementation root and follows eager, chained, wildcard, and the repository's
-bounded lazy `__getattr__` export forms to the owning definition. Its signature
-retains that binding path plus overload declarations, annotated values,
+bounded lazy `__getattr__` export forms plus local assignment aliases to the
+owning definition. Its signature retains that binding path plus overload
+declarations, annotated values,
 decorators, generic type parameters, resolved named defaults, class construction,
 repository-owned inherited APIs, public protocol dunder methods, and other public
 class members. Wildcard binding obeys the target's `__all__`; missing explicit or

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -170,13 +170,15 @@ added/removed typed edges, changed public signatures, and the union of base/head
 direct and transitive consumers. Public-boundary inspection starts at each
 implementation root and follows eager, chained, wildcard, and the repository's
 bounded lazy `__getattr__` export forms to the owning definition. Its signature
-retains that binding path plus annotated values, decorators, generic type
-parameters, class construction, public protocol dunder methods, and other
-public class members. Every declared public symbol gets exactly one snapshot
-record, and the repository snapshot is ratcheted to zero unresolved dynamic
-exports; an unsupported future form is exposed as `dynamic-export` rather than
-silently matched to an unrelated same-named definition. Unreadable refs, empty
-discovery, duplicate/unknown/self edges, and cycles fail closed.
+retains that binding path plus overload declarations, annotated values,
+decorators, generic type parameters, class construction, public protocol dunder
+methods, and other public class members. Wildcard binding obeys the target's
+`__all__`; missing explicit or lazy targets fail closed. Every declared public
+symbol gets exactly one snapshot record, and the repository snapshot is
+ratcheted to zero unresolved dynamic exports; an unsupported future form is
+exposed as `dynamic-export` rather than silently matched to an unrelated
+same-named definition. Unreadable refs, empty discovery,
+duplicate/unknown/self edges, and cycles fail closed.
 
 The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends
 its Markdown view to `GITHUB_STEP_SUMMARY`, while the contracts remain the only

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -152,6 +152,39 @@ Because governance reads the contract, adding a package adds no central index to
 edit: a new package is governed when `common/<pkg>/contract.py` exports a
 module-level `CONTRACT = PackageContract(...)`.
 
+### Dependency impact is a generated review plane
+
+`PackageContract.depends_on` and `PackageContract.interface` remain the authored
+facts. `common/meta/base/dependency_graph.py` validates those facts as one typed
+acyclic graph and computes direct plus transitive consumers; the pure
+`dependency_index` projection exposes that graph without filesystem I/O. There
+is no authored dependency table alongside the contracts.
+
+`common/meta/extension/dependency_report.py` owns the impure review edge. It
+discovers contracts and public definitions from a checkout, archives the chosen
+Git base ref into an isolated temporary tree, then compares base with the working
+tree. The JSON report includes added/removed typed edges, changed public
+signatures, and the union of base/head direct and transitive consumers. Every
+declared public symbol gets exactly one snapshot record; when AST inspection
+cannot statically resolve a lazy export, the record says so instead of silently
+dropping it. Unreadable refs, empty discovery, duplicate/unknown/self edges, and
+cycles fail closed.
+
+The report is ephemeral CI output, not SSOT: `.github/workflows/ci.yml` appends
+its Markdown view to `GITHUB_STEP_SUMMARY`, while the contracts remain the only
+authored dependency source. Run the same report locally with:
+
+```bash
+apps/backend/.venv/bin/python tools/report_ddd_dependencies.py \
+  --base-ref origin/main \
+  --json-out /tmp/ddd-dependencies.json \
+  --markdown-out /tmp/ddd-dependencies.md
+```
+
+This first plane represents `depends_on` as `compile` edges. Typed ports, event
+subscriptions, delivery/composition bindings, and the frontend L4 graph extend
+the same vocabulary in later #1894 slices; they do not create parallel graphs.
+
 That additive discovery has a blind spot: a directory with no discoverable
 `CONTRACT = PackageContract(...)` export is invisible to
 `check_package_contract`, not rejected — exactly how `common/ci`,
@@ -172,7 +205,8 @@ silently bypassing package governance.
   live example of a project-level shared (meta-model) package — the building-block
   layering it governs, applied to itself. Its
   [`contract.py`](./contract.py) publishes `PackageContract` / `ACRecord` /
-  `Invariant` / `Kind` / `Unit` / `contract_index` / `ac_vision_index`, declares its `units` (the
+  `Invariant` / `Kind` / `Unit` / `DependencyKind` / `DependencyEdge` /
+  `contract_index` / `dependency_index` / `ac_vision_index`, declares its `units` (the
   `PackageContract` aggregate + value objects in `base/`, the gate as a
   `domain-service` in `extension/`, both indexes as projections in
   `data/`), and its invariants + `AC-meta.*` roadmap pin to the governance-gate

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -172,10 +172,12 @@ implementation root and follows eager, chained, wildcard, and the repository's
 bounded lazy `__getattr__` export forms plus local assignment aliases to the
 owning definition. Its signature retains that binding path plus overload
 declarations, annotated values,
-decorators, generic type parameters, resolved named defaults, class construction,
-repository-owned inherited APIs, public protocol dunder methods, and other public
-class members. Wildcard binding obeys the target's `__all__`; missing explicit or
-lazy targets and ambiguous lazy control flow fail closed. Every declared public
+decorators, generic type parameters, local and repository-imported named defaults,
+annotation aliases, class construction, repository-owned inherited APIs, public
+protocol dunder methods, and other public class members. Value bindings are
+fingerprinted at their assignment/import time, so later rebinding cannot rewrite a
+captured default or alias. Wildcard binding obeys the target's `__all__`; missing
+explicit or lazy targets and ambiguous lazy control flow fail closed. Every declared public
 symbol gets exactly one snapshot record, and the repository snapshot is ratcheted
 to zero unresolved dynamic exports; a declaration with no statically visible
 binding is exposed as `dynamic-export` rather than silently matched to an

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -175,10 +175,11 @@ declarations, annotated values,
 decorators, generic type parameters, local and repository-imported named defaults,
 annotation aliases (including `TYPE_CHECKING` declarations), class construction,
 repository-owned inherited APIs, public protocol dunder methods, and other public
-class members. Bare and module-qualified project bindings use the same resolver.
-Value bindings are fingerprinted at their assignment/import time, so later
-rebinding cannot rewrite a captured default or alias. Wildcard binding obeys the
-target's `__all__`; missing
+class members. Referenced project function/class definitions and decorator bindings
+are fingerprinted as well. Bare and module-qualified project bindings use the same
+resolver. Value bindings are fingerprinted at their assignment/import time, so
+later rebinding cannot rewrite a captured default or alias. Wildcard binding obeys
+the target's `__all__`; missing
 explicit or lazy targets and ambiguous lazy control flow fail closed. Every declared public
 symbol gets exactly one snapshot record, and the repository snapshot is ratcheted
 to zero unresolved dynamic exports; a declaration with no statically visible

--- a/common/meta/readme.md
+++ b/common/meta/readme.md
@@ -175,11 +175,12 @@ declarations, annotated values,
 decorators, generic type parameters, local and repository-imported named defaults,
 annotation aliases (including `TYPE_CHECKING` declarations), class construction,
 repository-owned inherited APIs, public protocol dunder methods, and other public
-class members. Referenced project function/class definitions and decorator bindings
-are fingerprinted as well. Bare and module-qualified project bindings use the same
-resolver. Value bindings are fingerprinted at their assignment/import time, so
-later rebinding cannot rewrite a captured default or alias. Wildcard binding obeys
-the target's `__all__`; missing
+class members. Referenced local/imported function/class definitions, class-scope
+values, and decorator bindings are fingerprinted as well. Bare and module-qualified
+project bindings use the same resolver; relative lazy imports retain their explicit
+level. Value bindings are fingerprinted at their assignment/import time, so later
+rebinding cannot rewrite a captured default or alias. Wildcard binding obeys the
+target's `__all__`; missing
 explicit or lazy targets and ambiguous lazy control flow fail closed. Every declared public
 symbol gets exactly one snapshot record, and the repository snapshot is ratcheted
 to zero unresolved dynamic exports; a declaration with no statically visible

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -923,6 +923,49 @@ def test_AC_meta_dependency_governance_2_named_function_defaults_are_reported(
     assert "DEFAULT=10" in change["after"]
 
 
+def test_AC_meta_dependency_governance_2_local_alias_target_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: local aliases retain target signatures."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        def _implementation(value: str) -> str:
+            return value
+
+        Public = _implementation
+
+        def _implementation(value: int) -> int:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish aliased boundary")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        def _implementation(value: str, strict: bool = False) -> str:
+            return value
+
+        Public = _implementation
+
+        def _implementation(value: int) -> int:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "Public"
+    assert change["before"] != change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -9,6 +9,7 @@ import pytest
 
 from common.meta import PackageContract, dependency_index
 from common.meta.extension import check_package_contract as package_gate
+from common.meta.extension import dependency_report
 from common.meta.extension.dependency_report import (
     build_dependency_snapshot,
     build_impact_report,
@@ -200,6 +201,53 @@ def _seed_repo(tmp_path: Path) -> tuple[Path, str]:
     return repo, _git(repo, "rev-parse", "HEAD")
 
 
+def _write_public_types(
+    repo: Path,
+    *,
+    constructor: str,
+    enum_value: str,
+) -> None:
+    impl = "apps/backend/src/provider"
+    _write(
+        repo / "common/provider/contract.py",
+        f"""
+        from common.meta.package_contract import PackageContract
+
+        CONTRACT = PackageContract(
+            name="provider",
+            klass="meta",
+            tier="CODE-ONLY",
+            depends_on=[],
+            interface=["PublicClass", "PublicEnum"],
+            events=[],
+            invariants=[],
+            roadmap=[],
+            implementations={{"be": {impl!r}, "fe": None}},
+        )
+        """,
+    )
+    _write(
+        repo / f"{impl}/__init__.py",
+        (
+            "from .api import PublicClass, PublicEnum\n\n"
+            '__all__ = ["PublicClass", "PublicEnum"]\n'
+        ),
+    )
+    _write(
+        repo / f"{impl}/api.py",
+        f"""
+        from enum import StrEnum
+
+        class PublicClass:
+            def __init__(self, {constructor}) -> None:
+                self.value = value
+
+        class PublicEnum(StrEnum):
+            FIRST = {enum_value!r}
+        """,
+    )
+
+
 def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
     tmp_path: Path,
 ) -> None:
@@ -276,6 +324,102 @@ def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
     )
     with pytest.raises(RuntimeError, match="no readable BE implementation"):
         build_dependency_snapshot(broken)
+
+
+def test_AC_meta_dependency_governance_2_base_snapshot_uses_clean_interpreter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-meta.dependency-governance.2: HEAD imports cannot contaminate base."""
+
+    repo, base_ref = _seed_repo(tmp_path)
+
+    def contaminated_head_snapshot(_repo_root: Path) -> dict[str, object]:
+        raise AssertionError("HEAD interpreter leaked into the base snapshot")
+
+    monkeypatch.setattr(
+        dependency_report,
+        "build_dependency_snapshot",
+        contaminated_head_snapshot,
+    )
+
+    snapshot = dependency_report._snapshot_git_ref(repo, base_ref)
+
+    assert snapshot["direct_consumers"]["provider"] == ["middle"]
+
+
+def test_AC_meta_dependency_governance_2_base_contract_schema_is_not_reinterpreted(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: base facts survive contract-model drift."""
+
+    repo = tmp_path / "legacy-repo"
+    _write(
+        repo / "common/provider/contract.py",
+        """
+        from common.meta.package_contract import PackageContract
+
+        CONTRACT = PackageContract(
+            name="provider",
+            depends_on=[],
+            interface=[],
+            implementations={"be": None, "fe": None},
+        )
+        """,
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dependency-test@example.invalid")
+    _git(repo, "config", "user.name", "Dependency Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "legacy package contract")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+
+    snapshot = dependency_report._snapshot_git_ref(repo, base_ref)
+
+    assert snapshot["edges"] == []
+    assert snapshot["direct_consumers"] == {"provider": []}
+
+
+def test_AC_meta_dependency_governance_2_public_class_constructor_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: constructors are public signatures."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_types(repo, constructor="value: str", enum_value="first")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish public types")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_types(
+        repo,
+        constructor="value: str, strict: bool = False",
+        enum_value="first",
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    changes = {record["symbol"]: record for record in report["changed_public_symbols"]}
+    assert changes["PublicClass"]["before"] != changes["PublicClass"]["after"]
+    assert "strict: bool=False" in changes["PublicClass"]["after"]
+
+
+def test_AC_meta_dependency_governance_2_public_enum_members_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: enum members are public signatures."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_types(repo, constructor="value: str", enum_value="first")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish public types")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_types(repo, constructor="value: str", enum_value="renamed")
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    changes = {record["symbol"]: record for record in report["changed_public_symbols"]}
+    assert "FIRST='first'" in changes["PublicEnum"]["before"]
+    assert "FIRST='renamed'" in changes["PublicEnum"]["after"]
 
 
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import subprocess
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from common.meta import PackageContract, dependency_index
+from common.meta.extension import check_package_contract as package_gate
+from common.meta.extension.dependency_report import (
+    build_dependency_snapshot,
+    build_impact_report,
+)
+from common.meta.extension.check_package_contract import discover_packages
+from tools.report_ddd_dependencies import main
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _contract(
+    name: str,
+    *,
+    klass: str,
+    depends_on: list[str],
+) -> PackageContract:
+    return PackageContract(
+        name=name,
+        klass=klass,  # type: ignore[arg-type]
+        tier="CODE-ONLY",
+        depends_on=depends_on,
+        interface=[],
+        events=[],
+        invariants=[],
+        roadmap=[],
+        implementations={"be": None, "fe": None},
+    )
+
+
+def test_AC_meta_dependency_governance_1_projection_has_typed_edges_and_transitive_consumers() -> (
+    None
+):
+    """AC-meta.dependency-governance.1: one pure graph exposes full consumers."""
+
+    provider = _contract("provider", klass="meta", depends_on=[])
+    middle = _contract("middle", klass="infra", depends_on=["provider"])
+    consumer = _contract("consumer", klass="domain", depends_on=["middle"])
+
+    index = dependency_index([consumer, provider, middle])
+
+    assert index == {
+        "edges": [
+            {
+                "consumer": "consumer",
+                "provider": "middle",
+                "kind": "compile",
+                "detail": "PackageContract.depends_on",
+            },
+            {
+                "consumer": "middle",
+                "provider": "provider",
+                "kind": "compile",
+                "detail": "PackageContract.depends_on",
+            },
+        ],
+        "direct_consumers": {
+            "consumer": [],
+            "middle": ["consumer"],
+            "provider": ["middle"],
+        },
+        "transitive_consumers": {
+            "consumer": [],
+            "middle": ["consumer"],
+            "provider": ["consumer", "middle"],
+        },
+    }
+    assert dependency_index([middle, consumer, provider]) == index
+
+    with pytest.raises(ValueError, match="unknown package"):
+        dependency_index([_contract("broken", klass="domain", depends_on=["missing"])])
+    with pytest.raises(ValueError, match="duplicate package"):
+        dependency_index([provider, provider])
+    with pytest.raises(ValueError, match="duplicate dependency"):
+        dependency_index(
+            [
+                provider,
+                _contract(
+                    "duplicate",
+                    klass="domain",
+                    depends_on=["provider", "provider"],
+                ),
+            ]
+        )
+    with pytest.raises(ValueError, match="cannot depend on itself"):
+        dependency_index([_contract("selfish", klass="domain", depends_on=["selfish"])])
+    with pytest.raises(ValueError, match="dependency cycle"):
+        dependency_index(
+            [
+                _contract("first", klass="infra", depends_on=["second"]),
+                _contract("second", klass="infra", depends_on=["first"]),
+            ]
+        )
+
+
+def test_AC_meta_dependency_governance_1_package_gate_reuses_graph_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-meta.dependency-governance.1: gate/report/projection share one engine."""
+
+    contracts = [
+        _contract("provider", klass="meta", depends_on=[]),
+        _contract("consumer", klass="infra", depends_on=["provider"]),
+    ]
+    discovered = [
+        package_gate.DiscoveredPackage(
+            name=contract.name,
+            spec_dir=ROOT / "common" / contract.name,
+            impl_dir=None,
+            contract=contract,
+        )
+        for contract in contracts
+    ]
+    seen: list[PackageContract] = []
+
+    def build_once(values: list[PackageContract]) -> None:
+        seen.extend(values)
+
+    monkeypatch.setattr(package_gate, "build_dependency_graph", build_once)
+
+    assert package_gate._check_no_dependency_cycle(discovered) == []
+    assert seen == contracts
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", repo.as_posix(), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_package(
+    repo: Path,
+    name: str,
+    *,
+    klass: str,
+    depends_on: list[str],
+    parameters: str = "value: str",
+) -> None:
+    impl = f"apps/backend/src/{name}"
+    _write(
+        repo / f"common/{name}/contract.py",
+        f"""
+        from common.meta.package_contract import PackageContract
+
+        CONTRACT = PackageContract(
+            name={name!r},
+            klass={klass!r},
+            tier="CODE-ONLY",
+            depends_on={depends_on!r},
+            interface=["public"],
+            events=[],
+            invariants=[],
+            roadmap=[],
+            implementations={{"be": {impl!r}, "fe": None}},
+        )
+        """,
+    )
+    _write(
+        repo / f"{impl}/__init__.py",
+        'from .api import public\n\n__all__ = ["public"]\n',
+    )
+    _write(
+        repo / f"{impl}/api.py",
+        f"""
+        def public({parameters}) -> str:
+            return value
+        """,
+    )
+
+
+def _seed_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    _write_package(repo, "provider", klass="meta", depends_on=[])
+    _write_package(repo, "middle", klass="infra", depends_on=["provider"])
+    _write_package(repo, "consumer", klass="domain", depends_on=["middle"])
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "dependency-test@example.invalid")
+    _git(repo, "config", "user.name", "Dependency Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: impact includes indirect consumers."""
+
+    repo, base_ref = _seed_repo(tmp_path)
+    _write_package(
+        repo,
+        "provider",
+        klass="meta",
+        depends_on=[],
+        parameters="value: str, strict: bool = False",
+    )
+    _write_package(
+        repo,
+        "consumer",
+        klass="domain",
+        depends_on=["middle", "provider"],
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    assert report["errors"] == []
+    assert report["added_edges"] == [
+        {
+            "consumer": "consumer",
+            "provider": "provider",
+            "kind": "compile",
+            "detail": "PackageContract.depends_on",
+        }
+    ]
+    assert report["removed_edges"] == []
+    assert report["changed_public_symbols"] == [
+        {
+            "package": "provider",
+            "symbol": "public",
+            "before": "def(value: str) -> str",
+            "after": "def(value: str, strict: bool=False) -> str",
+        }
+    ]
+    assert report["affected_consumers"]["provider"] == {
+        "direct": ["consumer", "middle"],
+        "transitive": ["consumer", "middle"],
+        "indirect": [],
+    }
+    assert report["base"]["transitive_consumers"]["provider"] == [
+        "consumer",
+        "middle",
+    ]
+
+    with pytest.raises(RuntimeError, match="missing-base"):
+        build_impact_report(repo, base_ref="missing-base")
+    with pytest.raises(RuntimeError, match="no package contracts"):
+        build_dependency_snapshot(tmp_path / "empty")
+
+    broken = tmp_path / "broken"
+    _write(
+        broken / "common/broken/contract.py",
+        """
+        from common.meta.package_contract import PackageContract
+
+        CONTRACT = PackageContract(
+            name="broken",
+            klass="domain",
+            tier="CODE-ONLY",
+            depends_on=[],
+            interface=["public"],
+            events=[],
+            invariants=[],
+            roadmap=[],
+            implementations={"be": "apps/backend/src/broken", "fe": None},
+        )
+        """,
+    )
+    with pytest.raises(RuntimeError, match="no readable BE implementation"):
+        build_dependency_snapshot(broken)
+
+
+def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
+    None
+):
+    """AC-meta.dependency-governance.2: the report cannot undercount boundaries."""
+
+    snapshot = build_dependency_snapshot(ROOT)
+    expected = {
+        (package.name, symbol)
+        for package in discover_packages(ROOT)
+        for symbol in package.contract.interface
+    }
+    actual = {
+        (record["package"], record["symbol"]) for record in snapshot["public_symbols"]
+    }
+
+    assert actual == expected
+    assert len(snapshot["public_symbols"]) == len(expected)
+    assert "units_by_layer" not in snapshot
+    assert {edge["kind"] for edge in snapshot["edges"]} == {"compile"}
+
+
+def test_AC_meta_dependency_governance_2_cli_writes_ephemeral_ci_reports(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: CI gets JSON data and a review summary."""
+
+    repo, base_ref = _seed_repo(tmp_path)
+    _write_package(
+        repo,
+        "provider",
+        klass="meta",
+        depends_on=[],
+        parameters="value: str, strict: bool = False",
+    )
+    json_out = tmp_path / "dependency-report.json"
+    markdown_out = tmp_path / "dependency-report.md"
+
+    assert (
+        main(
+            [
+                "--repo-root",
+                str(repo),
+                "--base-ref",
+                base_ref,
+                "--json-out",
+                str(json_out),
+                "--markdown-out",
+                str(markdown_out),
+            ]
+        )
+        == 0
+    )
+    report = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert report["base_ref"] == base_ref
+    assert report["changed_public_symbols"][0]["package"] == "provider"
+    assert "## DDD Dependency Impact" in markdown
+    assert "| Changed public signatures | 1 |" in markdown
+    assert "### Public Boundary Changes" in markdown
+    assert "`def(value: str, strict: bool=False) -> str`" in markdown
+
+
+def test_AC_meta_dependency_governance_2_ci_publishes_dependency_summary() -> None:
+    """AC-meta.dependency-governance.2: the generated report runs in CI."""
+
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "tools/report_ddd_dependencies.py" in workflow
+    assert "DDD-DEPENDENCY-REPORT.md" in workflow
+    assert (
+        'cat "$RUNNER_TEMP/DDD-DEPENDENCY-REPORT.md" >> "$GITHUB_STEP_SUMMARY"'
+        in workflow
+    )

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -207,6 +207,28 @@ def _write_public_types(
     constructor: str,
     enum_value: str,
 ) -> None:
+    _write_public_surface(
+        repo,
+        interface=["PublicClass", "PublicEnum"],
+        source=f"""
+        from enum import StrEnum
+
+        class PublicClass:
+            def __init__(self, {constructor}) -> None:
+                self.value = value
+
+        class PublicEnum(StrEnum):
+            FIRST = {enum_value!r}
+        """,
+    )
+
+
+def _write_public_surface(
+    repo: Path,
+    *,
+    interface: list[str],
+    source: str,
+) -> None:
     impl = "apps/backend/src/provider"
     _write(
         repo / "common/provider/contract.py",
@@ -218,7 +240,7 @@ def _write_public_types(
             klass="meta",
             tier="CODE-ONLY",
             depends_on=[],
-            interface=["PublicClass", "PublicEnum"],
+            interface={interface!r},
             events=[],
             invariants=[],
             roadmap=[],
@@ -228,24 +250,9 @@ def _write_public_types(
     )
     _write(
         repo / f"{impl}/__init__.py",
-        (
-            "from .api import PublicClass, PublicEnum\n\n"
-            '__all__ = ["PublicClass", "PublicEnum"]\n'
-        ),
+        (f"from .api import {', '.join(interface)}\n\n__all__ = {interface!r}\n"),
     )
-    _write(
-        repo / f"{impl}/api.py",
-        f"""
-        from enum import StrEnum
-
-        class PublicClass:
-            def __init__(self, {constructor}) -> None:
-                self.value = value
-
-        class PublicEnum(StrEnum):
-            FIRST = {enum_value!r}
-        """,
-    )
+    _write(repo / f"{impl}/api.py", source)
 
 
 def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
@@ -420,6 +427,123 @@ def test_AC_meta_dependency_governance_2_public_enum_members_are_reported(
     changes = {record["symbol"]: record for record in report["changed_public_symbols"]}
     assert "FIRST='first'" in changes["PublicEnum"]["before"]
     assert "FIRST='renamed'" in changes["PublicEnum"]["after"]
+
+
+def test_AC_meta_dependency_governance_2_annotated_defaults_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: annotated defaults are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["PUBLIC_CONTRACT", "PublicConfig"],
+        source="""
+        class PublicConfig:
+            max_requests: int = 5
+
+        PUBLIC_CONTRACT: dict[str, int] = {"version": 1}
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish annotated defaults")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["PUBLIC_CONTRACT", "PublicConfig"],
+        source="""
+        class PublicConfig:
+            max_requests: int = 10
+
+        PUBLIC_CONTRACT: dict[str, int] = {"version": 2}
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    changes = {record["symbol"]: record for record in report["changed_public_symbols"]}
+    assert "max_requests: int=5" in changes["PublicConfig"]["before"]
+    assert "max_requests: int=10" in changes["PublicConfig"]["after"]
+    assert "{'version': 1}" in changes["PUBLIC_CONTRACT"]["before"]
+    assert "{'version': 2}" in changes["PUBLIC_CONTRACT"]["after"]
+
+
+def test_AC_meta_dependency_governance_2_method_decorators_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: method binding style is boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["PublicService"],
+        source="""
+        class PublicService:
+            @property
+            def value(self) -> str:
+                return "value"
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish decorated method")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["PublicService"],
+        source="""
+        class PublicService:
+            def value(self) -> str:
+                return "value"
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "PublicService"
+    assert "@property" in change["before"]
+    assert "@property" not in change["after"]
+
+
+def test_AC_meta_dependency_governance_2_generic_parameters_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: PEP 695 bounds are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["PublicGeneric", "public"],
+        source="""
+        class PublicGeneric[T]:
+            def __new__(cls, value: T) -> "PublicGeneric[T]":
+                return super().__new__(cls)
+
+        def public[T](value: T) -> T:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish generic boundaries")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["PublicGeneric", "public"],
+        source="""
+        class PublicGeneric[T: str]:
+            def __new__(cls, value: T) -> "PublicGeneric[T]":
+                return super().__new__(cls)
+
+        def public[T: str](value: T) -> T:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    changes = {record["symbol"]: record for record in report["changed_public_symbols"]}
+    assert "T: str" in changes["PublicGeneric"]["after"]
+    assert "T: str" in changes["public"]["after"]
 
 
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -1320,6 +1320,154 @@ def test_AC_meta_dependency_governance_2_imported_decorator_is_reported(
     assert change["before"] != change["after"]
 
 
+def test_AC_meta_dependency_governance_2_local_definition_default_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: local definitions are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        def callback(value: str) -> str:
+            return value
+
+        def public(fn=callback):
+            return fn
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish local definition default")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        def callback(value: str, strict: bool = False) -> str:
+            return value
+
+        def public(fn=callback):
+            return fn
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_class_local_default_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: class-scope bindings are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        class Public:
+            _DEFAULT = 1
+
+            def method(self, value: int = _DEFAULT) -> int:
+                return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish class-local default")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        class Public:
+            _DEFAULT = 2
+
+            def method(self, value: int = _DEFAULT) -> int:
+                return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "Public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_relative_lazy_import_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: lazy imports preserve relative levels."""
+
+    repo, _ = _seed_repo(tmp_path)
+    impl = "apps/backend/src/provider/lazy"
+    _write(
+        repo / "common/provider/contract.py",
+        f"""
+        from common.meta.package_contract import PackageContract
+
+        CONTRACT = PackageContract(
+            name="provider",
+            klass="meta",
+            tier="CODE-ONLY",
+            depends_on=[],
+            interface=["public"],
+            events=[],
+            invariants=[],
+            roadmap=[],
+            implementations={{"be": {impl!r}, "fe": None}},
+        )
+        """,
+    )
+    _write(
+        repo / f"{impl}/__init__.py",
+        """
+        __all__ = ["public"]
+
+        def __getattr__(name: str) -> object:
+            if name == "public":
+                from ..api import public
+                return public
+            raise AttributeError(name)
+        """,
+    )
+    _write(
+        repo / f"{impl}/api.py",
+        """
+        def public(value: int) -> int:
+            return value
+        """,
+    )
+    parent_api = repo / "apps/backend/src/provider/api.py"
+    _write(
+        parent_api,
+        """
+        def public(value: str) -> str:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish relative lazy import")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        parent_api,
+        """
+        def public(value: str, strict: bool = False) -> str:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -1236,6 +1236,90 @@ def test_AC_meta_dependency_governance_2_qualified_assignment_alias_is_reported(
     assert change["before"] != change["after"]
 
 
+def test_AC_meta_dependency_governance_2_imported_definitions_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: imported definitions are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public_callback", "public_type"],
+        source="""
+        from .types import Input, callback
+
+        def public_type(value: Input) -> Input:
+            return value
+
+        def public_callback(fn=callback):
+            return fn
+        """,
+    )
+    definitions = repo / "apps/backend/src/provider/types.py"
+    _write(
+        definitions,
+        """
+        class Input:
+            value: str
+
+        def callback(value: str) -> str:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish imported definitions")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        definitions,
+        """
+        class Input:
+            value: int
+
+        def callback(value: str, strict: bool = False) -> str:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    assert {change["symbol"] for change in report["changed_public_symbols"]} == {
+        "public_callback",
+        "public_type",
+    }
+
+
+def test_AC_meta_dependency_governance_2_imported_decorator_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: decorator bindings are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        from .decorators import PUBLIC_BINDING
+
+        class Public:
+            @PUBLIC_BINDING
+            def value(self) -> str:
+                return "value"
+        """,
+    )
+    decorators = repo / "apps/backend/src/provider/decorators.py"
+    _write(decorators, "PUBLIC_BINDING = property\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish imported decorator")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(decorators, "PUBLIC_BINDING = cached_property\n")
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "Public"
+    assert change["before"] != change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -811,6 +811,118 @@ def test_AC_meta_dependency_governance_2_lazy_root_binding_is_reported(
     assert "def(value: str) -> str" in record["signature"]
 
 
+def test_AC_meta_dependency_governance_2_unknown_lazy_branch_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: ambiguous lazy exports fail closed."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write(
+        repo / "apps/backend/src/provider/alternate.py",
+        """
+        def public(value: int) -> int:
+            return value
+        """,
+    )
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        """
+        from importlib import import_module
+
+        FLAG = object()
+        __all__ = ["public"]
+
+        def __getattr__(name: str) -> object:
+            if FLAG:
+                return getattr(import_module("src.provider.alternate"), name)
+            return getattr(import_module("src.provider.api"), name)
+        """,
+    )
+
+    with pytest.raises(RuntimeError, match="ambiguous lazy export 'public'"):
+        build_dependency_snapshot(repo)
+
+
+def test_AC_meta_dependency_governance_2_inherited_class_api_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: inherited APIs are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["PublicClass"],
+        source="""
+        class Base:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+        class PublicClass(Base):
+            pass
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish inherited boundary")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["PublicClass"],
+        source="""
+        class Base:
+            def __init__(self, value: str, strict: bool = False) -> None:
+                self.value = value
+
+        class PublicClass(Base):
+            pass
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "PublicClass"
+    assert "inherits[Base]" in change["before"]
+    assert "strict: bool=False" in change["after"]
+
+
+def test_AC_meta_dependency_governance_2_named_function_defaults_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: resolved defaults are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        DEFAULT = 5
+
+        def public(value: int = DEFAULT) -> int:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish named default")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        DEFAULT = 10
+
+        def public(value: int = DEFAULT) -> int:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert "DEFAULT=5" in change["before"]
+    assert "DEFAULT=10" in change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -1080,6 +1080,162 @@ def test_AC_meta_dependency_governance_2_default_uses_assignment_time_value(
     assert change["before"] != change["after"]
 
 
+def test_AC_meta_dependency_governance_2_type_checking_alias_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: type-checking aliases are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            _Input = int | str
+
+        def public(value: _Input) -> _Input:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish type-checking alias")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            _Input = int | str | bytes
+
+        def public(value: _Input) -> _Input:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_qualified_import_defaults_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: qualified defaults resolve modules."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public_from", "public_import"],
+        source="""
+        import src.provider.constants as imported_constants
+        from . import constants
+
+        def public_from(value: int = constants.DEFAULT) -> int:
+            return value
+
+        def public_import(value: int = imported_constants.DEFAULT) -> int:
+            return value
+        """,
+    )
+    constants = repo / "apps/backend/src/provider/constants.py"
+    _write(constants, "DEFAULT = 5\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish qualified defaults")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(constants, "DEFAULT = 10\n")
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    assert {change["symbol"] for change in report["changed_public_symbols"]} == {
+        "public_from",
+        "public_import",
+    }
+
+
+def test_AC_meta_dependency_governance_2_qualified_base_api_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: qualified inherited APIs are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        from . import base
+
+        class Public(base.Base):
+            pass
+        """,
+    )
+    base_source = repo / "apps/backend/src/provider/base.py"
+    _write(
+        base_source,
+        """
+        class Base:
+            def __init__(self, value: str) -> None:
+                self.value = value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish qualified base")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        base_source,
+        """
+        class Base:
+            def __init__(self, value: str, strict: bool = False) -> None:
+                self.value = value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "Public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_qualified_assignment_alias_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: qualified aliases retain targets."""
+
+    repo, _ = _seed_repo(tmp_path)
+    root = repo / "apps/backend/src/provider/__init__.py"
+    _write(
+        root,
+        """
+        from . import api
+
+        public = api.public
+        __all__ = ["public"]
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish qualified alias")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        repo / "apps/backend/src/provider/api.py",
+        """
+        def public(value: str, strict: bool = False) -> str:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -333,6 +333,32 @@ def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
         build_dependency_snapshot(broken)
 
 
+def test_AC_meta_dependency_governance_2_edge_change_includes_upstream_providers(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: topology fan-out reaches upstream."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_package(repo, "consumer", klass="domain", depends_on=[])
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "detach downstream consumer")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_package(repo, "consumer", klass="domain", depends_on=["middle"])
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    assert report["affected_consumers"]["middle"] == {
+        "direct": ["consumer"],
+        "transitive": ["consumer"],
+        "indirect": [],
+    }
+    assert report["affected_consumers"]["provider"] == {
+        "direct": ["middle"],
+        "transitive": ["consumer", "middle"],
+        "indirect": ["consumer"],
+    }
+
+
 def test_AC_meta_dependency_governance_2_base_snapshot_uses_clean_interpreter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -621,6 +621,115 @@ def test_AC_meta_dependency_governance_2_root_export_binding_is_reported(
     assert change["after"] == "dynamic-export"
 
 
+def test_AC_meta_dependency_governance_2_unresolved_reexport_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: broken explicit exports fail closed."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        'from .missing import public\n\n__all__ = ["public"]\n',
+    )
+
+    with pytest.raises(RuntimeError, match="cannot resolve export 'public'"):
+        build_dependency_snapshot(repo)
+
+
+def test_AC_meta_dependency_governance_2_overloads_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: overloads are public signatures."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        from typing import Any, overload
+
+        @overload
+        def public(value: str) -> str: ...
+
+        @overload
+        def public(value: None) -> None: ...
+
+        def public(value: Any) -> Any:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish overloaded boundary")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        from typing import Any, overload
+
+        @overload
+        def public(value: str, strict: bool = False) -> str: ...
+
+        @overload
+        def public(value: None) -> None: ...
+
+        def public(value: Any) -> Any:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert "@overload def(value: str) -> str" in change["before"]
+    assert "@overload def(value: str, strict: bool=False) -> str" in change["after"]
+    assert "def(value: Any) -> Any" in change["before"]
+    assert "def(value: Any) -> Any" in change["after"]
+
+
+def test_AC_meta_dependency_governance_2_wildcard_honors_target_all(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: wildcard bindings obey target __all__."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write(
+        repo / "apps/backend/src/provider/alternate.py",
+        """
+        def public(value: int) -> int:
+            return value
+
+        __all__: list[str] = []
+        """,
+    )
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        """
+        from .api import public
+        from .alternate import *
+
+        __all__ = ["public"]
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish guarded wildcard")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        repo / "apps/backend/src/provider/api.py",
+        """
+        def public(value: str, strict: bool = False) -> str:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert ".api.public" in change["before"]
+    assert ".api.public" in change["after"]
+    assert "strict: bool=False" in change["after"]
+
+
 def test_AC_meta_dependency_governance_2_protocol_methods_are_reported(
     tmp_path: Path,
 ) -> None:

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -966,6 +966,120 @@ def test_AC_meta_dependency_governance_2_local_alias_target_is_reported(
     assert change["before"] != change["after"]
 
 
+def test_AC_meta_dependency_governance_2_imported_default_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: imported defaults are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        from .constants import DEFAULT
+
+        def public(value: int = DEFAULT) -> int:
+            return value
+        """,
+    )
+    constants = repo / "apps/backend/src/provider/constants.py"
+    _write(constants, "DEFAULT = 5\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish imported default")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(constants, "DEFAULT = 10\n")
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_annotation_alias_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: annotation aliases are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        _Input = int | str
+
+        class Public:
+            value: _Input
+
+            def transform(self, value: _Input) -> _Input:
+                return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish annotation alias")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["Public"],
+        source="""
+        _Input = int | str | bytes
+
+        class Public:
+            value: _Input
+
+            def transform(self, value: _Input) -> _Input:
+                return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "Public"
+    assert change["before"] != change["after"]
+
+
+def test_AC_meta_dependency_governance_2_default_uses_assignment_time_value(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: defaults retain captured value bindings."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        A = 1
+        B = A
+        A = 2
+
+        def public(value: int = B) -> int:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish captured default")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["public"],
+        source="""
+        A = 2
+        B = A
+        A = 2
+
+        def public(value: int = B) -> int:
+            return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert change["before"] != change["after"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):

--- a/tests/tooling/test_ddd_dependency_report.py
+++ b/tests/tooling/test_ddd_dependency_report.py
@@ -291,8 +291,14 @@ def test_AC_meta_dependency_governance_2_impact_includes_indirect_consumers(
         {
             "package": "provider",
             "symbol": "public",
-            "before": "def(value: str) -> str",
-            "after": "def(value: str, strict: bool=False) -> str",
+            "before": (
+                ".api.public -> apps/backend/src/provider/api.py::public "
+                "=> def(value: str) -> str"
+            ),
+            "after": (
+                ".api.public -> apps/backend/src/provider/api.py::public "
+                "=> def(value: str, strict: bool=False) -> str"
+            ),
         }
     ]
     assert report["affected_consumers"]["provider"] == {
@@ -572,6 +578,130 @@ def test_AC_meta_dependency_governance_2_generic_parameters_are_reported(
     assert "T: str" in changes["public"]["after"]
 
 
+def test_AC_meta_dependency_governance_2_root_export_binding_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: root export targets are boundary data."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write(
+        repo / "apps/backend/src/provider/alternate.py",
+        """
+        def public(value: str) -> str:
+            return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish alternate implementation")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        'from .alternate import public\n\n__all__ = ["public"]\n',
+    )
+
+    switched = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = switched["changed_public_symbols"]
+    assert change["symbol"] == "public"
+    assert ".api.public" in change["before"]
+    assert ".alternate.public" in change["after"]
+
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "switch public implementation")
+    switched_ref = _git(repo, "rev-parse", "HEAD")
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        '__all__ = ["public"]\n',
+    )
+
+    removed = build_impact_report(repo, base_ref=switched_ref)
+
+    [change] = removed["changed_public_symbols"]
+    assert ".alternate.public" in change["before"]
+    assert change["after"] == "dynamic-export"
+
+
+def test_AC_meta_dependency_governance_2_protocol_methods_are_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: public protocols include dunder methods."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write_public_surface(
+        repo,
+        interface=["PublicCollection"],
+        source="""
+        from collections.abc import Iterator
+
+        class PublicCollection:
+            def __iter__(self) -> Iterator[str]:
+                return iter(())
+
+            def _normalize(self, value: str) -> str:
+                return value
+        """,
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "publish iterable boundary")
+    base_ref = _git(repo, "rev-parse", "HEAD")
+    _write_public_surface(
+        repo,
+        interface=["PublicCollection"],
+        source="""
+        from collections.abc import Iterator
+
+        class PublicCollection:
+            def __iter__(self) -> Iterator[int]:
+                return iter(())
+
+            def _normalize(self, value: object) -> object:
+                return value
+        """,
+    )
+
+    report = build_impact_report(repo, base_ref=base_ref)
+
+    [change] = report["changed_public_symbols"]
+    assert "__iter__(self) -> Iterator[str]" in change["before"]
+    assert "__iter__(self) -> Iterator[int]" in change["after"]
+    assert "_normalize" not in change["before"]
+    assert "_normalize" not in change["after"]
+
+
+def test_AC_meta_dependency_governance_2_lazy_root_binding_is_reported(
+    tmp_path: Path,
+) -> None:
+    """AC-meta.dependency-governance.2: lazy root exports retain their targets."""
+
+    repo, _ = _seed_repo(tmp_path)
+    _write(
+        repo / "apps/backend/src/provider/__init__.py",
+        """
+        from importlib import import_module
+
+        _EXPORTS = {"public": "src.provider.api"}
+        __all__ = ["public"]
+
+        def __getattr__(name: str) -> object:
+            module = _EXPORTS.get(name)
+            if module is None:
+                raise AttributeError(name)
+            return getattr(import_module(module), name)
+        """,
+    )
+
+    snapshot = build_dependency_snapshot(repo)
+
+    record = next(
+        record
+        for record in snapshot["public_symbols"]
+        if record["package"] == "provider" and record["symbol"] == "public"
+    )
+    assert record["resolution"] == "reexport"
+    assert "lazy:src.provider.api.public" in record["signature"]
+    assert "def(value: str) -> str" in record["signature"]
+
+
 def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symbol() -> (
     None
 ):
@@ -589,6 +719,11 @@ def test_AC_meta_dependency_governance_2_snapshot_accounts_for_every_public_symb
 
     assert actual == expected
     assert len(snapshot["public_symbols"]) == len(expected)
+    assert not [
+        record
+        for record in snapshot["public_symbols"]
+        if record["resolution"] == "dynamic"
+    ]
     assert "units_by_layer" not in snapshot
     assert {edge["kind"] for edge in snapshot["edges"]} == {"compile"}
 
@@ -632,7 +767,8 @@ def test_AC_meta_dependency_governance_2_cli_writes_ephemeral_ci_reports(
     assert "## DDD Dependency Impact" in markdown
     assert "| Changed public signatures | 1 |" in markdown
     assert "### Public Boundary Changes" in markdown
-    assert "`def(value: str, strict: bool=False) -> str`" in markdown
+    assert ".api.public" in markdown
+    assert "def(value: str, strict: bool=False) -> str" in markdown
 
 
 def test_AC_meta_dependency_governance_2_ci_publishes_dependency_summary() -> None:

--- a/tools/report_ddd_dependencies.py
+++ b/tools/report_ddd_dependencies.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Command wrapper for the generated DDD dependency impact report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from common.meta.extension.dependency_report import main  # noqa: E402
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the meta-owned typed compile dependency vocabulary and one pure graph engine shared by the package gate and data projection
- generate ref-isolated base-vs-HEAD JSON/Markdown reports for dependency edges, root-resolved public boundaries, and direct/transitive consumers
- publish the ephemeral report in the CI step summary and fail closed on invalid topology, unreadable refs, empty discovery, broken or ambiguous exports, or unreadable implementations

## Scope
This is PR-A for #1894. It establishes the computed dependency/impact plane only. Typed ports/events/composition bindings, ORM export removal, deep-import and base-purity debt, unit bindings, backend delivery nodes, and the frontend graph remain follow-up slices of #1894.

## Acceptance
- `AC-meta.dependency-governance.1`: deterministic typed graph, reverse/transitive consumers, shared topology policy, and duplicate/unknown/self/cycle rejection
- `AC-meta.dependency-governance.2`: import-isolated base comparison and historical compatibility; package-root resolution including eager/wildcard/bounded-lazy exports, relative levels, local/qualified assignment aliases, and `TYPE_CHECKING`; assignment-time fingerprints across module and class scopes for local/imported defaults, annotations, project definitions, decorators, inherited APIs, overloads, constructors, enum and annotated values, generic parameters, and protocol dunder methods; full consumer fan-out, zero unresolved current symbols, fail-closed behavior, CLI output, and CI summary wiring

## Review Fix Proof
- Root cause: the initial bounded AST interpreter treated some uncertain branches and local/module/class bindings as terminal syntax rather than preserving the runtime or typing binding captured by the public API.
- Why gates missed it: the original matrix covered direct declarations and supported re-exports but lacked adversarial lazy flow, relative imports, inherited APIs, scoped/module aliases, imported/captured defaults, annotation aliases, decorators, imported/local definitions, class bindings, and `TYPE_CHECKING`.
- Proof added: failing-first `AC-meta.dependency-governance.2` regressions now lock those cases. One lazy immutable binding environment resolves only referenced project bindings, preserves scope/assignment time, handles qualified attributes, and guards definition cycles without importing implementations.

## Verification
- `apps/backend/.venv/bin/python tools/preflight.py --tier=full` (2254 passed; all relevant gates passed)
- `apps/backend/.venv/bin/python tools/preflight.py --tier=static` (passed immediately before push)
- `moon run :lint` (passed)
- related governance tests: 89 passed; dependency graph coverage 100%, dependency report coverage 91%
- real `origin/main` comparison: 625 public symbols, 0 dynamic resolutions, 0 errors, 15.08 seconds
- `moon run :test` was attempted earlier: 2601 passed; one live MinIO endpoint failure and 503 cascading setup errors occurred while the local PostgreSQL container logged `Consistent recovery state has not been yet reached`; isolated GitHub CI remains the authoritative full-suite run

Part of #1894
Parent: #1863