### PR TITLE
[finance-report-1681-source-contributions] Publish decision-backed statement contributions

### DIFF
--- a/apps/backend/src/extraction/__init__.py
+++ b/apps/backend/src/extraction/__init__.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 # monkeypatch its functions (``validation.validate_balance = …``) and need one
 # canonical module object to patch.
 from src.extraction.base import validation
+from src.extraction.base.contribution import ResolvedStatementContribution
 from src.extraction.base.disposition import (
     DispositionCommand,
     DispositionContext,
@@ -145,6 +146,10 @@ from src.extraction.extension.reviewed_statement_envelope import (
     persist_statement_extraction_result,
 )
 from src.extraction.extension.service import ExtractionError, ExtractionService
+from src.extraction.extension.statement_contribution import (
+    list_statement_contributions,
+    resolve_statement_contribution,
+)
 from src.extraction.extension.statement_parsing import (
     StatementIngestionUseCase,
     build_statement_ingestion_use_case,
@@ -269,6 +274,7 @@ __all__ = [
     "RetryableStatementIngestionError",
     "ReviewedStatementEnvelopeCommand",
     "ReviewedStatementEnvelopeConflict",
+    "ResolvedStatementContribution",
     "RuleType",
     "SourceCapability",
     "SOURCE_CAPABILITIES",
@@ -330,6 +336,8 @@ __all__ = [
     "pending_stage1_review_filter",
     "persist_statement_extraction_result",
     "record_correction",
+    "resolve_statement_contribution",
+    "list_statement_contributions",
     "register_fx_rate_provider",
     "register_position_reconciler",
     "reject_statement_workflow",

--- a/apps/backend/src/extraction/base/__init__.py
+++ b/apps/backend/src/extraction/base/__init__.py
@@ -7,6 +7,7 @@ No ORM, no network, no LLM — the extension pipeline calls DOWN into these.
 
 from __future__ import annotations
 
+from src.extraction.base.contribution import ResolvedStatementContribution
 from src.extraction.base.disposition import (
     DispositionCommand,
     DispositionContext,
@@ -63,6 +64,7 @@ __all__ = [
     "IntentProposalOrigin",
     "ParseJob",
     "RetryableStatementIngestionError",
+    "ResolvedStatementContribution",
     "ReviewedStatementEnvelopeCommand",
     "SourceCapability",
     "SOURCE_CAPABILITIES",

--- a/apps/backend/src/extraction/base/contribution.py
+++ b/apps/backend/src/extraction/base/contribution.py
@@ -28,6 +28,7 @@ class ResolvedStatementContribution:
     state: Literal["authoritative", "unproven"]
     reason_code: str | None
     decision_id: UUID | None
+    source_document_id: UUID | None = None
 
     def __post_init__(self) -> None:
         if self.state == "authoritative" and (
@@ -38,6 +39,8 @@ class ResolvedStatementContribution:
             or self.effective_period_end is None
         ):
             raise ValueError("an authoritative statement contribution requires source identity and decision")
+        if self.state == "authoritative" and self.reason_code is not None:
+            raise ValueError("an authoritative statement contribution cannot have a reason_code")
         if (
             self.effective_period_start is not None
             and self.effective_period_end is not None
@@ -46,6 +49,8 @@ class ResolvedStatementContribution:
             raise ValueError("effective statement period is invalid")
         if self.state == "unproven" and not self.reason_code:
             raise ValueError("an unproven statement contribution requires a reason_code")
+        if self.state == "unproven" and self.decision_id is not None:
+            raise ValueError("an unproven statement contribution cannot have a decision_id")
 
     @property
     def is_authoritative(self) -> bool:
@@ -55,4 +60,7 @@ class ResolvedStatementContribution:
     def input_refs(self) -> tuple[str, ...]:
         if self.source_result_id is None:
             return ()
-        return (f"statement_result:{self.source_result_id}",)
+        refs = [f"statement_result:{self.source_result_id}"]
+        if self.source_document_id is not None:
+            refs.append(f"source_document:{self.source_document_id}")
+        return tuple(refs)

--- a/apps/backend/src/extraction/base/contribution.py
+++ b/apps/backend/src/extraction/base/contribution.py
@@ -1,0 +1,58 @@
+"""Pure statement-source contribution language for package consumers (#1681)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+from uuid import UUID
+
+from src.extraction.base.result import StatementExtractionResult
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedStatementContribution:
+    """One current immutable source result and its exact authority decision.
+
+    Consumers may render or freeze ``source_result`` but may not use its
+    provenance, confidence, source type, or timestamps as an authority signal.
+    ``state`` is determined solely by the current target-matching TraceRecord
+    decision resolved by extraction's extension boundary.
+    """
+
+    statement_id: UUID
+    source_result_id: UUID | None
+    source_result: StatementExtractionResult | None
+    effective_period_start: date | None
+    effective_period_end: date | None
+    state: Literal["authoritative", "unproven"]
+    reason_code: str | None
+    decision_id: UUID | None
+
+    def __post_init__(self) -> None:
+        if self.state == "authoritative" and (
+            self.source_result_id is None
+            or self.source_result is None
+            or self.decision_id is None
+            or self.effective_period_start is None
+            or self.effective_period_end is None
+        ):
+            raise ValueError("an authoritative statement contribution requires source identity and decision")
+        if (
+            self.effective_period_start is not None
+            and self.effective_period_end is not None
+            and self.effective_period_start > self.effective_period_end
+        ):
+            raise ValueError("effective statement period is invalid")
+        if self.state == "unproven" and not self.reason_code:
+            raise ValueError("an unproven statement contribution requires a reason_code")
+
+    @property
+    def is_authoritative(self) -> bool:
+        return self.state == "authoritative"
+
+    @property
+    def input_refs(self) -> tuple[str, ...]:
+        if self.source_result_id is None:
+            return ()
+        return (f"statement_result:{self.source_result_id}",)

--- a/apps/backend/src/extraction/extension/statement_contribution.py
+++ b/apps/backend/src/extraction/extension/statement_contribution.py
@@ -28,6 +28,7 @@ def _unproven(
     source_result: StatementExtractionResult | None = None,
     effective_period_start: date | None = None,
     effective_period_end: date | None = None,
+    source_document_id: UUID | None = None,
 ) -> ResolvedStatementContribution:
     return ResolvedStatementContribution(
         statement_id=statement_id,
@@ -38,6 +39,7 @@ def _unproven(
         state="unproven",
         reason_code=reason_code,
         decision_id=None,
+        source_document_id=source_document_id,
     )
 
 
@@ -58,18 +60,27 @@ async def resolve_statement_contribution(
     if statement is None or statement.user_id != user_id:
         return _unproven(statement_id=statement_id, reason_code="missing_statement")
     if statement.current_extraction_result_id is None:
-        return _unproven(statement_id=statement.id, reason_code="missing_current_source_result")
+        return _unproven(
+            statement_id=statement.id,
+            reason_code="missing_current_source_result",
+            source_document_id=statement.uploaded_document_id,
+        )
 
     source_record = await db.get(StatementExtractionResultRecord, statement.current_extraction_result_id)
     if source_record is None or source_record.user_id != user_id or source_record.statement_id != statement.id:
-        return _unproven(statement_id=statement.id, reason_code="missing_current_source_result")
+        return _unproven(
+            statement_id=statement.id,
+            reason_code="missing_current_source_result",
+            source_document_id=statement.uploaded_document_id,
+        )
     try:
         source_result = StatementExtractionResult.from_payload(source_record.payload)
-    except (TypeError, ValueError):
+    except (KeyError, TypeError, ValueError):
         return _unproven(
             statement_id=statement.id,
             source_result_id=source_record.id,
             reason_code="invalid_current_source_result",
+            source_document_id=statement.uploaded_document_id,
         )
     if source_result.content_digest != source_record.content_digest:
         return _unproven(
@@ -79,6 +90,7 @@ async def resolve_statement_contribution(
             effective_period_start=source_result.period_start,
             effective_period_end=source_result.period_end,
             reason_code="source_result_digest_mismatch",
+            source_document_id=statement.uploaded_document_id,
         )
 
     repository = SqlTraceRecordRepository(db, extraction_trace_policy_registry())
@@ -95,6 +107,7 @@ async def resolve_statement_contribution(
                 effective_period_start=source_result.period_start,
                 effective_period_end=source_result.period_end,
                 reason_code="missing_reviewed_envelope",
+                source_document_id=statement.uploaded_document_id,
             )
         target = VersionedTraceRef(
             kind="reviewed_statement_envelope",
@@ -123,6 +136,7 @@ async def resolve_statement_contribution(
             effective_period_start=source_result.period_start,
             effective_period_end=source_result.period_end,
             reason_code="missing_current_decision",
+            source_document_id=statement.uploaded_document_id,
         )
     if decision.target != target or (expected_decision_id is not None and decision.record_id != expected_decision_id):
         return _unproven(
@@ -132,6 +146,7 @@ async def resolve_statement_contribution(
             effective_period_start=source_result.period_start,
             effective_period_end=source_result.period_end,
             reason_code="target_mismatched_decision",
+            source_document_id=statement.uploaded_document_id,
         )
     if decision.result is not TraceResult.AUTHORITATIVE:
         return _unproven(
@@ -141,6 +156,7 @@ async def resolve_statement_contribution(
             effective_period_start=source_result.period_start,
             effective_period_end=source_result.period_end,
             reason_code="non_authoritative_decision",
+            source_document_id=statement.uploaded_document_id,
         )
     return ResolvedStatementContribution(
         statement_id=statement.id,
@@ -151,6 +167,7 @@ async def resolve_statement_contribution(
         state="authoritative",
         reason_code=None,
         decision_id=decision.record_id,
+        source_document_id=statement.uploaded_document_id,
     )
 
 

--- a/apps/backend/src/extraction/extension/statement_contribution.py
+++ b/apps/backend/src/extraction/extension/statement_contribution.py
@@ -1,0 +1,184 @@
+"""Resolve immutable statement source facts into package-facing contributions."""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.audit import SqlTraceRecordRepository, TraceLineage, TraceResult, TraceScope, VersionedTraceRef
+from src.extraction.base.contribution import ResolvedStatementContribution
+from src.extraction.base.result import StatementExtractionResult
+from src.extraction.extension.extraction_trace import ExtractionPromotionTracePolicy, extraction_trace_policy_registry
+from src.extraction.extension.reviewed_statement_envelope import (
+    ReviewedEnvelopeDecisionTracePolicy,
+    current_reviewed_statement_envelope,
+)
+from src.extraction.orm.reviewed_statement_envelope import StatementExtractionResultRecord
+from src.extraction.orm.statement_summary import StatementSummary
+
+
+def _unproven(
+    *,
+    statement_id: UUID,
+    reason_code: str,
+    source_result_id: UUID | None = None,
+    source_result: StatementExtractionResult | None = None,
+    effective_period_start: date | None = None,
+    effective_period_end: date | None = None,
+) -> ResolvedStatementContribution:
+    return ResolvedStatementContribution(
+        statement_id=statement_id,
+        source_result_id=source_result_id,
+        source_result=source_result,
+        effective_period_start=effective_period_start,
+        effective_period_end=effective_period_end,
+        state="unproven",
+        reason_code=reason_code,
+        decision_id=None,
+    )
+
+
+async def resolve_statement_contribution(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    statement_id: UUID,
+) -> ResolvedStatementContribution:
+    """Resolve exactly one current statement source result, never a projection.
+
+    A complete result requires its current extraction-promotion decision. A
+    source which requires review instead requires its current reviewed-envelope
+    decision. Both checks pin the target version, so a reparse or decision
+    supersession cannot authorize an older source payload.
+    """
+    statement = await db.get(StatementSummary, statement_id)
+    if statement is None or statement.user_id != user_id:
+        return _unproven(statement_id=statement_id, reason_code="missing_statement")
+    if statement.current_extraction_result_id is None:
+        return _unproven(statement_id=statement.id, reason_code="missing_current_source_result")
+
+    source_record = await db.get(StatementExtractionResultRecord, statement.current_extraction_result_id)
+    if source_record is None or source_record.user_id != user_id or source_record.statement_id != statement.id:
+        return _unproven(statement_id=statement.id, reason_code="missing_current_source_result")
+    try:
+        source_result = StatementExtractionResult.from_payload(source_record.payload)
+    except (TypeError, ValueError):
+        return _unproven(
+            statement_id=statement.id,
+            source_result_id=source_record.id,
+            reason_code="invalid_current_source_result",
+        )
+    if source_result.content_digest != source_record.content_digest:
+        return _unproven(
+            statement_id=statement.id,
+            source_result_id=source_record.id,
+            source_result=source_result,
+            effective_period_start=source_result.period_start,
+            effective_period_end=source_result.period_end,
+            reason_code="source_result_digest_mismatch",
+        )
+
+    repository = SqlTraceRecordRepository(db, extraction_trace_policy_registry())
+    scope = TraceScope.tenant(user_id)
+    effective_period_start: date | None = source_result.period_start
+    effective_period_end: date | None = source_result.period_end
+    if source_result.requires_review:
+        envelope = await current_reviewed_statement_envelope(db, user_id=user_id, statement_id=statement.id)
+        if envelope is None or envelope.source_result_id != source_record.id:
+            return _unproven(
+                statement_id=statement.id,
+                source_result_id=source_record.id,
+                source_result=source_result,
+                effective_period_start=source_result.period_start,
+                effective_period_end=source_result.period_end,
+                reason_code="missing_reviewed_envelope",
+            )
+        target = VersionedTraceRef(
+            kind="reviewed_statement_envelope",
+            id=str(source_result.result_id),
+            version=envelope.command_digest,
+        )
+        assertion = ReviewedEnvelopeDecisionTracePolicy().assertion
+        expected_decision_id = envelope.review_trace_record_id
+        effective_period_start = envelope.period_start
+        effective_period_end = envelope.period_end
+    else:
+        target = VersionedTraceRef(
+            kind="statement_extraction_result",
+            id=str(source_result.result_id),
+            version=source_result.content_digest,
+        )
+        assertion = ExtractionPromotionTracePolicy().assertion
+        expected_decision_id = None
+
+    decision = await repository.current_decision(scope, TraceLineage.from_refs(target, assertion))
+    if decision is None:
+        return _unproven(
+            statement_id=statement.id,
+            source_result_id=source_record.id,
+            source_result=source_result,
+            effective_period_start=source_result.period_start,
+            effective_period_end=source_result.period_end,
+            reason_code="missing_current_decision",
+        )
+    if decision.target != target or (expected_decision_id is not None and decision.record_id != expected_decision_id):
+        return _unproven(
+            statement_id=statement.id,
+            source_result_id=source_record.id,
+            source_result=source_result,
+            effective_period_start=source_result.period_start,
+            effective_period_end=source_result.period_end,
+            reason_code="target_mismatched_decision",
+        )
+    if decision.result is not TraceResult.AUTHORITATIVE:
+        return _unproven(
+            statement_id=statement.id,
+            source_result_id=source_record.id,
+            source_result=source_result,
+            effective_period_start=source_result.period_start,
+            effective_period_end=source_result.period_end,
+            reason_code="non_authoritative_decision",
+        )
+    return ResolvedStatementContribution(
+        statement_id=statement.id,
+        source_result_id=source_record.id,
+        source_result=source_result,
+        effective_period_start=effective_period_start,
+        effective_period_end=effective_period_end,
+        state="authoritative",
+        reason_code=None,
+        decision_id=decision.record_id,
+    )
+
+
+async def list_statement_contributions(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    as_of: date,
+) -> tuple[ResolvedStatementContribution, ...]:
+    """Resolve only current source results whose statement period is in scope."""
+    statement_ids = (
+        (
+            await db.execute(
+                select(StatementSummary.id)
+                .where(StatementSummary.user_id == user_id)
+                .where(StatementSummary.current_extraction_result_id.is_not(None))
+                .order_by(StatementSummary.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    contributions = [
+        await resolve_statement_contribution(db, user_id=user_id, statement_id=statement_id)
+        for statement_id in statement_ids
+    ]
+    return tuple(
+        contribution
+        for contribution in contributions
+        if contribution.effective_period_end is not None and contribution.effective_period_end <= as_of
+    )

--- a/apps/backend/tests/extraction/test_statement_contribution.py
+++ b/apps/backend/tests/extraction/test_statement_contribution.py
@@ -1,0 +1,210 @@
+"""Statement source contributions for package consumers (#1681)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from src.audit import SqlTraceRecordRepository, TraceEmitter
+from src.extraction.base.result import (
+    ExtractedPositionFact,
+    ExtractedTransactionFact,
+    ExtractionMethod,
+    SourceProvenance,
+    StatementEvidenceType,
+    StatementExtractionResult,
+    StatementSourceType,
+)
+from src.extraction.base.reviewed_statement_envelope import ReviewedStatementEnvelopeCommand
+from src.extraction.extension.extraction_trace import build_extraction_trace_records, extraction_trace_policy_registry
+from src.extraction.extension.reviewed_statement_envelope import (
+    confirm_reviewed_statement_envelope,
+    persist_statement_extraction_result,
+)
+from src.extraction.extension.statement_contribution import (
+    list_statement_contributions,
+    resolve_statement_contribution,
+)
+from src.extraction.orm.statement_enums import BankStatementStatus
+from src.extraction.orm.statement_summary import StatementSummary
+from src.ledger import Account, AccountType
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result(*, source_digest: str, evidence_type: StatementEvidenceType) -> StatementExtractionResult:
+    position_facts = (
+        ExtractedPositionFact(
+            fact_id="position-aapl",
+            symbol="AAPL",
+            quantity=Decimal("10"),
+            market_value=Decimal("1855.00"),
+            currency="USD",
+            confidence=Decimal("0.93"),
+        ),
+    )
+    transaction_facts = (
+        ExtractedTransactionFact(
+            fact_id="transaction-1",
+            transaction_date=date(2026, 1, 2),
+            description="Salary",
+            amount=Decimal("10.00"),
+            direction="IN",
+            currency="SGD",
+            balance_after=Decimal("110.00"),
+            confidence=Decimal("0.93"),
+        ),
+    )
+    if evidence_type is StatementEvidenceType.POSITION_SNAPSHOT:
+        return StatementExtractionResult.create(
+            producer_version="brokerage-parser@1",
+            source_content_digest=source_digest,
+            source_type=StatementSourceType.BROKERAGE,
+            evidence_type=evidence_type,
+            institution="Example Broker",
+            account_last4="1234",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            balances=(),
+            transactions=(),
+            positions=position_facts,
+            confidence=Decimal("0.93"),
+            balance_validated=True,
+            warnings=(),
+            review_reasons=(),
+            provenance=SourceProvenance(
+                intake_mode="csv",
+                method=ExtractionMethod.DETERMINISTIC,
+                provider="brokerage-parser",
+                model="brokerage-parser@1",
+            ),
+            statement_currency="USD",
+        )
+    return StatementExtractionResult.create(
+        producer_version="csv-parser@1",
+        source_content_digest=source_digest,
+        source_type=StatementSourceType.BANK,
+        evidence_type=evidence_type,
+        institution="Example Bank",
+        account_last4="1234",
+        period_start=None,
+        period_end=None,
+        balances=(),
+        transactions=transaction_facts,
+        positions=(),
+        confidence=Decimal("0.93"),
+        balance_validated=None,
+        warnings=(),
+        review_reasons=("source facts require confirmation",),
+        provenance=SourceProvenance(
+            intake_mode="csv",
+            method=ExtractionMethod.DETERMINISTIC,
+            provider="csv-parser",
+            model="csv-parser@1",
+        ),
+        statement_currency=None,
+    )
+
+
+async def _seed_current_result(db, test_user, *, result: StatementExtractionResult):
+    statement = StatementSummary(
+        user_id=test_user.id,
+        file_hash=result.source_content_digest,
+        institution=result.institution,
+        account_last4=result.account_last4,
+        currency=result.statement_currency,
+        period_start=result.period_start,
+        period_end=result.period_end,
+        opening_balance=None,
+        closing_balance=None,
+        status=BankStatementStatus.PARSED,
+    )
+    db.add(statement)
+    await db.flush()
+    trace_records = build_extraction_trace_records(
+        result,
+        user_id=test_user.id,
+        execution_id=f"test:{statement.id}:result:{result.result_id}",
+        occurred_at=datetime.now(UTC),
+    )
+    emitter = TraceEmitter(SqlTraceRecordRepository(db, extraction_trace_policy_registry()))
+    await emitter.emit_many(trace_records)
+    source_record = await persist_statement_extraction_result(
+        db,
+        statement=statement,
+        result=result,
+        source_trace_record_id=trace_records[0].record_id,
+    )
+    return statement, source_record, emitter
+
+
+async def test_AC_extraction_statement_contribution_1_preserves_exact_position_source_result(db, test_user):
+    """AC-extraction.statement-contribution.1: source facts cross the package boundary intact."""
+    result = _result(source_digest="a" * 64, evidence_type=StatementEvidenceType.POSITION_SNAPSHOT)
+    statement, source_record, _emitter = await _seed_current_result(db, test_user, result=result)
+
+    contribution = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
+    listed = await list_statement_contributions(db, user_id=test_user.id, as_of=date(2026, 1, 31))
+
+    assert contribution.is_authoritative
+    assert contribution.source_result_id == source_record.id
+    assert contribution.source_result is not None
+    assert contribution.source_result.content_digest == result.content_digest
+    assert contribution.source_result.positions == result.positions
+    assert contribution.effective_period_start == date(2026, 1, 1)
+    assert contribution.effective_period_end == date(2026, 1, 31)
+    assert contribution.input_refs == (f"statement_result:{source_record.id}",)
+    assert listed == (contribution,)
+
+
+async def test_AC_extraction_statement_contribution_2_reviewed_envelope_pins_exact_decision(db, test_user):
+    """AC-extraction.statement-contribution.2: an incomplete CSV needs its current review decision."""
+    result = _result(source_digest="b" * 64, evidence_type=StatementEvidenceType.TRANSACTION_LEDGER)
+    statement, source_record, emitter = await _seed_current_result(db, test_user, result=result)
+    account = Account(user_id=test_user.id, name="Example Bank - SGD", type=AccountType.ASSET, currency="SGD")
+    db.add(account)
+    await db.flush()
+    envelope = await confirm_reviewed_statement_envelope(
+        db,
+        user_id=test_user.id,
+        statement_id=statement.id,
+        command=ReviewedStatementEnvelopeCommand(
+            source_result_digest=result.content_digest,
+            account_id=account.id,
+            currency="SGD",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            opening_balance=Decimal("100.00"),
+            closing_balance=Decimal("110.00"),
+            rationale="The CSV has no statement header or balance envelope.",
+        ),
+        trace_emitter=emitter,
+    )
+
+    contribution = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
+
+    assert contribution.is_authoritative
+    assert contribution.source_result_id == source_record.id
+    assert contribution.decision_id == envelope.review_trace_record_id
+    assert contribution.effective_period_start == date(2026, 1, 1)
+    assert contribution.effective_period_end == date(2026, 1, 31)
+    assert contribution.input_refs == (f"statement_result:{source_record.id}",)
+
+
+async def test_AC_extraction_statement_contribution_3_fails_closed_without_current_decision(db, test_user):
+    """AC-extraction.statement-contribution.3: metadata and source rows cannot grant authority."""
+    result = _result(source_digest="c" * 64, evidence_type=StatementEvidenceType.TRANSACTION_LEDGER)
+    statement, source_record, _emitter = await _seed_current_result(db, test_user, result=result)
+
+    missing_review = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
+    cross_tenant = await resolve_statement_contribution(db, user_id=uuid4(), statement_id=statement.id)
+
+    assert not missing_review.is_authoritative
+    assert missing_review.source_result_id == source_record.id
+    assert missing_review.reason_code == "missing_reviewed_envelope"
+    assert missing_review.decision_id is None
+    assert not cross_tenant.is_authoritative
+    assert cross_tenant.reason_code == "missing_statement"

--- a/apps/backend/tests/extraction/test_statement_contribution.py
+++ b/apps/backend/tests/extraction/test_statement_contribution.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 import pytest
 
 from src.audit import SqlTraceRecordRepository, TraceEmitter
+from src.extraction import DocumentType, UploadedDocument
+from src.extraction.base.contribution import ResolvedStatementContribution
 from src.extraction.base.result import (
     ExtractedPositionFact,
     ExtractedTransactionFact,
@@ -110,8 +112,18 @@ def _result(*, source_digest: str, evidence_type: StatementEvidenceType) -> Stat
 
 
 async def _seed_current_result(db, test_user, *, result: StatementExtractionResult):
+    document = UploadedDocument(
+        user_id=test_user.id,
+        file_path=f"memory://statement-contribution/{result.source_content_digest}",
+        file_hash=result.source_content_digest,
+        original_filename="statement.csv",
+        document_type=DocumentType.BANK_STATEMENT,
+    )
+    db.add(document)
+    await db.flush()
     statement = StatementSummary(
         user_id=test_user.id,
+        uploaded_document_id=document.id,
         file_hash=result.source_content_digest,
         institution=result.institution,
         account_last4=result.account_last4,
@@ -138,13 +150,13 @@ async def _seed_current_result(db, test_user, *, result: StatementExtractionResu
         result=result,
         source_trace_record_id=trace_records[0].record_id,
     )
-    return statement, source_record, emitter
+    return statement, source_record, emitter, document
 
 
 async def test_AC_extraction_statement_contribution_1_preserves_exact_position_source_result(db, test_user):
     """AC-extraction.statement-contribution.1: source facts cross the package boundary intact."""
     result = _result(source_digest="a" * 64, evidence_type=StatementEvidenceType.POSITION_SNAPSHOT)
-    statement, source_record, _emitter = await _seed_current_result(db, test_user, result=result)
+    statement, source_record, _emitter, document = await _seed_current_result(db, test_user, result=result)
 
     contribution = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
     listed = await list_statement_contributions(db, user_id=test_user.id, as_of=date(2026, 1, 31))
@@ -156,14 +168,18 @@ async def test_AC_extraction_statement_contribution_1_preserves_exact_position_s
     assert contribution.source_result.positions == result.positions
     assert contribution.effective_period_start == date(2026, 1, 1)
     assert contribution.effective_period_end == date(2026, 1, 31)
-    assert contribution.input_refs == (f"statement_result:{source_record.id}",)
+    assert contribution.source_document_id == document.id
+    assert contribution.input_refs == (
+        f"statement_result:{source_record.id}",
+        f"source_document:{document.id}",
+    )
     assert listed == (contribution,)
 
 
 async def test_AC_extraction_statement_contribution_2_reviewed_envelope_pins_exact_decision(db, test_user):
     """AC-extraction.statement-contribution.2: an incomplete CSV needs its current review decision."""
     result = _result(source_digest="b" * 64, evidence_type=StatementEvidenceType.TRANSACTION_LEDGER)
-    statement, source_record, emitter = await _seed_current_result(db, test_user, result=result)
+    statement, source_record, emitter, document = await _seed_current_result(db, test_user, result=result)
     account = Account(user_id=test_user.id, name="Example Bank - SGD", type=AccountType.ASSET, currency="SGD")
     db.add(account)
     await db.flush()
@@ -191,16 +207,25 @@ async def test_AC_extraction_statement_contribution_2_reviewed_envelope_pins_exa
     assert contribution.decision_id == envelope.review_trace_record_id
     assert contribution.effective_period_start == date(2026, 1, 1)
     assert contribution.effective_period_end == date(2026, 1, 31)
-    assert contribution.input_refs == (f"statement_result:{source_record.id}",)
+    assert contribution.source_document_id == document.id
+    assert contribution.input_refs == (
+        f"statement_result:{source_record.id}",
+        f"source_document:{document.id}",
+    )
 
 
 async def test_AC_extraction_statement_contribution_3_fails_closed_without_current_decision(db, test_user):
-    """AC-extraction.statement-contribution.3: metadata and source rows cannot grant authority."""
+    """AC-extraction.statement-contribution.3: invalid source or decisions cannot grant authority."""
     result = _result(source_digest="c" * 64, evidence_type=StatementEvidenceType.TRANSACTION_LEDGER)
-    statement, source_record, _emitter = await _seed_current_result(db, test_user, result=result)
+    statement, source_record, _emitter, _document = await _seed_current_result(db, test_user, result=result)
 
     missing_review = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
     cross_tenant = await resolve_statement_contribution(db, user_id=uuid4(), statement_id=statement.id)
+
+    malformed_payload = dict(source_record.payload)
+    malformed_payload.pop("schema_version")
+    source_record.payload = malformed_payload
+    malformed_source = await resolve_statement_contribution(db, user_id=test_user.id, statement_id=statement.id)
 
     assert not missing_review.is_authoritative
     assert missing_review.source_result_id == source_record.id
@@ -208,3 +233,35 @@ async def test_AC_extraction_statement_contribution_3_fails_closed_without_curre
     assert missing_review.decision_id is None
     assert not cross_tenant.is_authoritative
     assert cross_tenant.reason_code == "missing_statement"
+    assert not malformed_source.is_authoritative
+    assert malformed_source.reason_code == "invalid_current_source_result"
+
+
+async def test_AC_extraction_statement_contribution_3_rejects_contradictory_authority_fields():
+    """AC-extraction.statement-contribution.3: state-specific authority fields are coherent."""
+    source_result_id = uuid4()
+    decision_id = uuid4()
+
+    with pytest.raises(ValueError, match="authoritative statement contribution cannot have a reason_code"):
+        ResolvedStatementContribution(
+            statement_id=uuid4(),
+            source_result_id=source_result_id,
+            source_result=_result(source_digest="d" * 64, evidence_type=StatementEvidenceType.POSITION_SNAPSHOT),
+            effective_period_start=date(2026, 1, 1),
+            effective_period_end=date(2026, 1, 31),
+            state="authoritative",
+            reason_code="unexpected_reason",
+            decision_id=decision_id,
+        )
+
+    with pytest.raises(ValueError, match="unproven statement contribution cannot have a decision_id"):
+        ResolvedStatementContribution(
+            statement_id=uuid4(),
+            source_result_id=None,
+            source_result=None,
+            effective_period_start=None,
+            effective_period_end=None,
+            state="unproven",
+            reason_code="missing_source",
+            decision_id=decision_id,
+        )

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -179,6 +179,24 @@ CONTRACT = PackageContract(
             kind=Kind.VALUE_OBJECT,
             module="base/result.py",
         ),
+        # #1681: the only source-result/position payload reporting may consume.
+        # It resolves an immutable source version and its current TraceRecord
+        # decision before the reporting package can freeze either.
+        Unit(
+            name="ResolvedStatementContribution",
+            kind=Kind.VALUE_OBJECT,
+            module="base/contribution.py",
+        ),
+        Unit(
+            name="resolve_statement_contribution",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/statement_contribution.py",
+        ),
+        Unit(
+            name="list_statement_contributions",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/statement_contribution.py",
+        ),
         Unit(
             name="ReviewedStatementEnvelopeCommand",
             kind=Kind.VALUE_OBJECT,
@@ -306,6 +324,7 @@ CONTRACT = PackageContract(
         "StatementIngestionStatus",
         "StatementIngestionUseCase",
         "StatementExtractionResult",
+        "ResolvedStatementContribution",
         "StatementEvidenceType",
         "StatementPostingDependencies",
         "StatementPostingOutcome",
@@ -352,6 +371,8 @@ CONTRACT = PackageContract(
         "pending_stage1_review_filter",
         "persist_statement_extraction_result",
         "record_correction",
+        "resolve_statement_contribution",
+        "list_statement_contributions",
         "register_fx_rate_provider",
         "register_position_reconciler",
         "register_statement_source",
@@ -3992,6 +4013,54 @@ CONTRACT = PackageContract(
             ),
             priority="P0",
             status="open",
+            proof_kind="invariant",
+        ),
+        # ── group statement-contribution: source-to-package boundary (#1681) ──
+        ACRecord(
+            id="AC-extraction.statement-contribution.1",
+            statement=(
+                "resolve_statement_contribution publishes the exact current immutable "
+                "StatementExtractionResult, including its transaction and position facts, "
+                "record identity, digest, and decision id without reconstructing a cassette "
+                "or exposing extraction ORM rows to consumers."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_contribution.py"
+                "::test_AC_extraction_statement_contribution_1_preserves_exact_position_source_result"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="invariant",
+        ),
+        ACRecord(
+            id="AC-extraction.statement-contribution.2",
+            statement=(
+                "A contribution is authoritative only when its exact current source version "
+                "has a current authoritative extraction-promotion or reviewed-envelope "
+                "TraceRecord decision; provenance, confidence, source class, or import time "
+                "cannot substitute for that decision."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_contribution.py"
+                "::test_AC_extraction_statement_contribution_2_reviewed_envelope_pins_exact_decision"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="invariant",
+        ),
+        ACRecord(
+            id="AC-extraction.statement-contribution.3",
+            statement=(
+                "Missing, non-authoritative, stale, cross-tenant, or target-mismatched "
+                "source decisions return an explicit unproven contribution and never grant "
+                "trust to a package consumer."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_statement_contribution.py"
+                "::test_AC_extraction_statement_contribution_3_fails_closed_without_current_decision"
+            ),
+            priority="P0",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -4021,7 +4021,7 @@ CONTRACT = PackageContract(
             statement=(
                 "resolve_statement_contribution publishes the exact current immutable "
                 "StatementExtractionResult, including its transaction and position facts, "
-                "record identity, digest, and decision id without reconstructing a cassette "
+                "record identity, digest, uploaded-document reference, and decision id without reconstructing a cassette "
                 "or exposing extraction ORM rows to consumers."
             ),
             test=(
@@ -4051,9 +4051,10 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-extraction.statement-contribution.3",
             statement=(
-                "Missing, non-authoritative, stale, cross-tenant, or target-mismatched "
-                "source decisions return an explicit unproven contribution and never grant "
-                "trust to a package consumer."
+                "Malformed, missing, non-authoritative, stale, cross-tenant, or target-mismatched "
+                "source facts or decisions return an explicit unproven contribution and never grant "
+                "trust to a package consumer; authoritative contributions carry no reason code and "
+                "unproven contributions carry no decision id."
             ),
             test=(
                 "apps/backend/tests/extraction/test_statement_contribution.py"

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -237,7 +237,8 @@ can promote a diverged projection.
 `resolve_statement_contribution()` and `list_statement_contributions()` are
 the only extraction interfaces a report package may use for statement source
 facts. A `ResolvedStatementContribution` contains the exact immutable current
-`StatementExtractionResult`, persisted source-result id, input ref, and current
+`StatementExtractionResult`, persisted source-result id, immutable
+uploaded-document reference when one is present, input refs, and current
 promotion or reviewed-envelope `TraceRecord` decision. It carries transaction
 and position facts exactly as persisted; it never reconstructs a cassette or
 exposes `StatementSummary`, `AtomicTransaction`, or `AtomicPosition` rows to a

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -232,6 +232,24 @@ Stage-1 approval rechecks that the mutable projection still equals the current
 complete source result or its current reviewed envelope, so no route or worker
 can promote a diverged projection.
 
+### Package-facing statement contributions (#1681)
+
+`resolve_statement_contribution()` and `list_statement_contributions()` are
+the only extraction interfaces a report package may use for statement source
+facts. A `ResolvedStatementContribution` contains the exact immutable current
+`StatementExtractionResult`, persisted source-result id, input ref, and current
+promotion or reviewed-envelope `TraceRecord` decision. It carries transaction
+and position facts exactly as persisted; it never reconstructs a cassette or
+exposes `StatementSummary`, `AtomicTransaction`, or `AtomicPosition` rows to a
+consumer.
+
+The contribution is `authoritative` only when its exact source version has its
+current target-matching decision. A missing, non-authoritative, stale,
+cross-tenant, or target-mismatched decision returns `unproven`. Source type,
+parser confidence, import time, and provenance remain display/diagnostic facts,
+not an authority shortcut. Report assembly freezes the contribution's ids and
+digest; it never resolves a replacement after reopen or export.
+
 `StatementExtractionResult` separately preserves a scalar statement-declared currency.
 For a transaction ledger, a scalar declaration or an exact source-declared balance
 bucket is required; an individual transaction currency can never fill that gap. A


### PR DESCRIPTION
## Summary
- Publish extraction-owned ResolvedStatementContribution for immutable current source results and their exact decisions.
- Preserve transaction and position facts without exposing extraction ORM rows or reconstructing cassettes.
- Fail closed for missing, stale, cross-tenant, target-mismatched, and non-authoritative source decisions.
- Add extraction package ACs, proof tests, and boundary documentation.

## Verification
- Statement contribution, reviewed envelope, and source-result contracts: 19 passed.
- tools/preflight.py --tier=static passed.
- Commit hooks passed: ruff, ruff-format, mypy, and security checks.

Closes #1681