### PR TITLE
[finance-report-1894-base-purity] Ratchet base purity debt

### DIFF
--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2507,6 +2507,24 @@ CONTRACT = PackageContract(
             parent="package_model",
         ),
         ConceptRecord(
+            key="base_purity_baseline",
+            owner="common/meta/data/base-purity-baseline.json",
+            description=(
+                "Exact shrink-only inventory of legacy ORM, configuration, observability, "
+                "network, and session dependencies in package base layers; "
+                "check_base_purity rejects newly introduced or stale entries."
+            ),
+            cross_refs=[
+                "common/meta/extension/base_purity.py",
+                "common/meta/extension/check_base_purity.py",
+                "tools/check_base_purity.py",
+            ],
+            family="package_model",
+            kind="baseline",
+            authority="machine_generated",
+            parent="package_model",
+        ),
+        ConceptRecord(
             key="l4_root_import_baseline",
             owner="common/meta/data/l4-root-import-baseline.json",
             description=(

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -2519,7 +2519,7 @@ CONTRACT = PackageContract(
                 "common/meta/extension/check_base_purity.py",
                 "tools/check_base_purity.py",
             ],
-            family="package_model",
+            family="platform",
             kind="baseline",
             authority="machine_generated",
             parent="package_model",

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -363,7 +363,7 @@ CONTRACT = PackageContract(
                 "::test_AC_meta_dependency_governance_4_base_impurity_is_exact"
             ),
             priority="P0",
-            status="open",
+            status="done",
         ),
         ACRecord(
             id="AC-meta.dependency-governance.5",

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -352,6 +352,20 @@ CONTRACT = PackageContract(
             status="done",
         ),
         ACRecord(
+            id="AC-meta.dependency-governance.4",
+            statement=(
+                "Production package base layers have no new ORM, configuration, "
+                "observability, network, or session dependency; legacy findings are "
+                "an exact shrink-only baseline and an empty or unreadable scan fails."
+            ),
+            test=(
+                "tests/tooling/test_base_purity.py"
+                "::test_AC_meta_dependency_governance_4_base_impurity_is_exact"
+            ),
+            priority="P0",
+            status="open",
+        ),
+        ACRecord(
             id="AC-meta.dependency-governance.5",
             statement=(
                 "ORM-defined types are not silently added to package-root public "

--- a/common/meta/data/base-purity-baseline.json
+++ b/common/meta/data/base-purity-baseline.json
@@ -1,0 +1,16 @@
+[
+  "extraction/base/disposition.py::from src.extraction.orm.layer2 import TransactionDirection",
+  "extraction/base/validation.py::from src.extraction.orm.statement_enums import BankStatementStatus",
+  "ledger/base/contribution.py::from src.ledger.orm.account import AccountType",
+  "ledger/base/contribution.py::from src.ledger.orm.journal import Direction",
+  "ledger/base/processing.py::from src.ledger.orm.account import AccountType",
+  "ledger/base/processing.py::from src.ledger.orm.journal import Direction, JournalEntry",
+  "ledger/base/types/entry.py::from src.ledger.orm.journal import Direction",
+  "ledger/base/validators.py::from src.ledger.orm.journal import Direction, JournalEntry, JournalLine",
+  "ledger/base/validators.py::import src.config",
+  "llm/base/secrets.py::import src.config",
+  "llm/base/usage.py::from src.observability import get_logger",
+  "reconciliation/base/config.py::from src.observability import get_logger",
+  "reconciliation/base/repository.py::from src.extraction.orm.layer2 import AtomicTransaction",
+  "reconciliation/base/repository.py::from src.reconciliation.orm.reconciliation import ReconciliationMatch"
+]

--- a/common/meta/extension/base_purity.py
+++ b/common/meta/extension/base_purity.py
@@ -1,0 +1,42 @@
+"""Pure AST discovery of forbidden dependencies in package ``base`` layers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+FORBIDDEN_SEGMENTS = frozenset({"orm", "observability", "database", "session"})
+FORBIDDEN_MODULES = frozenset({"sqlalchemy", "httpx", "requests", "aiohttp"})
+
+
+def _forbidden(module: str) -> bool:
+    parts = module.split(".")
+    return (
+        parts[0] in FORBIDDEN_MODULES
+        or module == "src.config"
+        or any(part in FORBIDDEN_SEGMENTS for part in parts)
+    )
+
+
+def discover_impurities(backend_src: Path) -> list[str]:
+    """Return canonical forbidden import statements under production ``*/base``."""
+    findings: list[str] = []
+    for path in sorted(backend_src.glob("*/base/**/*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        rel = path.relative_to(backend_src)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and _forbidden(node.module)
+            ):
+                names = ", ".join(alias.name for alias in node.names)
+                findings.append(f"{rel}::from {node.module} import {names}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if _forbidden(alias.name):
+                        findings.append(f"{rel}::import {alias.name}")
+    return sorted(set(findings))

--- a/common/meta/extension/check_base_purity.py
+++ b/common/meta/extension/check_base_purity.py
@@ -1,0 +1,48 @@
+"""Fail-closed shrink-only gate for production package-base impurity debt."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from common.meta.base.gate_cli import run_gate
+from common.meta.extension.base_purity import discover_impurities
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE = REPO_ROOT / "common/meta/data/base-purity-baseline.json"
+
+
+def violations(repo_root: Path, baseline_path: Path) -> list[str]:
+    try:
+        baseline = set(json.loads(baseline_path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"cannot read base-purity baseline: {exc}"]
+    current = set(discover_impurities(repo_root / "apps/backend/src"))
+    return [
+        *(f"new base impurity: {item}" for item in sorted(current - baseline)),
+        *(f"stale base-purity baseline: {item}" for item in sorted(baseline - current)),
+    ]
+
+
+def _run_command(_argv: Sequence[str] | None = None) -> int:
+    findings = violations(REPO_ROOT, BASELINE)
+    if findings:
+        print("[BASE-PURITY] FAILED", file=sys.stderr)
+        print("\n".join(findings), file=sys.stderr)
+        return 1
+    print("[BASE-PURITY] PASSED.")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    status = _run_command(argv)
+    findings = [] if status == 0 else [f"command returned status {status}"]
+    return run_gate(
+        "BASE-PURITY", lambda _repo_root: findings, [], failure_status=status
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/common/meta/extension/check_base_purity.py
+++ b/common/meta/extension/check_base_purity.py
@@ -25,7 +25,10 @@ def violations(repo_root: Path, baseline_path: Path) -> list[str]:
         baseline = set(json.loads(baseline_path.read_text(encoding="utf-8")))
     except (OSError, json.JSONDecodeError) as exc:
         return [f"cannot read base-purity baseline: {exc}"]
-    current = set(discover_impurities(repo_root / "apps/backend/src"))
+    backend_src = repo_root / "apps/backend/src"
+    if not backend_src.is_dir():
+        return [f"cannot scan package base layers: missing directory {backend_src}"]
+    current = set(discover_impurities(backend_src))
     return [
         *(f"new base impurity: {item}" for item in sorted(current - baseline)),
         *(f"stale base-purity baseline: {item}" for item in sorted(baseline - current)),

--- a/common/meta/extension/check_base_purity.py
+++ b/common/meta/extension/check_base_purity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from collections.abc import Sequence
@@ -11,7 +12,12 @@ from common.meta.base.gate_cli import run_gate
 from common.meta.extension.base_purity import discover_impurities
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-BASELINE = REPO_ROOT / "common/meta/data/base-purity-baseline.json"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    return parser.parse_args(argv)
 
 
 def violations(repo_root: Path, baseline_path: Path) -> list[str]:
@@ -26,8 +32,11 @@ def violations(repo_root: Path, baseline_path: Path) -> list[str]:
     ]
 
 
-def _run_command(_argv: Sequence[str] | None = None) -> int:
-    findings = violations(REPO_ROOT, BASELINE)
+def _run_command(argv: Sequence[str] | None = None) -> int:
+    repo_root = parse_args(list(argv or ())).repo_root.resolve()
+    findings = violations(
+        repo_root, repo_root / "common/meta/data/base-purity-baseline.json"
+    )
     if findings:
         print("[BASE-PURITY] FAILED", file=sys.stderr)
         print("\n".join(findings), file=sys.stderr)
@@ -37,7 +46,12 @@ def _run_command(_argv: Sequence[str] | None = None) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    status = _run_command(argv)
+    try:
+        status = _run_command(argv)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 1
+    if status == 2:
+        return 2
     findings = [] if status == 0 else [f"command returned status {status}"]
     return run_gate(
         "BASE-PURITY", lambda _repo_root: findings, [], failure_status=status

--- a/common/testing/preflight.py
+++ b/common/testing/preflight.py
@@ -283,6 +283,19 @@ CHECKS: tuple[Check, ...] = (
         "types must remain an exact shrink-only baseline",
     ),
     Check(
+        name="base-purity",
+        globs=(
+            "apps/backend/src/*.py",
+            "common/meta/data/base-purity-baseline.json",
+            "common/meta/extension/base_purity.py",
+            "common/meta/extension/check_base_purity.py",
+            "tools/check_base_purity.py",
+        ),
+        commands=((PY, "tools/check_base_purity.py"),),
+        why="package base-layer or base-purity gate changed: ORM, config, observability, "
+        "network, and session debt must remain an exact shrink-only baseline",
+    ),
+    Check(
         name="frontend",
         globs=("apps/frontend/*",),
         commands=(

--- a/tests/tooling/test_base_purity.py
+++ b/tests/tooling/test_base_purity.py
@@ -1,7 +1,9 @@
 """Base-layer dependency purity ratchet for #1894."""
 
-from pathlib import Path
+from __future__ import annotations
+
 import json
+from pathlib import Path
 
 from common.meta.extension.base_purity import discover_impurities
 from common.meta.extension.check_base_purity import main, violations
@@ -37,3 +39,13 @@ def test_base_purity_gate_rejects_new_and_stale_debt(tmp_path: Path) -> None:
 
     assert any("new base impurity" in finding for finding in findings)
     assert any("stale base-purity baseline" in finding for finding in findings)
+
+
+def test_base_purity_gate_fails_when_scan_target_is_missing(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text("[]\n", encoding="utf-8")
+
+    assert any(
+        "cannot scan package base layers" in finding
+        for finding in violations(tmp_path, baseline)
+    )

--- a/tests/tooling/test_base_purity.py
+++ b/tests/tooling/test_base_purity.py
@@ -1,0 +1,38 @@
+"""Base-layer dependency purity ratchet for #1894."""
+
+from pathlib import Path
+import json
+
+from common.meta.extension.base_purity import discover_impurities
+from common.meta.extension.check_base_purity import violations
+
+
+def test_AC_meta_dependency_governance_4_base_impurity_is_exact(tmp_path: Path) -> None:
+    """AC-meta.dependency-governance.4: forbidden base dependencies are explicit."""
+    src = tmp_path / "apps/backend/src"
+    (src / "ledger/base").mkdir(parents=True)
+    (src / "ledger/base/rule.py").write_text(
+        "from src.ledger.orm.journal import JournalEntry\n", encoding="utf-8"
+    )
+    (src / "ledger/base/pure.py").write_text(
+        "from decimal import Decimal\n", encoding="utf-8"
+    )
+
+    assert discover_impurities(src) == [
+        "ledger/base/rule.py::from src.ledger.orm.journal import JournalEntry"
+    ]
+
+
+def test_base_purity_gate_rejects_new_and_stale_debt(tmp_path: Path) -> None:
+    src = tmp_path / "apps/backend/src/ledger/base"
+    src.mkdir(parents=True)
+    (src / "rule.py").write_text("import src.config\n", encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(["retired/base.py::import src.config"]), encoding="utf-8"
+    )
+
+    findings = violations(tmp_path, baseline)
+
+    assert any("new base impurity" in finding for finding in findings)
+    assert any("stale base-purity baseline" in finding for finding in findings)

--- a/tests/tooling/test_base_purity.py
+++ b/tests/tooling/test_base_purity.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import json
 
 from common.meta.extension.base_purity import discover_impurities
-from common.meta.extension.check_base_purity import violations
+from common.meta.extension.check_base_purity import main, violations
 
 
 def test_AC_meta_dependency_governance_4_base_impurity_is_exact(tmp_path: Path) -> None:
@@ -21,6 +21,7 @@ def test_AC_meta_dependency_governance_4_base_impurity_is_exact(tmp_path: Path) 
     assert discover_impurities(src) == [
         "ledger/base/rule.py::from src.ledger.orm.journal import JournalEntry"
     ]
+    assert main() == 0
 
 
 def test_base_purity_gate_rejects_new_and_stale_debt(tmp_path: Path) -> None:

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -104,6 +104,15 @@ class TestSelectChecks:
         ]
         assert "public-orm-exports" in names
 
+    def test_backend_source_edit_selects_base_purity(self):
+        names = [
+            c.name
+            for c in preflight.select_checks(
+                ["apps/backend/src/reconciliation/base/repository.py"]
+            )
+        ]
+        assert "base-purity" in names
+
     def test_migration_edit_selects_migration_risk(self):
         names = [
             c.name

--- a/tests/tooling/test_preflight.py
+++ b/tests/tooling/test_preflight.py
@@ -105,13 +105,12 @@ class TestSelectChecks:
         assert "public-orm-exports" in names
 
     def test_backend_source_edit_selects_base_purity(self):
-        names = [
-            c.name
-            for c in preflight.select_checks(
-                ["apps/backend/src/reconciliation/base/repository.py"]
-            )
-        ]
-        assert "base-purity" in names
+        selected = preflight.select_checks(
+            ["apps/backend/src/reconciliation/base/repository.py"]
+        )
+
+        base_purity = next(check for check in selected if check.name == "base-purity")
+        assert base_purity.commands == ((preflight.PY, "tools/check_base_purity.py"),)
 
     def test_migration_edit_selects_migration_risk(self):
         names = [

--- a/tests/tooling/test_s4_gate_contracts.py
+++ b/tests/tooling/test_s4_gate_contracts.py
@@ -53,6 +53,7 @@ MIGRATED_GATE_MODULES = (
     "common.meta.extension.check_ac_proof_kind",
     "common.meta.extension.check_ac_tier_baseline",
     "common.meta.extension.check_app_boundary",
+    "common.meta.extension.check_base_purity",
     "common.meta.extension.check_context_contract",
     "common.meta.extension.check_authority_reconcile",
     "common.meta.extension.check_draft_packages",

--- a/tools/check_base_purity.py
+++ b/tools/check_base_purity.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Command wrapper for the base-purity shrink-only gate."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.meta.extension.check_base_purity import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_base_purity.py
+++ b/tools/check_base_purity.py
@@ -4,9 +4,9 @@
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from common.meta.extension.check_base_purity import main  # noqa: E402
 

--- a/tools/check_base_purity.py
+++ b/tools/check_base_purity.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Command wrapper for the base-purity shrink-only gate."""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
@@ -10,5 +12,5 @@ if str(ROOT_DIR) not in sys.path:
 
 from common.meta.extension.check_base_purity import main  # noqa: E402
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())


### PR DESCRIPTION
Part of #1894. Adds exact shrink-only base-layer impurity discovery/baseline for ORM, application config, observability, database/session and network imports. Verification: base-purity gate, package contract, AC index, static preflight.