### PR TITLE
[finance-report-567-package-current] Freeze selected market valuations in package manifests

### DIFF
--- a/apps/backend/src/portfolio/extension/performance_report.py
+++ b/apps/backend/src/portfolio/extension/performance_report.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from typing import cast
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.audit.money import Money, to_money
+from src.audit.money import Currency, Money, to_money
 from src.audit.ratio import Ratio
 from src.extraction.orm.layer2 import AtomicPosition
 from src.extraction.orm.layer3 import ManagedPosition, PositionStatus
@@ -38,6 +39,7 @@ from src.schemas.portfolio import (
     InvestmentPerformanceAllocationRow,
     InvestmentPerformanceDataFreshness,
     InvestmentPerformanceHoldingRow,
+    InvestmentPerformanceMarketValuationSelection,
     InvestmentPerformanceReportScheduleResponse,
 )
 
@@ -205,7 +207,9 @@ async def build_investment_performance_report_schedule(
         position = position_by_asset.get(holding.asset_identifier)
         if position is None:
             cost_basis = (
-                await _schedule_amount(Money(holding.cost_basis, holding.currency), holding.acquisition_date)
+                await _schedule_amount(
+                    Money(holding.cost_basis, Currency.of(holding.currency)), holding.acquisition_date
+                )
             ).quantize()
         else:
             cost_basis = (await _schedule_amount(position.cost_basis_money, position.acquisition_date)).quantize()
@@ -235,7 +239,7 @@ async def build_investment_performance_report_schedule(
                     dimension=dimension,
                     category=row.category,
                     value=to_money(row.value),
-                    percentage=_percent(row.percentage),
+                    percentage=row.percentage,
                     count=row.count,
                 )
             )
@@ -247,10 +251,10 @@ async def build_investment_performance_report_schedule(
             ("asset_class", "asset_type", "Unclassified"),
         ]:
             grouped: dict[str, tuple[Decimal, int]] = {}
-            for holding, row in zip(holdings, holding_rows, strict=True):
+            for holding, holding_row in zip(holdings, holding_rows, strict=True):
                 category = getattr(holding, attribute) or fallback_category
                 current_value, current_count = grouped.get(category, (Decimal("0.00"), 0))
-                grouped[category] = (current_value + row.market_value, current_count + 1)
+                grouped[category] = (current_value + holding_row.market_value, current_count + 1)
             for category, (value, count) in grouped.items():
                 allocation_ratio = Ratio.fraction_or_zero(value, total_market_value)
                 allocation_rows.append(
@@ -310,7 +314,13 @@ async def build_investment_performance_report_schedule(
             select(StockPrice)
             .where(StockPrice.symbol.in_(asset_identifiers))
             .where(StockPrice.price_date <= as_of_date)
-            .order_by(StockPrice.price_date.desc(), StockPrice.created_at.desc(), StockPrice.source.asc())
+            .order_by(
+                StockPrice.price_date.desc(),
+                StockPrice.created_at.desc(),
+                StockPrice.source.asc(),
+                StockPrice.currency.asc(),
+                StockPrice.id.asc(),
+            )
         )
         stock_prices = list(stock_price_result.scalars().all())
     latest_stock_price_by_asset: dict[str, StockPrice] = {}
@@ -321,17 +331,33 @@ async def build_investment_performance_report_schedule(
     providers: set[str] = set()
     stale_holdings: list[str] = []
     for asset_identifier in asset_identifiers:
-        override = latest_override_by_asset.get(asset_identifier)
-        stock_price = latest_stock_price_by_asset.get(asset_identifier)
-        atomic = latest_atomic_by_asset.get(asset_identifier)
+        selected_override: MarketDataOverride | None = latest_override_by_asset.get(asset_identifier)
+        selected_stock_price: StockPrice | None = latest_stock_price_by_asset.get(asset_identifier)
+        selected_atomic: AtomicPosition | None = latest_atomic_by_asset.get(asset_identifier)
 
         candidates: list[tuple[date, str, object, str | None]] = []
-        if override is not None:
-            candidates.append((override.price_date, "market_data_override", override.id, override.source.value))
-        if stock_price is not None:
-            candidates.append((stock_price.price_date, "stock_price", stock_price.id, stock_price.source))
-        if atomic is not None:
-            candidates.append((atomic.snapshot_date, "atomic_position", atomic.id, atomic.broker))
+        if selected_override is not None:
+            candidates.append(
+                (
+                    selected_override.price_date,
+                    "market_data_override",
+                    selected_override.id,
+                    selected_override.source.value,
+                )
+            )
+        if selected_stock_price is not None:
+            candidates.append(
+                (
+                    selected_stock_price.price_date,
+                    "stock_price",
+                    selected_stock_price.id,
+                    selected_stock_price.source,
+                )
+            )
+        if selected_atomic is not None:
+            candidates.append(
+                (selected_atomic.snapshot_date, "atomic_position", selected_atomic.id, selected_atomic.broker)
+            )
 
         if not candidates:
             stale_holdings.append(asset_identifier)
@@ -375,6 +401,14 @@ async def build_investment_performance_report_schedule(
         dividend_income=to_money(sum(dividend_by_asset.values(), Decimal("0.00"))),
         dividend_yield=_percent(dividend_yield),
         holdings=holding_rows,
+        market_valuation_selections=[
+            InvestmentPerformanceMarketValuationSelection(
+                asset_identifier=asset_identifier,
+                observation_id=cast(UUID, stock_price.id),
+                requested_as_of=as_of_date,
+            )
+            for asset_identifier, stock_price in sorted(latest_stock_price_by_asset.items())
+        ],
         allocation=allocation_rows,
         data_freshness=data_freshness,
         source_links=sorted(source_links),

--- a/apps/backend/src/portfolio/extension/performance_report.py
+++ b/apps/backend/src/portfolio/extension/performance_report.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import cast
+from typing import cast, overload
 from uuid import UUID
 
 from sqlalchemy import select
@@ -42,6 +42,14 @@ from src.schemas.portfolio import (
     InvestmentPerformanceMarketValuationSelection,
     InvestmentPerformanceReportScheduleResponse,
 )
+
+
+@overload
+def _percent(value: Decimal) -> Decimal: ...
+
+
+@overload
+def _percent(value: None) -> None: ...
 
 
 def _percent(value: Decimal | None) -> Decimal | None:
@@ -239,7 +247,7 @@ async def build_investment_performance_report_schedule(
                     dimension=dimension,
                     category=row.category,
                     value=to_money(row.value),
-                    percentage=row.percentage,
+                    percentage=_percent(row.percentage),
                     count=row.count,
                 )
             )

--- a/apps/backend/src/portfolio/extension/performance_report.py
+++ b/apps/backend/src/portfolio/extension/performance_report.py
@@ -59,6 +59,44 @@ def _percent(value: Decimal | None) -> Decimal | None:
     return percent_ratio.to_percent()
 
 
+def _stock_symbol(asset_identifier: str) -> str:
+    """Use the holdings service's stock-symbol normalization at every schedule boundary."""
+    return asset_identifier.strip().upper()
+
+
+def _market_valuation_selections(
+    *,
+    holdings: list[HoldingResponse],
+    stock_prices_by_symbol: dict[str, StockPrice],
+    as_of_date: date,
+    used_report_preparation_evidence: bool,
+) -> list[InvestmentPerformanceMarketValuationSelection]:
+    """Publish only external prices that the point-in-time schedule actually rendered."""
+    if used_report_preparation_evidence:
+        # This mode can render a post-period manual override; it has no
+        # point-in-time stock-price selection to freeze.
+        return []
+
+    selections: dict[tuple[str, UUID], InvestmentPerformanceMarketValuationSelection] = {}
+    for holding in holdings:
+        if holding.quantity == Decimal("0"):
+            # Snapshot holdings fall back to the atomic zero-value row rather
+            # than multiplying a provider price, so no market price was used.
+            continue
+        stock_price = stock_prices_by_symbol.get(_stock_symbol(holding.asset_identifier))
+        if stock_price is None:
+            # The point-in-time holdings service rendered the statement-backed
+            # atomic valuation, which is covered by the statement contribution.
+            continue
+        observation_id = cast(UUID, stock_price.id)
+        selections[(holding.asset_identifier, observation_id)] = InvestmentPerformanceMarketValuationSelection(
+            asset_identifier=holding.asset_identifier,
+            observation_id=observation_id,
+            requested_as_of=as_of_date,
+        )
+    return [selections[key] for key in sorted(selections)]
+
+
 def _source_document_links(source_documents: object) -> list[str]:
     if isinstance(source_documents, list):
         docs = source_documents
@@ -317,10 +355,11 @@ async def build_investment_performance_report_schedule(
         latest_override_by_asset.setdefault(override.asset_identifier, override)
 
     stock_prices: list[StockPrice] = []
-    if asset_identifiers:
+    stock_symbols = {_stock_symbol(asset_identifier) for asset_identifier in asset_identifiers}
+    if stock_symbols:
         stock_price_result = await db.execute(
             select(StockPrice)
-            .where(StockPrice.symbol.in_(asset_identifiers))
+            .where(StockPrice.symbol.in_(stock_symbols))
             .where(StockPrice.price_date <= as_of_date)
             .order_by(
                 StockPrice.price_date.desc(),
@@ -331,16 +370,16 @@ async def build_investment_performance_report_schedule(
             )
         )
         stock_prices = list(stock_price_result.scalars().all())
-    latest_stock_price_by_asset: dict[str, StockPrice] = {}
+    latest_stock_price_by_symbol: dict[str, StockPrice] = {}
     for stock_price in stock_prices:
-        latest_stock_price_by_asset.setdefault(stock_price.symbol, stock_price)
+        latest_stock_price_by_symbol.setdefault(stock_price.symbol, stock_price)
 
     price_dates: list[date] = []
     providers: set[str] = set()
     stale_holdings: list[str] = []
     for asset_identifier in asset_identifiers:
         selected_override: MarketDataOverride | None = latest_override_by_asset.get(asset_identifier)
-        selected_stock_price: StockPrice | None = latest_stock_price_by_asset.get(asset_identifier)
+        selected_stock_price: StockPrice | None = latest_stock_price_by_symbol.get(_stock_symbol(asset_identifier))
         selected_atomic: AtomicPosition | None = latest_atomic_by_asset.get(asset_identifier)
 
         candidates: list[tuple[date, str, object, str | None]] = []
@@ -409,14 +448,12 @@ async def build_investment_performance_report_schedule(
         dividend_income=to_money(sum(dividend_by_asset.values(), Decimal("0.00"))),
         dividend_yield=_percent(dividend_yield),
         holdings=holding_rows,
-        market_valuation_selections=[
-            InvestmentPerformanceMarketValuationSelection(
-                asset_identifier=asset_identifier,
-                observation_id=cast(UUID, stock_price.id),
-                requested_as_of=as_of_date,
-            )
-            for asset_identifier, stock_price in sorted(latest_stock_price_by_asset.items())
-        ],
+        market_valuation_selections=_market_valuation_selections(
+            holdings=holdings,
+            stock_prices_by_symbol=latest_stock_price_by_symbol,
+            as_of_date=as_of_date,
+            used_report_preparation_evidence=used_report_preparation_evidence,
+        ),
         allocation=allocation_rows,
         data_freshness=data_freshness,
         source_links=sorted(source_links),

--- a/apps/backend/src/pricing/__init__.py
+++ b/apps/backend/src/pricing/__init__.py
@@ -47,6 +47,7 @@ from src.pricing.base import (
     PricingError,
     ResolutionPolicy,
 )
+from src.pricing.base.contribution import MarketValuationSelection
 from src.pricing.extension import (
     MARKET_DATA_QUANTITY_UNIT,
     MARKET_DATA_SYNC_TZ,
@@ -75,6 +76,7 @@ from src.pricing.extension import (
     resolve,
     resolve_manual_valuation_contributions,
     resolve_missing_fx_rate,
+    resolve_selected_market_valuation_contribution,
     resolve_valuation_contribution,
     run_daily_market_data_sync,
     run_market_data_scheduler,
@@ -111,6 +113,7 @@ __all__ = [
     "MarketDataSyncResult",
     "ManualValuationAttestationPolicy",
     "MarketDataSyncState",
+    "MarketValuationSelection",
     "ObservationRepository",
     "ObservationSource",
     "PrefetchedFxRates",
@@ -143,6 +146,7 @@ __all__ = [
     "record_override",
     "resolve",
     "resolve_manual_valuation_contributions",
+    "resolve_selected_market_valuation_contribution",
     "resolve_valuation_contribution",
     "resolve_missing_fx_rate",
     "run_daily_market_data_sync",

--- a/apps/backend/src/pricing/base/contribution.py
+++ b/apps/backend/src/pricing/base/contribution.py
@@ -45,6 +45,15 @@ class ResolvedValuationContribution:
         return (f"pricing_observation:{self.observation_id}",)
 
 
+@dataclass(frozen=True, slots=True)
+class MarketValuationSelection:
+    """The exact market observation a report schedule rendered for one security."""
+
+    subject: PriceableSubject
+    observation_id: UUID
+    requested_as_of: date
+
+
 def resolution_policy_identity(policy: ResolutionPolicy) -> str:
     """Stable package-visible identity of one value-selection policy."""
     return f"max_age_days={policy.max_age_days};min_authority={policy.min_authority.name}"

--- a/apps/backend/src/pricing/extension/__init__.py
+++ b/apps/backend/src/pricing/extension/__init__.py
@@ -65,6 +65,7 @@ from src.pricing.extension.valuation_contribution import (
     ResolvedValuationContribution,
     pricing_trace_policy_registry,
     resolve_manual_valuation_contributions,
+    resolve_selected_market_valuation_contribution,
     resolve_valuation_contribution,
 )
 
@@ -94,6 +95,7 @@ __all__ = [
     "ResolvedMarketValuationPolicy",
     "resolve",
     "resolve_manual_valuation_contributions",
+    "resolve_selected_market_valuation_contribution",
     "resolve_valuation_contribution",
     "resolve_missing_fx_rate",
     "run_daily_market_data_sync",

--- a/apps/backend/src/pricing/extension/valuation_contribution.py
+++ b/apps/backend/src/pricing/extension/valuation_contribution.py
@@ -32,7 +32,11 @@ from src.audit import (
     VersionedTraceRef,
 )
 from src.audit.extension.trace_repository import SqlTraceRecordRepository
-from src.pricing.base.contribution import ResolvedValuationContribution, resolution_policy_identity
+from src.pricing.base.contribution import (
+    MarketValuationSelection,
+    ResolvedValuationContribution,
+    resolution_policy_identity,
+)
 from src.pricing.base.errors import NoObservationError
 from src.pricing.base.observation import (
     Authority,
@@ -392,6 +396,36 @@ async def resolve_valuation_contribution(
         observation=observation,
         as_of=as_of,
         policy=policy,
+    )
+
+
+async def resolve_selected_market_valuation_contribution(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    selection: MarketValuationSelection,
+    policy: ResolutionPolicy,
+) -> ResolvedValuationContribution:
+    """Authorize only the exact market observation already rendered by a schedule.
+
+    A package may not silently replace the schedule's source with whatever
+    happens to resolve later.  Pricing re-resolves under its published policy
+    and turns any identity mismatch into an explicit unproven input.
+    """
+    contribution = await resolve_valuation_contribution(
+        db,
+        user_id=user_id,
+        subject=selection.subject,
+        as_of=selection.requested_as_of,
+        policy=policy,
+    )
+    if contribution.is_authoritative and contribution.observation_id == selection.observation_id:
+        return contribution
+    return _unproven(
+        subject=selection.subject,
+        as_of=selection.requested_as_of,
+        policy=policy,
+        reason_code="selected_observation_mismatch",
     )
 
 

--- a/apps/backend/src/pricing/extension/valuation_contribution.py
+++ b/apps/backend/src/pricing/extension/valuation_contribution.py
@@ -419,7 +419,9 @@ async def resolve_selected_market_valuation_contribution(
         as_of=selection.requested_as_of,
         policy=policy,
     )
-    if contribution.is_authoritative and contribution.observation_id == selection.observation_id:
+    if not contribution.is_authoritative:
+        return contribution
+    if contribution.observation_id == selection.observation_id:
         return contribution
     return _unproven(
         subject=selection.subject,

--- a/apps/backend/src/reporting/extension/package_document.py
+++ b/apps/backend/src/reporting/extension/package_document.py
@@ -7,7 +7,7 @@ import json
 from collections import defaultdict
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import select
@@ -30,9 +30,12 @@ from src.extraction.extension.extraction_trace import extraction_trace_policy_re
 from src.ledger import ledger_trace_policy_registry, list_journal_contributions
 from src.portfolio import build_investment_performance_report_schedule
 from src.pricing import (
+    MarketValuationSelection,
+    PriceableSubject,
     ResolutionPolicy,
     pricing_trace_policy_registry,
     resolve_manual_valuation_contributions,
+    resolve_selected_market_valuation_contribution,
 )
 from src.reporting.base.package_contribution import PackageSectionContribution, PackageSectionId
 from src.reporting.base.package_decision import (
@@ -206,9 +209,19 @@ def _valuation_section_contribution(contribution: Any) -> PackageSectionContribu
     if not input_refs:
         identity = contribution.lineage_id or f"{contribution.subject.kind.value}:{contribution.subject.key}"
         input_refs = (f"valuation:{identity}",)
+    if contribution.subject.kind.value == "security":
+        sections = cast(
+            tuple[PackageSectionId, ...],
+            ("balance_sheet", "investment_performance", "traceability_appendix"),
+        )
+    else:
+        sections = cast(
+            tuple[PackageSectionId, ...],
+            ("balance_sheet", "annualized_income_long_term", "traceability_appendix"),
+        )
     return PackageSectionContribution(
         contribution_type="valuation",
-        section_ids=("balance_sheet", "annualized_income_long_term", "traceability_appendix"),
+        section_ids=sections,
         payload=contribution,
         state=contribution.state,
         decision_id=contribution.decision_id,
@@ -379,7 +392,7 @@ class PackageAssembler:
             as_of_date=as_of_date,
         )
         decisions_by_source_id = _policy_decisions_by_source_id(policy)
-        contributions = await self._contributions(
+        base_contributions = await self._contributions(
             db,
             user_id=user_id,
             start_date=start_date,
@@ -396,7 +409,16 @@ class PackageAssembler:
             currency=currency,
             include_restricted=include_restricted,
             decisions_by_source_id=decisions_by_source_id,
-            contributions=contributions,
+            contributions=base_contributions,
+        )
+        market_contributions = await self._selected_market_contributions(
+            db,
+            user_id=user_id,
+            selections=sections.investment_performance.market_valuation_selections,
+        )
+        contributions = (*base_contributions, *market_contributions)
+        sections.traceability_appendix = PersonalReportPackageTraceabilityResponse.model_validate(
+            await build_personal_report_package_traceability_payload(contributions=contributions)
         )
         sections.notes = _package_notes(statement_disposition_policy)
         input_manifest, unproven_input_refs = await self._input_manifest(
@@ -681,6 +703,30 @@ class PackageAssembler:
             ),
             *(_valuation_section_contribution(item) for item in valuation_results),
         )
+
+    async def _selected_market_contributions(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        selections: list[Any],
+    ) -> tuple[PackageSectionContribution[Any], ...]:
+        """Freeze only the exact external prices rendered by the investment schedule."""
+        contributions = []
+        policy = ResolutionPolicy(max_age_days=0)
+        for selection in selections:
+            contribution = await resolve_selected_market_valuation_contribution(
+                db,
+                user_id=user_id,
+                selection=MarketValuationSelection(
+                    subject=PriceableSubject.security(selection.asset_identifier),
+                    observation_id=selection.observation_id,
+                    requested_as_of=selection.requested_as_of,
+                ),
+                policy=policy,
+            )
+            contributions.append(_valuation_section_contribution(contribution))
+        return tuple(contributions)
 
     async def _input_manifest(
         self,

--- a/apps/backend/src/schemas/portfolio.py
+++ b/apps/backend/src/schemas/portfolio.py
@@ -148,7 +148,10 @@ class PriceUpdateBatchResponse(BaseModel):
     """
 
     updated_count: int = Field(..., description="Number of price overrides applied.")
-    results: list[PriceUpdateResponse] = Field(default_factory=list)
+    results: list[PriceUpdateResponse] = Field(
+        default_factory=list,
+        description="Per-asset price override results.",
+    )
 
 
 class CostBasisMethodUpdateResponse(BaseModel):
@@ -195,6 +198,14 @@ class InvestmentPerformanceHoldingRow(BaseModel):
     currency: CurrencyCode
 
 
+class InvestmentPerformanceMarketValuationSelection(BaseModel):
+    """External market observation actually used for a schedule holding."""
+
+    asset_identifier: str
+    observation_id: UUID
+    requested_as_of: date
+
+
 class InvestmentPerformanceAllocationRow(BaseModel):
     """Allocation row for one report-schedule dimension."""
 
@@ -211,7 +222,10 @@ class InvestmentPerformanceDataFreshness(BaseModel):
     latest_price_date: date | None
     market_data_provider: str | None
     stale: bool
-    stale_holdings: list[str] = Field(default_factory=list)
+    stale_holdings: list[str] = Field(
+        default_factory=list,
+        description="Holdings whose selected price predates the schedule as-of date.",
+    )
     manual_override_basis: str | None = None
 
 
@@ -230,6 +244,10 @@ class InvestmentPerformanceReportScheduleResponse(BaseModel):
     dividend_income: MoneyAmount
     dividend_yield: Annotated[Decimal | None, Field(decimal_places=2)]
     holdings: list[InvestmentPerformanceHoldingRow]
+    market_valuation_selections: list[InvestmentPerformanceMarketValuationSelection] = Field(
+        default_factory=list,
+        description="Exact external market observations rendered for schedule holdings.",
+    )
     allocation: list[InvestmentPerformanceAllocationRow]
     data_freshness: InvestmentPerformanceDataFreshness
     source_links: list[str]
@@ -285,13 +303,13 @@ class BrokerageImportResponse(BaseModel):
     """Response for brokerage position import."""
 
     broker: str
-    parsed_positions: int = Field(ge=0)
-    created_atomic_positions: int = Field(ge=0)
-    existing_atomic_positions: int = Field(ge=0)
-    reconcile_created: int = Field(ge=0)
-    reconcile_updated: int = Field(ge=0)
-    reconcile_disposed: int = Field(ge=0)
-    skipped: int = Field(ge=0)
+    parsed_positions: int = Field(ge=0, description="Parsed brokerage position count.")
+    created_atomic_positions: int = Field(ge=0, description="New immutable position snapshots created.")
+    existing_atomic_positions: int = Field(ge=0, description="Existing immutable position snapshots reused.")
+    reconcile_created: int = Field(ge=0, description="Managed positions created by reconciliation.")
+    reconcile_updated: int = Field(ge=0, description="Managed positions updated by reconciliation.")
+    reconcile_disposed: int = Field(ge=0, description="Managed positions marked disposed by reconciliation.")
+    skipped: int = Field(ge=0, description="Parsed positions skipped during import.")
     # #1484: the broker ASSET account these positions reconciled into (null when
     # no single broker account applies, e.g. zero positions or a mixed-broker
     # payload). The statements import handler also uses it to anchor the source

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -14,7 +14,7 @@ from src.extraction.orm.layer2 import AtomicPosition, AtomicTransaction, Transac
 from src.extraction.orm.layer3 import CostBasisMethod, ManagedPosition, PositionStatus
 from src.ledger import Account, AccountType
 from src.portfolio import AssetNotFoundError, DividendIncome, InvestmentTransaction, InvestmentTransactionType
-from src.pricing.orm.market_data import FxRate
+from src.pricing.orm.market_data import FxRate, StockPrice
 from src.routers import portfolio as portfolio_router
 from src.schemas.portfolio import HoldingResponse
 from tests.ledger._ledger_helpers import create_valid_posted_entry
@@ -537,6 +537,45 @@ async def test_AC17_10_1_AC17_10_2_get_investment_performance_report_schedule(
     assert data["notes"]
     if data["time_weighted_return"] is None:
         assert any("TWR unavailable" in note for note in data["notes"])
+
+
+async def test_AC17_10_1_investment_schedule_publishes_the_exact_market_observation_it_uses(
+    client: AsyncClient,
+    db: AsyncSession,
+    portfolio_with_data,
+):
+    """AC-portfolio.report-schedule.1: package consumers receive the actual stock-price identity, not a heuristic."""
+    as_of = date.today()
+    stock_price = StockPrice(
+        symbol="AAPL",
+        price=Decimal("125.05"),
+        currency="SGD",
+        price_date=as_of,
+        source="recorded-provider",
+    )
+    db.add(stock_price)
+    await db.commit()
+
+    response = await client.get(
+        "/portfolio/performance/report-schedule",
+        params={
+            "period_start": (as_of - timedelta(days=90)).isoformat(),
+            "period_end": as_of.isoformat(),
+            "as_of_date": as_of.isoformat(),
+            "currency": "SGD",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["holdings"][0]["market_value"] == "12505.00"
+    assert payload["market_valuation_selections"] == [
+        {
+            "asset_identifier": "AAPL",
+            "observation_id": str(stock_price.id),
+            "requested_as_of": as_of.isoformat(),
+        }
+    ]
 
 
 async def test_AC17_10_6_investment_performance_schedule_converts_mixed_currency_amounts(

--- a/apps/backend/tests/portfolio/test_portfolio_router.py
+++ b/apps/backend/tests/portfolio/test_portfolio_router.py
@@ -86,7 +86,7 @@ async def portfolio_with_data(db: AsyncSession, test_user, investment_account):
     )
     db.add(atomic)
     await db.commit()
-    return {"position": position, "account": investment_account}
+    return {"position": position, "atomic": atomic, "account": investment_account}
 
 
 async def test_get_holdings_empty_portfolio(client: AsyncClient):
@@ -544,8 +544,25 @@ async def test_AC17_10_1_investment_schedule_publishes_the_exact_market_observat
     db: AsyncSession,
     portfolio_with_data,
 ):
-    """AC-portfolio.report-schedule.1: package consumers receive the actual stock-price identity, not a heuristic."""
+    """AC-portfolio.report-schedule.1: freeze only prices actually used by snapshot holdings."""
     as_of = date.today()
+    position = portfolio_with_data["position"]
+    atomic = portfolio_with_data["atomic"]
+    # Match the holdings service's normalised provider lookup while preserving
+    # the source identifier rendered in the schedule.
+    position.asset_identifier = " aapl "
+    atomic.asset_identifier = " aapl "
+    zero_position = ManagedPosition(
+        user_id=position.user_id,
+        account_id=position.account_id,
+        asset_identifier="ZERO",
+        quantity=Decimal("0"),
+        cost_basis=Decimal("0.00"),
+        currency="SGD",
+        acquisition_date=as_of,
+        status=PositionStatus.ACTIVE,
+        cost_basis_method=CostBasisMethod.FIFO,
+    )
     stock_price = StockPrice(
         symbol="AAPL",
         price=Decimal("125.05"),
@@ -553,7 +570,26 @@ async def test_AC17_10_1_investment_schedule_publishes_the_exact_market_observat
         price_date=as_of,
         source="recorded-provider",
     )
-    db.add(stock_price)
+    unused_zero_stock_price = StockPrice(
+        symbol="ZERO",
+        price=Decimal("5.00"),
+        currency="SGD",
+        price_date=as_of,
+        source="recorded-provider",
+    )
+    # A zero snapshot falls back to statement value, not its provider price.
+    zero_snapshot = AtomicPosition(
+        user_id=position.user_id,
+        snapshot_date=as_of,
+        asset_identifier="ZERO",
+        broker="Investment Account",
+        quantity=Decimal("0"),
+        market_value=Decimal("0.00"),
+        currency="SGD",
+        dedup_hash="zero_schedule_market_selection",
+        source_documents={},
+    )
+    db.add_all([zero_position, stock_price, unused_zero_stock_price, zero_snapshot])
     await db.commit()
 
     response = await client.get(
@@ -568,10 +604,13 @@ async def test_AC17_10_1_investment_schedule_publishes_the_exact_market_observat
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["holdings"][0]["market_value"] == "12505.00"
+    assert (
+        next(holding for holding in payload["holdings"] if holding["asset_identifier"] == " aapl ")["market_value"]
+        == "12505.00"
+    )
     assert payload["market_valuation_selections"] == [
         {
-            "asset_identifier": "AAPL",
+            "asset_identifier": " aapl ",
             "observation_id": str(stock_price.id),
             "requested_as_of": as_of.isoformat(),
         }

--- a/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
+++ b/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
@@ -277,12 +277,24 @@ async def test_AC_pricing_valuation_contribution_6_selected_market_input_require
         ),
         policy=ResolutionPolicy(max_age_days=0),
     )
+    missing = await resolve_selected_market_valuation_contribution(
+        db,
+        user_id=test_user.id,
+        selection=MarketValuationSelection(
+            subject=PriceableSubject.security("MISSING"),
+            observation_id=uuid4(),
+            requested_as_of=as_of,
+        ),
+        policy=ResolutionPolicy(max_age_days=0),
+    )
 
     assert contribution.is_authoritative
     assert contribution.observation_id == selected_price.id
     assert contribution.decision_id is not None
     assert not mismatch.is_authoritative
     assert mismatch.reason_code == "selected_observation_mismatch"
+    assert not missing.is_authoritative
+    assert missing.reason_code == "no_eligible_observation"
 
     package_contributions = await PackageAssembler()._selected_market_contributions(
         db,

--- a/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
+++ b/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
@@ -13,14 +13,18 @@ from sqlalchemy import select
 from src.audit.orm.trace_record import TraceRecordRow
 from src.extraction.orm.layer3 import ManualValuationSnapshot
 from src.pricing import (
+    MarketValuationSelection,
     PriceableSubject,
     ResolutionPolicy,
     StockPrice,
     build_manual_valuation_lines,
     record_manual_valuation,
     resolve_manual_valuation_contributions,
+    resolve_selected_market_valuation_contribution,
     resolve_valuation_contribution,
 )
+from src.reporting.extension.package_document import PackageAssembler
+from src.schemas.portfolio import InvestmentPerformanceMarketValuationSelection
 
 pytestmark = pytest.mark.asyncio
 
@@ -234,3 +238,76 @@ async def test_AC_pricing_valuation_contribution_5_resolves_each_manual_lineage_
     assert all("confidence_tier" not in line and "trusted" not in line for line in asset_lines)
     pricing_source = Path(__file__).parents[2] / "src" / "pricing"
     assert all("confidence_tier" not in path.read_text() for path in pricing_source.rglob("*.py"))
+
+
+async def test_AC_pricing_valuation_contribution_6_selected_market_input_requires_exact_schedule_observation(
+    db,
+    test_user,
+):
+    """AC-pricing.valuation-contribution.6: a package can freeze only its schedule's exact market input."""
+    as_of = date(2026, 12, 31)
+    selected_price = StockPrice(
+        symbol="PKGSEC",
+        price=Decimal("125.05"),
+        currency="SGD",
+        price_date=as_of,
+        source="recorded-provider",
+    )
+    db.add(selected_price)
+    await db.flush()
+
+    selection = MarketValuationSelection(
+        subject=PriceableSubject.security("PKGSEC"),
+        observation_id=selected_price.id,
+        requested_as_of=as_of,
+    )
+    contribution = await resolve_selected_market_valuation_contribution(
+        db,
+        user_id=test_user.id,
+        selection=selection,
+        policy=ResolutionPolicy(max_age_days=0),
+    )
+    mismatch = await resolve_selected_market_valuation_contribution(
+        db,
+        user_id=test_user.id,
+        selection=MarketValuationSelection(
+            subject=PriceableSubject.security("PKGSEC"),
+            observation_id=uuid4(),
+            requested_as_of=as_of,
+        ),
+        policy=ResolutionPolicy(max_age_days=0),
+    )
+
+    assert contribution.is_authoritative
+    assert contribution.observation_id == selected_price.id
+    assert contribution.decision_id is not None
+    assert not mismatch.is_authoritative
+    assert mismatch.reason_code == "selected_observation_mismatch"
+
+    package_contributions = await PackageAssembler()._selected_market_contributions(
+        db,
+        user_id=test_user.id,
+        selections=[
+            InvestmentPerformanceMarketValuationSelection(
+                asset_identifier="PKGSEC",
+                observation_id=selected_price.id,
+                requested_as_of=as_of,
+            )
+        ],
+    )
+    manifest, unproven = await PackageAssembler()._input_manifest(
+        db,
+        user_id=test_user.id,
+        contributions=package_contributions,
+    )
+
+    assert len(package_contributions) == 1
+    assert package_contributions[0].is_authoritative
+    assert package_contributions[0].section_ids == (
+        "balance_sheet",
+        "investment_performance",
+        "traceability_appendix",
+    )
+    assert unproven == []
+    assert manifest[0].decision_id == contribution.decision_id
+    assert manifest[0].input_refs == [f"pricing_observation:{selected_price.id}"]

--- a/apps/backend/tests/reporting/test_package_document.py
+++ b/apps/backend/tests/reporting/test_package_document.py
@@ -280,6 +280,7 @@ def test_AC_reporting_package_document_7_manifest_folds_only_typed_contributions
         "list_statement_contributions",
         "list_journal_contributions",
         "resolve_manual_valuation_contributions",
+        "resolve_selected_market_valuation_contribution",
     ):
         assert public_boundary in assembler_source
     input_manifest_source = assembler_source.split("async def _input_manifest", 1)[1]

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -2091,36 +2091,43 @@
             "type": "string"
           },
           "created_atomic_positions": {
+            "description": "New immutable position snapshots created.",
             "minimum": 0.0,
             "title": "Created Atomic Positions",
             "type": "integer"
           },
           "existing_atomic_positions": {
+            "description": "Existing immutable position snapshots reused.",
             "minimum": 0.0,
             "title": "Existing Atomic Positions",
             "type": "integer"
           },
           "parsed_positions": {
+            "description": "Parsed brokerage position count.",
             "minimum": 0.0,
             "title": "Parsed Positions",
             "type": "integer"
           },
           "reconcile_created": {
+            "description": "Managed positions created by reconciliation.",
             "minimum": 0.0,
             "title": "Reconcile Created",
             "type": "integer"
           },
           "reconcile_disposed": {
+            "description": "Managed positions marked disposed by reconciliation.",
             "minimum": 0.0,
             "title": "Reconcile Disposed",
             "type": "integer"
           },
           "reconcile_updated": {
+            "description": "Managed positions updated by reconciliation.",
             "minimum": 0.0,
             "title": "Reconcile Updated",
             "type": "integer"
           },
           "skipped": {
+            "description": "Parsed positions skipped during import.",
             "minimum": 0.0,
             "title": "Skipped",
             "type": "integer"
@@ -4046,6 +4053,7 @@
             "type": "boolean"
           },
           "stale_holdings": {
+            "description": "Holdings whose selected price predates the schedule as-of date.",
             "items": {
               "type": "string"
             },
@@ -4118,6 +4126,32 @@
         "title": "InvestmentPerformanceHoldingRow",
         "type": "object"
       },
+      "InvestmentPerformanceMarketValuationSelection": {
+        "description": "External market observation actually used for a schedule holding.",
+        "properties": {
+          "asset_identifier": {
+            "title": "Asset Identifier",
+            "type": "string"
+          },
+          "observation_id": {
+            "format": "uuid",
+            "title": "Observation Id",
+            "type": "string"
+          },
+          "requested_as_of": {
+            "format": "date",
+            "title": "Requested As Of",
+            "type": "string"
+          }
+        },
+        "required": [
+          "asset_identifier",
+          "observation_id",
+          "requested_as_of"
+        ],
+        "title": "InvestmentPerformanceMarketValuationSelection",
+        "type": "object"
+      },
       "InvestmentPerformanceReportScheduleResponse": {
         "description": "Report-ready investment performance schedule consumed by EPIC-005.",
         "properties": {
@@ -4164,6 +4198,14 @@
               "$ref": "#/components/schemas/InvestmentPerformanceHoldingRow"
             },
             "title": "Holdings",
+            "type": "array"
+          },
+          "market_valuation_selections": {
+            "description": "Exact external market observations rendered for schedule holdings.",
+            "items": {
+              "$ref": "#/components/schemas/InvestmentPerformanceMarketValuationSelection"
+            },
+            "title": "Market Valuation Selections",
             "type": "array"
           },
           "money_weighted_return": {
@@ -7739,6 +7781,7 @@
         "description": "Typed response for ``POST /portfolio/prices/update`` (#1008).\n\nReplaces a raw ``dict`` return so the batch result is declared in OpenAPI and\nconsumable by the generated frontend client.",
         "properties": {
           "results": {
+            "description": "Per-asset price override results.",
             "items": {
               "$ref": "#/components/schemas/PriceUpdateResponse"
             },

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -253,7 +253,17 @@ CONTRACT = PackageContract(
             module="base/contribution.py",
         ),
         Unit(
+            name="MarketValuationSelection",
+            kind=Kind.VALUE_OBJECT,
+            module="base/contribution.py",
+        ),
+        Unit(
             name="resolve_valuation_contribution",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/valuation_contribution.py",
+        ),
+        Unit(
+            name="resolve_selected_market_valuation_contribution",
             kind=Kind.DOMAIN_SERVICE,
             module="extension/valuation_contribution.py",
         ),
@@ -317,6 +327,7 @@ CONTRACT = PackageContract(
         "MarketDataScopes",
         "MarketDataSyncResult",
         "MarketDataSyncState",
+        "MarketValuationSelection",
         "ManualValuationAttestationPolicy",
         "ObservationRepository",
         "ObservationSource",
@@ -351,6 +362,7 @@ CONTRACT = PackageContract(
         "pricing_trace_policy_registry",
         "resolve",
         "resolve_manual_valuation_contributions",
+        "resolve_selected_market_valuation_contribution",
         "resolve_valuation_contribution",
         "resolve_missing_fx_rate",
         "run_daily_market_data_sync",
@@ -1050,6 +1062,21 @@ CONTRACT = PackageContract(
             test=(
                 "apps/backend/tests/pricing/test_resolved_valuation_contribution.py"
                 "::test_AC_pricing_valuation_contribution_5_resolves_each_manual_lineage_without_shadow_trust"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-pricing.valuation-contribution.6",
+            statement=(
+                "A report schedule can name one selected market observation only through "
+                "pricing's typed selection boundary; pricing returns an authoritative "
+                "contribution only when its current resolved observation is that exact "
+                "identity, otherwise the package input is explicitly unproven."
+            ),
+            test=(
+                "apps/backend/tests/pricing/test_resolved_valuation_contribution.py"
+                "::test_AC_pricing_valuation_contribution_6_selected_market_input_requires_exact_schedule_observation"
             ),
             priority="P0",
             status="done",

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -46,6 +46,9 @@ policy)` call.
   selected observation, its immutable digest, the resolution policy, exact
   `TraceRecord` decision id, and an explicit `authoritative` or `unproven`
   state. It is the only valuation input a report package may freeze.
+- **`MarketValuationSelection`** — the exact external observation identity
+  actually rendered by an investment schedule; pricing verifies it against the
+  current resolution policy before a package may freeze it.
 
 ## Boundary rulings (record, don't relitigate — see #1610)
 
@@ -109,6 +112,13 @@ superseded, rejected, cross-tenant, or target-mismatched decision. A package
 may display the value as a draft input but cannot call the resulting document
 trusted. A frozen package stores the returned IDs/digests and never re-runs
 this resolution when it is reopened or exported.
+
+For market-priced holdings, the investment schedule publishes the exact
+`MarketValuationSelection` identity it rendered. Reporting passes that typed
+selection back to pricing; pricing re-resolves under its policy and accepts it
+only when the resolved observation is the same immutable identity. A source
+statement fallback remains a statement contribution, rather than being
+misrepresented as a market-price decision.
 
 Reserved (declared in [`contract.py`](./contract.py), no `module=` yet): the
 `LatestPriceView`/`StalenessView` read projections.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -6,7 +6,7 @@
 - API title: `Finance Report API`
 - API version: `0.1.0`
 - Endpoint count: `131`
-- Schema count: `253`
+- Schema count: `254`
 
 Paths below are backend OpenAPI paths. The production reverse proxy exposes them under `/api`.
 


### PR DESCRIPTION
## Root cause
`PackageAssembler` froze manual valuation contributions but never the selected `StockPrice`/market valuation decision. A package could render a market-priced holding without a causal pricing decision in its input manifest.

## Why gates missed it
Existing pricing tests proved generic market resolution and manual lineage decisions independently; package tests used fixtures or did not assert that the schedule-selected observation entered the manifest.

## Proof added
- The investment schedule publishes the exact stock-price observation it rendered.
- Pricing re-resolves that typed selection and returns `unproven` if its identity differs.
- Package assembly folds the resulting contribution into the manifest and traceability appendix.
- Regressions cover matching and mismatching observations, schedule publication, and the package boundary.

## Verification
- `apps/backend/.venv/bin/python tools/preflight.py --tier=full`
- 33 targeted pricing/reporting/portfolio/package API tests passed.
- `moon run :lint` passed.
- `moon run :test` could not start the local isolated database: Podman machine reports started but its socket remains unavailable (`127.0.0.1:61270`); this is an environment limitation, not a skipped project test.

Closes #1915