### PR TITLE
[finance-report-1923-unmatched-flag-proof] Stabilize UnmatchedBoard flag readiness proof

### DIFF
--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -72,8 +72,10 @@ describe("UnmatchedBoard", () => {
 
     render(<UnmatchedBoard />);
 
-    expect(await screen.findByText("Flagged locally")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Unflag local" })).toBeInTheDocument();
+    // The flag badge is rendered in the list before the selected-detail pane
+    // commits. Wait for the user action this proof needs instead of that proxy.
+    expect(await screen.findByRole("button", { name: "Unflag local" })).toBeInTheDocument();
+    expect(screen.getByText("Flagged locally")).toBeInTheDocument();
   });
 
   it("keeps review available when local flag storage is malformed or unavailable", async () => {

--- a/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
+++ b/apps/frontend/src/__tests__/unmatchedBoardComponent.test.tsx
@@ -72,8 +72,8 @@ describe("UnmatchedBoard", () => {
 
     render(<UnmatchedBoard />);
 
-    // The flag badge is rendered in the list before the selected-detail pane
-    // commits. Wait for the user action this proof needs instead of that proxy.
+    // The list badge may render before or after the selected-detail pane commits.
+    // Wait for the user action this proof needs instead of using the badge as a proxy.
     expect(await screen.findByRole("button", { name: "Unflag local" })).toBeInTheDocument();
     expect(screen.getByText("Flagged locally")).toBeInTheDocument();
   });


### PR DESCRIPTION
## What

- Make the persisted-local-flag proof await the selected-detail `Unflag local` action, then assert the corresponding list badge.
- Preserve production behavior; no retry, timeout, or timing-specific product code is added.

## Root Cause

Main CI run `29661621358` at `d054604` failed in `Frontend Vitest Coverage` after the list had rendered `Flagged locally` but before React committed the selected detail pane. The test used the list badge as a proxy, then synchronously queried the detail button. The identical head passed PR CI, confirming a proof-readiness race rather than a product regression.

## Verification

- Focused `unmatchedBoardComponent` suite passed.
- Local full `npm run test:coverage` completed and produced `coverage/lcov.info`.
- Static preflight passed (`ac-proof-traceability`, `authority-reconcile`).
- `moon run :lint` passed.

Closes #1923.