### PR TITLE
[finance-report-950-coverage-ratchet] test(audit): restore main coverage ratchet

### DIFF
--- a/.opencode/skills/domain/preflight/SKILL.md
+++ b/.opencode/skills/domain/preflight/SKILL.md
@@ -44,6 +44,7 @@ not contend with the operator's machine).
 | You touched | It runs |
 |---|---|
 | `docs/project/EPIC*.md`, `docs/ac_registry*.yaml`, `docs/infra_registry*.yaml` | `generate_ac_registry.py` → `check_ac_index.py` |
+| `tests/*.py`, `apps/backend/tests/*.py`, frontend `*.test.*` / `*.spec.*` | `check_ac_index.py` (AC proof traceability) |
 | `common/meta/data/MANIFEST.yaml` | `check_ssot_ownership.py`, `check_manifest.py` |
 | `docs/*`, `mkdocs.yml`, `vision.md`, `README.md` | `lint_doc_consistency.py` |
 | `*.md`, `common/meta/data/*.yaml`, `tests/*.py`, `common/*`, `tools/*.py` | `check_taxonomy_drift.py` (retired taxonomy vocabulary gate, AC-meta.vocab.1) |

--- a/apps/backend/tests/audit/test_boundary_codecs.py
+++ b/apps/backend/tests/audit/test_boundary_codecs.py
@@ -48,7 +48,7 @@ pytestmark = pytest.mark.no_db
     issue="#950",
 )
 def test_AC_audit_31_4_boundary_codecs_preserve_typed_decimal_values():
-    """Codec boundaries use exact decimal strings and reject malformed payloads."""
+    """AC-audit.31.4 / AC-audit.33.1: codecs preserve exact typed decimal values."""
     money = Money(Decimal("12.3400"), "USD")
     assert money_to_wire(money) == {"amount": "12.34", "currency": "USD"}
     assert money_from_wire({"amount": "12.34", "currency": "USD"}) == money
@@ -114,7 +114,7 @@ def test_AC_audit_31_4_boundary_codecs_preserve_typed_decimal_values():
     issue="#950",
 )
 def test_AC_audit_33_1_money_tolerance_validates_and_scales_exactly():
-    """Tolerance is typed, currency-aware, and scales its full band exactly."""
+    """AC-audit.33.1: tolerance is typed, currency-aware, and scales exactly."""
     tolerance = MoneyTolerance(Money(Decimal("1.00"), "USD"), Ratio.from_percent(Decimal("5")))
     assert tolerance.threshold_for(Money(Decimal("10.00"), "USD")) == Money(Decimal("1.00"), "USD")
     assert tolerance.threshold_for(Money(Decimal("100.00"), "USD")) == Money(Decimal("5.00"), "USD")

--- a/apps/backend/tests/audit/test_boundary_codecs.py
+++ b/apps/backend/tests/audit/test_boundary_codecs.py
@@ -1,0 +1,138 @@
+"""Backend boundary-codec proofs for the audit value language."""
+
+from decimal import Decimal
+
+import pytest
+from common.testing.ac_proof import ac_proof
+
+from src.audit.money import (
+    ExchangeRate,
+    FloatNotAllowedError as MoneyFloatNotAllowedError,
+    InvalidMoneyPayloadError,
+    Money,
+    MoneyTolerance,
+    exchange_rate_from_db_fields,
+    exchange_rate_from_wire,
+    exchange_rate_to_db_fields,
+    exchange_rate_to_wire,
+    money_from_db_fields,
+    money_from_wire,
+    money_to_db_fields,
+    money_to_wire,
+)
+from src.audit.quantity import (
+    InvalidQuantityPayloadError,
+    Quantity,
+    quantity_from_db_fields,
+    quantity_from_wire,
+    quantity_to_db_fields,
+    quantity_to_wire,
+)
+from src.audit.ratio import Ratio, ratio_from_db_value, ratio_from_wire, ratio_to_db_value, ratio_to_wire
+from src.audit.unit_price import (
+    InvalidUnitPricePayloadError,
+    UnitPrice,
+    unit_price_from_db_fields,
+    unit_price_from_wire,
+    unit_price_to_db_fields,
+    unit_price_to_wire,
+)
+
+pytestmark = pytest.mark.no_db
+
+
+@ac_proof(
+    proof_id="test_audit_boundary_codecs_preserve_typed_decimal_values",
+    ac_ids=["AC-audit.31.4", "AC-audit.33.1"],
+    ci_tier="pr_ci",
+    issue="#950",
+)
+def test_AC_audit_31_4_boundary_codecs_preserve_typed_decimal_values():
+    """Codec boundaries use exact decimal strings and reject malformed payloads."""
+    money = Money(Decimal("12.3400"), "USD")
+    assert money_to_wire(money) == {"amount": "12.34", "currency": "USD"}
+    assert money_from_wire({"amount": "12.34", "currency": "USD"}) == money
+    assert money_to_db_fields(money) == {"amount": Decimal("12.3400"), "currency": "USD"}
+    assert money_from_db_fields(Decimal("12.3400"), "USD") == money
+    for encoder in (money_to_wire, money_to_db_fields):
+        with pytest.raises(TypeError, match="expects Money"):
+            encoder(object())  # type: ignore[arg-type]
+    with pytest.raises(InvalidMoneyPayloadError, match="missing 'amount'"):
+        money_from_wire({"currency": "USD"})
+    with pytest.raises(MoneyFloatNotAllowedError, match="decimal string"):
+        money_from_wire({"amount": 12.34, "currency": "USD"})
+
+    rate = ExchangeRate("USD", "SGD", Decimal("1.3500"))
+    assert exchange_rate_to_wire(rate) == {"base": "USD", "quote": "SGD", "rate": "1.35"}
+    assert exchange_rate_from_wire({"base": "USD", "quote": "SGD", "rate": "1.35"}) == rate
+    assert exchange_rate_to_db_fields(rate) == {"base": "USD", "quote": "SGD", "rate": Decimal("1.3500")}
+    assert exchange_rate_from_db_fields("USD", "SGD", Decimal("1.3500")) == rate
+    for encoder in (exchange_rate_to_wire, exchange_rate_to_db_fields):
+        with pytest.raises(TypeError, match="expects ExchangeRate"):
+            encoder(object())  # type: ignore[arg-type]
+
+    ratio = Ratio(Decimal("0.125"))
+    assert ratio_to_wire(ratio) == "0.125"
+    assert ratio_from_wire("0.125") == ratio
+    assert ratio_to_db_value(ratio) == Decimal("0.125")
+    assert ratio_from_db_value(Decimal("0.125")) == ratio
+    for encoder in (ratio_to_wire, ratio_to_db_value):
+        with pytest.raises(TypeError, match="expects Ratio"):
+            encoder(object())  # type: ignore[arg-type]
+
+    quantity = Quantity(Decimal("3.500000"), "shares")
+    assert quantity_to_wire(quantity) == {"value": "3.5", "unit": "shares"}
+    assert quantity_from_wire({"value": "3.5", "unit": "shares"}) == quantity
+    assert quantity_to_db_fields(quantity) == {"value": Decimal("3.500000"), "unit": "shares"}
+    assert quantity_from_db_fields(Decimal("3.500000"), "shares") == quantity
+    for encoder in (quantity_to_wire, quantity_to_db_fields):
+        with pytest.raises(TypeError, match="expects Quantity"):
+            encoder(object())  # type: ignore[arg-type]
+    with pytest.raises(InvalidQuantityPayloadError, match="missing 'unit'"):
+        quantity_from_wire({"value": "3.5"})
+
+    unit_price = UnitPrice(Decimal("4.250000"), "USD", "shares")
+    assert unit_price_to_wire(unit_price) == {"rate": "4.25", "currency": "USD", "unit": "shares"}
+    assert unit_price_from_wire({"rate": "4.25", "currency": "USD", "unit": "shares"}) == unit_price
+    assert unit_price_to_db_fields(unit_price) == {
+        "rate": Decimal("4.250000"),
+        "currency": "USD",
+        "unit": "shares",
+    }
+    assert unit_price_from_db_fields(Decimal("4.250000"), "USD", "shares") == unit_price
+    for encoder in (unit_price_to_wire, unit_price_to_db_fields):
+        with pytest.raises(TypeError, match="expects UnitPrice"):
+            encoder(object())  # type: ignore[arg-type]
+    with pytest.raises(InvalidUnitPricePayloadError, match="missing 'rate'"):
+        unit_price_from_wire({"currency": "USD", "unit": "shares"})
+
+
+@ac_proof(
+    proof_id="test_money_tolerance_rejects_invalid_bands_and_scales_exactly",
+    ac_ids=["AC-audit.33.1"],
+    ci_tier="pr_ci",
+    issue="#950",
+)
+def test_AC_audit_33_1_money_tolerance_validates_and_scales_exactly():
+    """Tolerance is typed, currency-aware, and scales its full band exactly."""
+    tolerance = MoneyTolerance(Money(Decimal("1.00"), "USD"), Ratio.from_percent(Decimal("5")))
+    assert tolerance.threshold_for(Money(Decimal("10.00"), "USD")) == Money(Decimal("1.00"), "USD")
+    assert tolerance.threshold_for(Money(Decimal("100.00"), "USD")) == Money(Decimal("5.00"), "USD")
+    assert tolerance.holds(Money(Decimal("104.99"), "USD"), Money(Decimal("100.00"), "USD"))
+    assert not tolerance.holds(Money(Decimal("105.01"), "USD"), Money(Decimal("100.00"), "USD"))
+    assert tolerance.scaled(Decimal("2")) == MoneyTolerance(
+        Money(Decimal("2.00"), "USD"), Ratio.from_percent(Decimal("10"))
+    )
+    assert tolerance.scaled(2) == tolerance.scaled(Decimal("2"))
+    with pytest.raises(TypeError, match="absolute must be Money"):
+        MoneyTolerance(object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="relative must be Ratio"):
+        MoneyTolerance(Money(Decimal("1.00"), "USD"), object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="absolute tolerance"):
+        MoneyTolerance(Money(Decimal("-0.01"), "USD"))
+    with pytest.raises(ValueError, match="relative tolerance"):
+        MoneyTolerance(Money(Decimal("0"), "USD"), Ratio(Decimal("-0.01")))
+    with pytest.raises(TypeError, match="scale factor"):
+        tolerance.scaled(True)
+    with pytest.raises(ValueError, match="scale factor"):
+        tolerance.scaled(Decimal("-1"))

--- a/apps/backend/tests/extraction/test_statement_result_contract.py
+++ b/apps/backend/tests/extraction/test_statement_result_contract.py
@@ -299,7 +299,7 @@ def test_AC_extraction_source_capability_1_declares_semantics_not_test_paths():
     issue="#950",
 )
 def test_AC_extraction_result_envelope_1_rejects_malformed_source_facts():
-    """A result cannot create trusted source facts from malformed primitive values."""
+    """AC-extraction.result-envelope.1: malformed primitive source facts fail closed."""
     complete = _complete_result()
 
     with pytest.raises(ValueError, match="provider is required"):

--- a/apps/backend/tests/extraction/test_statement_result_contract.py
+++ b/apps/backend/tests/extraction/test_statement_result_contract.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from common.testing.ac_proof import ac_proof
 
 from src.extraction import (
     SOURCE_CAPABILITIES,
@@ -15,6 +16,7 @@ from src.extraction import (
     ExtractedPositionFact,
     ExtractedTransactionFact,
     ExtractionMethod,
+    SourceCapability,
     SourceCapabilityStatus,
     SourceProvenance,
     StatementBalanceFact,
@@ -288,3 +290,83 @@ def test_AC_extraction_source_capability_1_declares_semantics_not_test_paths():
     assert by_id["settlement_note"].status is SourceCapabilityStatus.GAP
     assert by_id["csv_export"].status is SourceCapabilityStatus.MANUAL_TRUSTED
     assert "pytest" not in repr(SOURCE_CAPABILITIES).lower()
+
+
+@ac_proof(
+    proof_id="test_statement_result_source_facts_fail_closed",
+    ac_ids=["AC-extraction.result-envelope.1"],
+    ci_tier="pr_ci",
+    issue="#950",
+)
+def test_AC_extraction_result_envelope_1_rejects_malformed_source_facts():
+    """A result cannot create trusted source facts from malformed primitive values."""
+    complete = _complete_result()
+
+    with pytest.raises(ValueError, match="provider is required"):
+        SourceProvenance("pdf", ExtractionMethod.DETERMINISTIC, " ", "model")
+    with pytest.raises(TypeError, match="method must be ExtractionMethod"):
+        SourceProvenance("pdf", "deterministic", "provider", "model")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="currency must be a three-letter code"):
+        StatementBalanceFact("US", Decimal("0"), Decimal("1"))
+    with pytest.raises(TypeError, match="balances must use Decimal"):
+        StatementBalanceFact("USD", 0, Decimal("1"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="transaction direction"):
+        replace(complete.transactions[0], direction="SIDEWAYS")
+    with pytest.raises(ValueError, match="positive Decimal"):
+        replace(complete.transactions[0], amount=Decimal("0"))
+    with pytest.raises(TypeError, match="balance_after must use Decimal"):
+        replace(complete.transactions[0], balance_after=0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="transaction confidence"):
+        replace(complete.transactions[0], confidence=Decimal("1.01"))
+    with pytest.raises(TypeError, match="position values must use Decimal"):
+        replace(complete.positions[0], quantity=1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="status must be SourceCapabilityStatus"):
+        SourceCapability(
+            capability_id="invalid",
+            status="supported",  # type: ignore[arg-type]
+            intake_modes=("pdf",),
+            evidence_kinds=("statement",),
+            produced_facts=("transaction",),
+            review_semantics="review",
+            traceability_target="trace",
+        )
+    with pytest.raises(ValueError, match="cannot own test paths"):
+        SourceCapability(
+            capability_id="invalid",
+            status=SourceCapabilityStatus.SUPPORTED,
+            intake_modes=("pytest",),
+            evidence_kinds=("statement",),
+            produced_facts=("transaction",),
+            review_semantics="review",
+            traceability_target="trace",
+        )
+    with pytest.raises(ValueError, match="requires semantic identifiers"):
+        SourceCapability(
+            capability_id="invalid",
+            status=SourceCapabilityStatus.SUPPORTED,
+            intake_modes=("",),
+            evidence_kinds=("statement",),
+            produced_facts=("transaction",),
+            review_semantics="review",
+            traceability_target="trace",
+        )
+
+    for invalid in (
+        {"schema_version": "999"},
+        {"source_content_digest": "A" * 64},
+        {"source_type": "bank_statement"},
+        {"evidence_type": "transaction_ledger"},
+        {"account_last4": "12345"},
+        {"period_start": date(2026, 2, 1), "period_end": date(2026, 1, 1)},
+        {"balances": (complete.balances[0], complete.balances[0])},
+        {"confidence": 1},
+        {"confidence": Decimal("-0.01")},
+        {"warnings": ("",)},
+    ):
+        with pytest.raises((TypeError, ValueError)):
+            replace(complete, **invalid)
+
+    identity_mismatch = complete.to_payload()
+    identity_mismatch["content_digest"] = "0" * 64
+    with pytest.raises(ValueError, match="identity mismatch"):
+        StatementExtractionResult.from_payload(identity_mismatch)

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -85,6 +85,19 @@ CHECKS: tuple[Check, ...] = (
         why="EPIC/AC changed: regenerate the registry and re-run the single AC-index gate (folds in EPIC->AC->test traceability + critical-proof contract)",
     ),
     Check(
+        name="ac-proof-traceability",
+        globs=(
+            "tests/*.py",
+            "apps/backend/tests/*.py",
+            "apps/frontend/*.test.ts",
+            "apps/frontend/*.test.tsx",
+            "apps/frontend/*.spec.ts",
+            "apps/frontend/*.spec.tsx",
+        ),
+        commands=((PY, "tools/check_ac_index.py"),),
+        why="Test proof changed: re-run the single AC-index integrity gate so every declared AC reference remains discoverable before CI",
+    ),
+    Check(
         name="ssot-ownership",
         # docs/ssot/ is retired (#1823); the concept registry lives at
         # common/meta/data/MANIFEST.yaml now, so that path (not the dead
@@ -358,7 +371,10 @@ def run_checks(
         )
         ok = True
         for command in check.commands:
-            if runner(_resolve(command, python, matching_paths=matching_paths), cwd) != 0:
+            if (
+                runner(_resolve(command, python, matching_paths=matching_paths), cwd)
+                != 0
+            ):
                 ok = False
                 break
         results.append(CheckResult(check.name, ok))

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -58,6 +58,16 @@ class TestSelectChecks:
         ]
         assert "gate-contracts" in names
 
+    def test_AC_testing_preflight_1_backend_proof_test_selects_ac_index(self):
+        """AC-testing.preflight.1: changed backend proofs re-run AC integrity locally."""
+        names = [
+            c.name
+            for c in preflight.select_checks(
+                ["apps/backend/tests/audit/test_boundary_codecs.py"], tier="static"
+            )
+        ]
+        assert "ac-proof-traceability" in names
+
     def test_docs_edit_selects_doc_consistency(self):
         names = [c.name for c in preflight.select_checks(["docs/project/README.md"])]
         assert "doc-consistency" in names  # docs/* matches


### PR DESCRIPTION
## What

- Restore the main coverage ratchet with executable backend proofs for all audit decimal boundary codecs and MoneyTolerance.
- Fail closed on malformed statement source facts and tampered immutable result identities.
- Make proof-test changes run AC traceability validation in local static preflight.

## Root Cause

The merged source-boundary changes passed PR diff coverage, but their cumulative uncovered backend branches reduced main coverage below the committed component waterline. The authoritative main run failed only at unified coverage; all functional, integration, E2E, frontend, schema, lint, and tooling jobs passed.

## Why Gates Missed It

PR coverage blocks uncovered changed lines at its local threshold, while the global component ratchet is report-only on PRs and blocking only after merge. Individual PRs therefore did not prove that their combined coverage preserved the main backend waterline.

Static preflight also did not select `check_ac_index.py` for backend/frontend proof-test changes, so an AC reference confined to a test body could bypass local traceability validation.

## Proof Added

- Exact wire and DB round trips plus invalid-type/payload rejection for Money, ExchangeRate, Ratio, Quantity, and UnitPrice.
- Typed MoneyTolerance thresholds, scaling, and invalid-band rejection.
- Immutable extraction-result validation for malformed primitive facts, invalid semantic capability declarations, and content/result identity tampering.
- A red-to-green preflight selector contract: proof-test changes now execute `check_ac_index.py` without running unrelated registry generation.

Scoped LCOV moves every CI-reported uncovered line in these six backend modules to 100 percent. It adds 85 covered backend lines, recovering the component ratchet without lowering its baseline.

## Verification

- 14 targeted audit/extraction tests passed.
- 53 preflight selector tests passed.
- 199 audit and statement-result tests passed.
- Scoped LCOV: six repaired backend modules at 100 percent; `common/testing/preflight.py` at 97 percent.
- Static preflight passed.
- moon run :lint passed.
- moon run :test could not start because the local Podman socket was unavailable; GitHub CI is the final container-backed verification.

Part of #950.