### PR TITLE
[finance-report-696-trusted-year-v0] Add trusted year v0 terminal proof

### DIFF
--- a/apps/backend/tests/integration/test_trusted_year_scenario.py
+++ b/apps/backend/tests/integration/test_trusted_year_scenario.py
@@ -5,11 +5,25 @@ from __future__ import annotations
 import hashlib
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from uuid import uuid4
 
+import pytest
 from common.testing.ac_proof import ac_proof
 from common.testing.trusted_year import TRUSTED_YEAR_SCENARIO
+from sqlalchemy import select
 
-from src.audit import SqlTraceRecordRepository, TraceEmitter
+from src.audit import (
+    SqlTraceRecordRepository,
+    TraceEmitter,
+    TraceRecord,
+    TraceRecordPersistenceError,
+    TraceRecordType,
+    TraceResult,
+    TraceScope,
+    VersionedTraceRef,
+    current_authoritative_trace_decision_projection,
+)
+from src.audit.orm.trace_record import TraceRecordParentRow, TraceRecordRow
 from src.config import settings
 from src.database import create_session_maker_from_db
 from src.deps import PaginationParams
@@ -47,6 +61,7 @@ from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Account, AccountType, post_opening_balance_entry
 from src.pricing import record_manual_valuation
 from src.pricing.orm.market_data import StockPrice
+from src.reporting import PackageAssembler
 from src.routers.reports import (
     PackageSnapshotExportFormat,
     export_personal_report_package_snapshot,
@@ -219,10 +234,106 @@ async def _stream_body(response) -> str:
     return "".join([chunk.decode() if isinstance(chunk, bytes) else chunk async for chunk in response.body_iterator])
 
 
+async def _supersede_selected_authority_parents(db, *, user_id, document) -> None:
+    """Invalidate selected authority through the append-only graph product reads."""
+    decision_ids = {entry.decision_id for entry in document.input_manifest}
+    projection = current_authoritative_trace_decision_projection(TraceScope.tenant(user_id)).subquery(
+        "trusted_year_current_decisions"
+    )
+    current_ids = set(
+        (await db.execute(select(projection.c.decision_id).where(projection.c.decision_id.in_(decision_ids)))).scalars()
+    )
+    assert current_ids == decision_ids
+
+    observation_ids: set = set()
+    frontier = decision_ids
+    visited = set(decision_ids)
+    while frontier:
+        parent_ids = set(
+            (
+                await db.execute(
+                    select(TraceRecordParentRow.parent_id).where(TraceRecordParentRow.record_id.in_(frontier))
+                )
+            ).scalars()
+        )
+        unseen = parent_ids - visited
+        if not unseen:
+            break
+        rows = (
+            await db.execute(select(TraceRecordRow.id, TraceRecordRow.record_type).where(TraceRecordRow.id.in_(unseen)))
+        ).all()
+        observation_ids.update(
+            record_id for record_id, record_type in rows if record_type is TraceRecordType.OBSERVATION
+        )
+        frontier = {record_id for record_id, record_type in rows if record_type is TraceRecordType.DECISION}
+        visited.update(unseen)
+    assert observation_ids
+    repository = SqlTraceRecordRepository(db)
+    parents = [
+        parent
+        for parent_id in sorted(observation_ids, key=str)
+        if (parent := await repository.get(TraceScope.tenant(user_id), parent_id)) is not None
+    ]
+    assert {parent.record_id for parent in parents} == observation_ids
+
+    def correction(parent, *, scope, target_id: str, suffix: str) -> TraceRecord:
+        return TraceRecord.observation(
+            scope=scope,
+            target=VersionedTraceRef(
+                parent.target.kind,
+                target_id,
+                f"{parent.target.version}:{suffix}",
+            ),
+            target_class=parent.target_class,
+            assertion=parent.assertion,
+            authority=parent.authority,
+            result=TraceResult.UNPROVEN,
+            execution_id=f"trusted-year-v0:{suffix}:{parent.record_id}",
+            evidence_manifest_digest=hashlib.sha256(
+                f"trusted-year-v0:{suffix}:{parent.record_id}".encode()
+            ).hexdigest(),
+            occurred_at=datetime.now(UTC),
+            score=None,
+            reason_code="trusted_year_authority_counterfactual",
+            supersedes_id=parent.record_id,
+        )
+
+    first = parents[0]
+    with pytest.raises(TraceRecordPersistenceError, match="cross-scope"):
+        await repository.append(
+            correction(
+                first,
+                scope=TraceScope.tenant(uuid4()),
+                target_id=first.target.id,
+                suffix="cross-scope",
+            )
+        )
+    with pytest.raises(TraceRecordPersistenceError, match="lineage"):
+        await repository.append(
+            correction(
+                first,
+                scope=first.scope,
+                target_id=f"{first.target.id}:mismatch",
+                suffix="target-mismatch",
+            )
+        )
+
+    for parent in parents:
+        await repository.append(
+            correction(
+                parent,
+                scope=parent.scope,
+                target_id=parent.target.id,
+                suffix="superseded",
+            )
+        )
+
+
 @ac_proof(
     "trusted-year-v0-terminal",
     ac_ids=[
         "AC-testing.trusted-year.2",
+        "AC-testing.trusted-year.3",
         "AC-testing.package-lifecycle.1",
     ],
     scope="behavioral",
@@ -236,7 +347,7 @@ async def _stream_body(response) -> str:
 async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_lifecycle(
     db, test_user, monkeypatch
 ) -> None:
-    """AC-testing.trusted-year.2 AC-testing.package-lifecycle.1."""
+    """AC-testing.trusted-year.2 AC-testing.trusted-year.3 AC-testing.package-lifecycle.1."""
     scenario = TRUSTED_YEAR_SCENARIO
     monkeypatch.setattr(settings, "enable_ai_classification", True)
 
@@ -331,15 +442,22 @@ async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_l
     assert document.sections.balance_sheet.net_income == expected.net_income
     assert document.sections.balance_sheet.net_worth_adjustment_gain_loss == expected.net_worth_adjustment
     assert document.sections.balance_sheet.is_balanced
+    assert document.sections.balance_sheet.assets
+    assert document.sections.income_statement.income
+    assert document.sections.income_statement.expenses
     assert document.sections.income_statement.net_income == expected.net_income
     assert document.sections.cash_flow.summary.ending_cash == expected.ending_cash
     assert document.sections.cash_flow.summary.investing_activities == -expected.investment_purchase
+    assert document.sections.cash_flow.operating
+    assert document.sections.cash_flow.investing
     holding = next(
         item
         for item in document.sections.investment_performance.holdings
         if item.asset_identifier == scenario.position.symbol
     )
     assert holding.market_value == expected.investment_market_value
+    assert document.sections.notes.notes
+    assert document.sections.traceability_appendix.lines
     assert document.readiness.input_coverage.unproven_input_count == 0
     manifest_refs = {input_ref for entry in document.input_manifest for input_ref in entry.input_refs}
     assert {input_ref.partition(":")[0] for input_ref in manifest_refs} == set(scenario.expected_manifest)
@@ -363,6 +481,30 @@ async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_l
     assert str(snapshot.id) in json_body
     assert "115250.00" in json_body
     assert "balance_sheet.total_assets" in await _stream_body(csv_export)
+
+    authority_counterfactual = await db.begin_nested()
+    await _supersede_selected_authority_parents(
+        db,
+        user_id=test_user.id,
+        document=document,
+    )
+    candidate = await PackageAssembler().assemble(
+        db,
+        user_id=test_user.id,
+        framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 12, 31),
+        as_of_date=date(2026, 12, 31),
+        currency="SGD",
+        include_restricted=True,
+    )
+    assert candidate.status is PersonalReportPackageSnapshotStatus.DRAFT
+    assert candidate.readiness.state is PersonalReportPackageReadinessState.BLOCKED
+    assert candidate.package_decision_id is None
+    assert candidate.readiness.input_coverage.unproven_input_count > 0
+    assert "unproven_package_input" in {blocker.code for blocker in candidate.readiness.blockers}
+    await authority_counterfactual.rollback()
+    db.expire_all()
 
     db.add(
         StockPrice(

--- a/apps/backend/tests/integration/test_trusted_year_scenario.py
+++ b/apps/backend/tests/integration/test_trusted_year_scenario.py
@@ -362,7 +362,7 @@ async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_l
         ]
 
     monkeypatch.setattr(transaction_classification, "propose_categories", deterministic_proposer)
-    bank = Account(user_id=test_user.id, name="DBS Cash", type=AccountType.ASSET, currency="SGD")
+    bank = Account(user_id=test_user.id, name="DBS", type=AccountType.ASSET, currency="SGD")
     securities = Account(
         user_id=test_user.id,
         name="Asset - Securities",

--- a/apps/backend/tests/integration/test_trusted_year_scenario.py
+++ b/apps/backend/tests/integration/test_trusted_year_scenario.py
@@ -504,7 +504,6 @@ async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_l
     assert candidate.readiness.input_coverage.unproven_input_count > 0
     assert "unproven_package_input" in {blocker.code for blocker in candidate.readiness.blockers}
     await authority_counterfactual.rollback()
-    db.expire_all()
 
     db.add(
         StockPrice(

--- a/apps/backend/tests/integration/test_trusted_year_scenario.py
+++ b/apps/backend/tests/integration/test_trusted_year_scenario.py
@@ -1,0 +1,392 @@
+"""Executable TrustedYearScenario v0 terminal proof (#696)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from common.testing.ac_proof import ac_proof
+from common.testing.trusted_year import TRUSTED_YEAR_SCENARIO
+
+from src.audit import SqlTraceRecordRepository, TraceEmitter
+from src.config import settings
+from src.database import create_session_maker_from_db
+from src.deps import PaginationParams
+from src.extraction import DocumentType, ParseJob, UploadedDocument
+from src.extraction.base.result import (
+    ExtractedPositionFact,
+    ExtractionMethod,
+    SourceProvenance,
+    StatementEvidenceType,
+    StatementExtractionResult,
+    StatementSourceType,
+)
+from src.extraction.extension import transaction_classification
+from src.extraction.extension.extraction_trace import (
+    build_extraction_trace_records,
+    extraction_trace_policy_registry,
+)
+from src.extraction.extension.reviewed_statement_envelope import (
+    ReviewedStatementEnvelopeCommand,
+    confirm_reviewed_statement_envelope,
+    persist_statement_extraction_result,
+)
+from src.extraction.extension.statement_posting import auto_create_posted_entries_for_statement
+from src.extraction.extension.statement_validation import approve_statement, resolve_statement_transactions
+from src.extraction.extension.transaction_classification import CategoryProposal, TransactionCategory
+from src.extraction.orm.layer3 import (
+    ClassificationRule,
+    ManualValuationComponentType,
+    ManualValuationLiquidityClass,
+    RuleType,
+)
+from src.extraction.orm.reviewed_statement_envelope import StatementExtractionResultRecord
+from src.extraction.orm.statement_enums import BankStatementStatus
+from src.extraction.orm.statement_summary import StatementSummary
+from src.ledger import Account, AccountType, post_opening_balance_entry
+from src.pricing import record_manual_valuation
+from src.pricing.orm.market_data import StockPrice
+from src.routers.reports import (
+    PackageSnapshotExportFormat,
+    export_personal_report_package_snapshot,
+    generate_personal_report_package_snapshot,
+    get_personal_report_package_snapshot,
+    list_personal_report_package_snapshots,
+)
+from src.routers.statements import import_brokerage_statement_positions
+from src.schemas import (
+    PersonalReportingFrameworkId,
+    PersonalReportPackageGenerateRequest,
+    PersonalReportPackageReadinessState,
+    PersonalReportPackageSnapshotStatus,
+)
+from tests.statement_ingestion import execute_statement_ingestion, posting_dependencies
+
+
+def _bank_csv() -> bytes:
+    return (
+        b"Statement Currency,Date,Description,Debit Amount,Credit Amount\n"
+        b"SGD,2026-06-05,Salary credit,,5000.00\n"
+        b"SGD,2026-06-10,Rent debit,1000.00,\n"
+        b"SGD,2026-06-15,Buy security,1000.00,\n"
+    )
+
+
+async def _ingest_reviewed_bank_statement(db, *, user_id, bank: Account) -> None:
+    content = _bank_csv()
+    digest = hashlib.sha256(content).hexdigest()
+    bank_id = bank.id
+    statement = StatementSummary(
+        user_id=user_id,
+        file_hash=digest,
+        institution="DBS",
+        status=BankStatementStatus.UPLOADED,
+    )
+    db.add(statement)
+    await db.flush()
+    statement_id = statement.id
+    await db.commit()
+    await execute_statement_ingestion(
+        ParseJob(
+            statement_id=statement_id,
+            filename="trusted-year-v0.csv",
+            institution="DBS",
+            user_id=user_id,
+            account_id=bank_id,
+            file_hash=digest,
+            storage_key="trusted-year/v0.csv",
+            model=None,
+        ),
+        content=content,
+        session_maker=create_session_maker_from_db(db),
+    )
+    db.expire_all()
+    statement = await db.get(StatementSummary, statement_id)
+    assert statement is not None
+    transactions = await resolve_statement_transactions(db, statement)
+    source_record = await db.get(StatementExtractionResultRecord, statement.current_extraction_result_id)
+    assert source_record is not None
+    statement.account_id = bank_id
+    statement.currency = "SGD"
+    statement.period_start = min(transaction.txn_date for transaction in transactions)
+    statement.period_end = max(transaction.txn_date for transaction in transactions)
+    statement.opening_balance = TRUSTED_YEAR_SCENARIO.opening_cash
+    statement.closing_balance = TRUSTED_YEAR_SCENARIO.expected.ending_cash
+    await db.flush()
+    emitter = TraceEmitter(SqlTraceRecordRepository(db, extraction_trace_policy_registry()))
+    await confirm_reviewed_statement_envelope(
+        db,
+        user_id=user_id,
+        statement_id=statement.id,
+        command=ReviewedStatementEnvelopeCommand(
+            source_result_digest=source_record.content_digest,
+            account_id=bank_id,
+            currency="SGD",
+            period_start=statement.period_start,
+            period_end=statement.period_end,
+            opening_balance=statement.opening_balance,
+            closing_balance=statement.closing_balance,
+            rationale="TrustedYearScenario v0 reviewed source envelope.",
+        ),
+        trace_emitter=emitter,
+    )
+    approved = await approve_statement(db, statement.id, user_id)
+    outcome = await auto_create_posted_entries_for_statement(db, approved, user_id, dependencies=posting_dependencies())
+    assert outcome.review_reasons == ()
+    assert outcome.created_count == 3
+
+
+async def _import_brokerage_position(db, *, user_id) -> None:
+    position = TRUSTED_YEAR_SCENARIO.position
+    digest = hashlib.sha256(f"trusted-year-v0:{position.institution}:{position.symbol}".encode()).hexdigest()
+    result = StatementExtractionResult.create(
+        producer_version="trusted-year-v0@1",
+        source_content_digest=digest,
+        source_type=StatementSourceType.BROKERAGE,
+        evidence_type=StatementEvidenceType.POSITION_SNAPSHOT,
+        institution=position.institution,
+        account_last4="2026",
+        period_start=position.as_of,
+        period_end=position.as_of,
+        balances=(),
+        transactions=(),
+        positions=(
+            ExtractedPositionFact(
+                fact_id="trusted-year-v0-aapl",
+                symbol=position.symbol,
+                quantity=position.quantity,
+                market_value=position.source_value,
+                currency="SGD",
+                confidence=Decimal("0.95"),
+                asset_type="stock",
+            ),
+        ),
+        confidence=Decimal("0.95"),
+        balance_validated=True,
+        warnings=(),
+        review_reasons=(),
+        provenance=SourceProvenance(
+            intake_mode="csv",
+            method=ExtractionMethod.DETERMINISTIC,
+            provider="trusted-year-v0-brokerage",
+            model="v1",
+        ),
+        statement_currency="SGD",
+    )
+    document = UploadedDocument(
+        user_id=user_id,
+        file_path=f"memory://trusted-year/{digest}",
+        file_hash=digest,
+        original_filename="trusted-year-v0-moomoo.csv",
+        document_type=DocumentType.BROKERAGE_STATEMENT,
+    )
+    db.add(document)
+    await db.flush()
+    statement = StatementSummary(
+        user_id=user_id,
+        uploaded_document_id=document.id,
+        file_hash=digest,
+        institution=position.institution,
+        account_last4="2026",
+        currency="SGD",
+        period_start=position.as_of,
+        period_end=position.as_of,
+        status=BankStatementStatus.PARSED,
+        extraction_metadata={"statement_extraction_result": result.to_payload()},
+    )
+    db.add(statement)
+    await db.flush()
+    traces = build_extraction_trace_records(
+        result,
+        user_id=user_id,
+        execution_id=f"trusted-year-v0:{statement.id}:{result.result_id}",
+        occurred_at=datetime.now(UTC),
+    )
+    await TraceEmitter(SqlTraceRecordRepository(db, extraction_trace_policy_registry())).emit_many(traces)
+    await persist_statement_extraction_result(
+        db,
+        statement=statement,
+        result=result,
+        source_trace_record_id=traces[0].record_id,
+    )
+    await db.commit()
+    imported = await import_brokerage_statement_positions(statement.id, db, user_id)
+    assert (imported.parsed_positions, imported.created_atomic_positions) == (1, 1)
+
+
+async def _stream_body(response) -> str:
+    return "".join([chunk.decode() if isinstance(chunk, bytes) else chunk async for chunk in response.body_iterator])
+
+
+@ac_proof(
+    "trusted-year-v0-terminal",
+    ac_ids=[
+        "AC-testing.trusted-year.2",
+        "AC-testing.package-lifecycle.1",
+    ],
+    scope="behavioral",
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    source_classes=["bank_statement", "brokerage_statement"],
+    scenario_id="trusted-year-v0",
+    oracle_kind="independent_decimal",
+    issue="#696",
+)
+async def test_AC_testing_trusted_year_2_deterministic_executor_proves_package_lifecycle(
+    db, test_user, monkeypatch
+) -> None:
+    """AC-testing.trusted-year.2 AC-testing.package-lifecycle.1."""
+    scenario = TRUSTED_YEAR_SCENARIO
+    monkeypatch.setattr(settings, "enable_ai_classification", True)
+
+    async def deterministic_proposer(transactions, _policy):
+        categories = {
+            "Salary credit": TransactionCategory.SALARY,
+            "Rent debit": TransactionCategory.HOUSING,
+        }
+        return [
+            CategoryProposal(category=categories[item.description].value, confidence=99, reason="trusted-year-v0")
+            for item in transactions
+        ]
+
+    monkeypatch.setattr(transaction_classification, "propose_categories", deterministic_proposer)
+    bank = Account(user_id=test_user.id, name="DBS Cash", type=AccountType.ASSET, currency="SGD")
+    securities = Account(
+        user_id=test_user.id,
+        name="Asset - Securities",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    db.add_all((bank, securities))
+    await db.flush()
+    db.add(
+        ClassificationRule(
+            user_id=test_user.id,
+            created_by=test_user.id,
+            version_number=1,
+            effective_date=date(2026, 1, 1),
+            rule_name="Reviewed TrustedYear investment purchase",
+            rule_type=RuleType.KEYWORD_MATCH,
+            rule_config={"keywords": ["Buy security"]},
+            tag_mappings={"intent": "investment_purchase"},
+            default_account_id=securities.id,
+        )
+    )
+    await post_opening_balance_entry(
+        db,
+        test_user.id,
+        entry_date=date(2026, 1, 1),
+        balances={bank.id: scenario.opening_cash},
+        currency="SGD",
+        memo="TrustedYearScenario v0 opening cash",
+    )
+    await _ingest_reviewed_bank_statement(db, user_id=test_user.id, bank=bank)
+    await _import_brokerage_position(db, user_id=test_user.id)
+    db.add(
+        StockPrice(
+            symbol=scenario.position.symbol,
+            price=scenario.position.selected_value / scenario.position.quantity,
+            currency="SGD",
+            price_date=scenario.position.as_of,
+            source="trusted-year-v0-recorded-provider",
+        )
+    )
+    valuation = scenario.valuation
+    await record_manual_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType(valuation.component_type),
+        liquidity_class=ManualValuationLiquidityClass(valuation.liquidity_class),
+        as_of=valuation.as_of,
+        value=valuation.value,
+        currency="SGD",
+        source=valuation.source,
+    )
+    await db.commit()
+
+    async def skip_market_refresh(*_args, **_kwargs) -> None:
+        pass
+
+    monkeypatch.setattr("src.routers.reports._ensure_report_market_data_fresh", skip_market_refresh)
+    snapshot = await generate_personal_report_package_snapshot(
+        db,
+        user_id=test_user.id,
+        request=PersonalReportPackageGenerateRequest(
+            framework_id=PersonalReportingFrameworkId.US_GAAP_LIKE,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+            as_of_date=date(2026, 12, 31),
+            currency="SGD",
+            include_restricted=True,
+        ),
+    )
+    document = snapshot.document
+    expected = scenario.expected
+    assert snapshot.status is PersonalReportPackageSnapshotStatus.TRUSTED
+    assert document.readiness.state is PersonalReportPackageReadinessState.READY, document.readiness.blockers
+    assert document.sections.balance_sheet.total_assets == expected.total_assets
+    assert document.sections.balance_sheet.total_liabilities == expected.total_liabilities
+    assert document.sections.balance_sheet.total_equity == expected.ledger_equity
+    assert document.sections.balance_sheet.net_income == expected.net_income
+    assert document.sections.balance_sheet.net_worth_adjustment_gain_loss == expected.net_worth_adjustment
+    assert document.sections.balance_sheet.is_balanced
+    assert document.sections.income_statement.net_income == expected.net_income
+    assert document.sections.cash_flow.summary.ending_cash == expected.ending_cash
+    assert document.sections.cash_flow.summary.investing_activities == -expected.investment_purchase
+    holding = next(
+        item
+        for item in document.sections.investment_performance.holdings
+        if item.asset_identifier == scenario.position.symbol
+    )
+    assert holding.market_value == expected.investment_market_value
+    assert document.readiness.input_coverage.unproven_input_count == 0
+    manifest_refs = {input_ref for entry in document.input_manifest for input_ref in entry.input_refs}
+    assert {input_ref.partition(":")[0] for input_ref in manifest_refs} == set(scenario.expected_manifest)
+    assert all(
+        entry.decision_id and entry.target_kind and entry.target_id and entry.assertion_kind and entry.authority_tier
+        for entry in document.input_manifest
+    )
+
+    frozen = document.model_dump(mode="json")
+    listed = await list_personal_report_package_snapshots(db, test_user.id, pagination=PaginationParams())
+    assert [item.id for item in listed] == [snapshot.id]
+    reopened = await get_personal_report_package_snapshot(snapshot.id, db, test_user.id)
+    assert reopened.document.model_dump(mode="json") == frozen
+    json_export = await export_personal_report_package_snapshot(
+        snapshot.id, db, test_user.id, format=PackageSnapshotExportFormat.JSON
+    )
+    csv_export = await export_personal_report_package_snapshot(
+        snapshot.id, db, test_user.id, format=PackageSnapshotExportFormat.CSV
+    )
+    json_body = await _stream_body(json_export)
+    assert str(snapshot.id) in json_body
+    assert "115250.00" in json_body
+    assert "balance_sheet.total_assets" in await _stream_body(csv_export)
+
+    db.add(
+        StockPrice(
+            symbol=scenario.position.symbol,
+            price=Decimal("200.00"),
+            currency="SGD",
+            price_date=scenario.position.as_of,
+            source="trusted-year-v0-later-price",
+        )
+    )
+    await record_manual_valuation(
+        db,
+        test_user.id,
+        component_type=ManualValuationComponentType(valuation.component_type),
+        liquidity_class=ManualValuationLiquidityClass(valuation.liquidity_class),
+        as_of=valuation.as_of,
+        value=Decimal("200000.00"),
+        currency="SGD",
+        source=valuation.source,
+    )
+    await db.commit()
+    reopened_after_mutation = await get_personal_report_package_snapshot(snapshot.id, db, test_user.id)
+    assert reopened_after_mutation.document.model_dump(mode="json") == frozen
+    export_after_mutation = await export_personal_report_package_snapshot(
+        snapshot.id, db, test_user.id, format=PackageSnapshotExportFormat.JSON
+    )
+    assert await _stream_body(export_after_mutation) == json_body

--- a/common/testing/ac_proof.py
+++ b/common/testing/ac_proof.py
@@ -57,6 +57,8 @@ class AcProof:
     source_classes: tuple[str, ...] = ()
     mirror_proof_id: str = ""
     issue: str = ""
+    scenario_id: str = ""
+    oracle_kind: str = ""
     required_markers: tuple[str, ...] = ()
     outcomes: tuple[str, ...] = field(default_factory=tuple)
 
@@ -73,6 +75,8 @@ def ac_proof(
     source_classes: list[str] | tuple[str, ...] = (),
     mirror_proof_id: str = "",
     issue: str = "",
+    scenario_id: str = "",
+    oracle_kind: str = "",
     required_markers: list[str] | tuple[str, ...] = (),
     outcomes: list[str] | tuple[str, ...] = (),
 ) -> Callable[[F], F]:
@@ -108,6 +112,8 @@ def ac_proof(
         source_classes=tuple(source_classes),
         mirror_proof_id=mirror_proof_id,
         issue=issue,
+        scenario_id=scenario_id,
+        oracle_kind=oracle_kind,
         required_markers=tuple(required_markers),
         outcomes=tuple(outcomes),
     )

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -72,6 +72,7 @@ CONTRACT = PackageContract(
     units=[
         Unit(name="Cassette", kind=Kind.VALUE_OBJECT),
         Unit(name="FixtureDocument", kind=Kind.VALUE_OBJECT),
+        Unit(name="TrustedYearScenario", kind=Kind.ENTITY),
     ],
     implementations={"be": "common/testing", "fe": None},
     interface=["money_amount"],
@@ -4017,8 +4018,92 @@ CONTRACT = PackageContract(
             priority="P2",
             status="done",
         ),
+        ACRecord(
+            id="AC-testing.capability-proof.1",
+            statement=(
+                "A PR-CI behavioral proof is collected with an explicit scenario id "
+                "and independent oracle kind, and its execution is reconciled from JUnit."
+            ),
+            test=(
+                "tests/tooling/test_trusted_year_scenario.py::"
+                "test_AC_testing_capability_proof_1_collector_preserves_scenario_binding"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.capability-proof.2",
+            statement=(
+                "One terminal proof binds exactly one scenario to one independent oracle; "
+                "blank or stitched proof bindings are rejected."
+            ),
+            test=(
+                "tests/tooling/test_trusted_year_scenario.py::"
+                "test_AC_testing_capability_proof_2_binding_rejects_stitching"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.trusted-year.1",
+            statement=(
+                "TrustedYearScenario is a testing-owned immutable entity whose monetary "
+                "inputs and independently authored expected outputs are exact Decimals."
+            ),
+            test=(
+                "tests/tooling/test_trusted_year_scenario.py::"
+                "test_AC_testing_trusted_year_1_scenario_is_small_exact_and_closed"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.trusted-year.2",
+            statement=(
+                "The v0 scenario deterministically traverses reviewed source authority, "
+                "ledger posting, valuation, and every report section to exact oracle values."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_trusted_year_scenario.py::"
+                "test_AC_testing_trusted_year_2_deterministic_executor_proves_package_lifecycle"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-testing.package-lifecycle.1",
+            statement=(
+                "A trusted package can be generated, listed, reopened, and exported without "
+                "later source or valuation mutations changing its frozen document."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_trusted_year_scenario.py::"
+                "test_AC_testing_trusted_year_2_deterministic_executor_proves_package_lifecycle"
+            ),
+            priority="P0",
+            status="done",
+        ),
     ],
     concepts=[
+        ConceptRecord(
+            key="trusted_year_scenario",
+            owner="common/testing/README.md#trusted-year-scenario",
+            description=(
+                "Small immutable annual input, independent Decimal oracle, and "
+                "single-proof binding for terminal report-package verification."
+            ),
+            cross_refs=[
+                "common/testing/trusted_year.py",
+                "apps/backend/tests/integration/test_trusted_year_scenario.py",
+                "tests/tooling/test_trusted_year_scenario.py",
+            ],
+            proofs=[
+                "tests/tooling/test_trusted_year_scenario.py",
+                "apps/backend/tests/integration/test_trusted_year_scenario.py",
+            ],
+            family="tdd",
+            kind="concept",
+        ),
         ConceptRecord(
             key="tool_shim_contract",
             owner="common/testing/tool_shim_contract.py",

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4071,6 +4071,20 @@ CONTRACT = PackageContract(
             status="done",
         ),
         ACRecord(
+            id="AC-testing.trusted-year.3",
+            statement=(
+                "Cross-scope and target-mismatched authority mutations are rejected, "
+                "and superseding every authority parent in the selected manifest makes "
+                "the next package candidate draft/unproven without changing the frozen package."
+            ),
+            test=(
+                "apps/backend/tests/integration/test_trusted_year_scenario.py::"
+                "test_AC_testing_trusted_year_2_deterministic_executor_proves_package_lifecycle"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
             id="AC-testing.package-lifecycle.1",
             statement=(
                 "A trusted package can be generated, listed, reopened, and exported without "

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4101,7 +4101,7 @@ CONTRACT = PackageContract(
     concepts=[
         ConceptRecord(
             key="trusted_year_scenario",
-            owner="common/testing/README.md#trusted-year-scenario",
+            owner="common/testing/readme.md#trusted-year-scenario",
             description=(
                 "Small immutable annual input, independent Decimal oracle, and "
                 "single-proof binding for terminal report-package verification."

--- a/common/testing/generate_critical_proof_matrix.py
+++ b/common/testing/generate_critical_proof_matrix.py
@@ -59,6 +59,8 @@ _PROOF_KEY_ORDER = (
     "source_classes",
     "mirror_proof_id",
     "issue",
+    "scenario_id",
+    "oracle_kind",
     "file",
     "test",
     "required_markers",
@@ -169,7 +171,13 @@ def _collect_from_file(path: Path, repo_root: Path) -> list[CollectedProof]:
             value = kwargs.get(optional)
             if value:
                 fields[optional] = str(value)
-        for optional in ("trust_mode", "mirror_proof_id", "issue"):
+        for optional in (
+            "trust_mode",
+            "mirror_proof_id",
+            "issue",
+            "scenario_id",
+            "oracle_kind",
+        ):
             value = kwargs.get(optional)
             if value:
                 fields[optional] = str(value)

--- a/common/testing/readme.md
+++ b/common/testing/readme.md
@@ -217,6 +217,23 @@ all ACs colliding in one central JSON object). Hermetic proof of the whole chain
    when behavior breaks (the real L3 proof).
 3. Migrating additional ACs and front-end (vitest) emission.
 
+## <a id="trusted-year-scenario"></a>TrustedYearScenario
+
+`trusted_year.py` owns one deliberately small terminal scenario and its
+independently authored `Decimal` oracle. The v0 entity contains one reviewed
+bank statement with income, expense, and investment-purchase movements; one
+brokerage position and selected market price; and one reviewed manual
+valuation. It is test truth, not a second product capability registry or a new
+transaction taxonomy.
+
+One `pr_ci` behavioral proof must bind the scenario to one independent oracle
+through explicit `scenario_id` and `oracle_kind` metadata. The integration path
+uses existing authority boundaries: LLM-led classification for supported P&L
+categories, a reviewed deterministic rule with explicit intent for the asset
+movement, immutable extraction results, ledger decisions, valuation decisions,
+and the frozen report-package lifecycle. Source-matrix expansion, deployed
+replay, operator evidence, and broader proof-format deletion remain outside v0.
+
 ---
 
 ## <a id="pdf-fixtures"></a>PDF Fixtures

--- a/common/testing/trusted_year.py
+++ b/common/testing/trusted_year.py
@@ -1,0 +1,194 @@
+"""Small, independent annual scenario for terminal report-package proof (#696)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import StrEnum
+
+
+class TrustedYearError(ValueError):
+    """Raised when scenario truth or its proof binding is ambiguous."""
+
+
+def _text(value: str, field: str) -> None:
+    if not value.strip():
+        raise TrustedYearError(f"{field} is required")
+
+
+def _money(value: Decimal, field: str) -> None:
+    if not isinstance(value, Decimal):
+        raise TrustedYearError(f"{field} must be Decimal")
+
+
+class MovementType(StrEnum):
+    """Economic meanings required by the v0 oracle, not a product taxonomy."""
+
+    INCOME = "income"
+    EXPENSE = "expense"
+    INVESTMENT_PURCHASE = "investment_purchase"
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearMovement:
+    description: str
+    occurred_on: date
+    type: MovementType
+    amount: Decimal
+
+    def __post_init__(self) -> None:
+        _text(self.description, "movement.description")
+        _money(self.amount, "movement.amount")
+        if self.amount <= 0:
+            raise TrustedYearError("movement.amount must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearPosition:
+    institution: str
+    symbol: str
+    quantity: Decimal
+    source_value: Decimal
+    selected_value: Decimal
+    as_of: date
+
+    def __post_init__(self) -> None:
+        _text(self.institution, "position.institution")
+        _text(self.symbol, "position.symbol")
+        for field in ("quantity", "source_value", "selected_value"):
+            _money(getattr(self, field), f"position.{field}")
+        if self.quantity <= 0 or self.source_value < 0 or self.selected_value < 0:
+            raise TrustedYearError("position values are outside their valid range")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearValuation:
+    component_type: str
+    liquidity_class: str
+    value: Decimal
+    source: str
+    as_of: date
+
+    def __post_init__(self) -> None:
+        _text(self.component_type, "valuation.component_type")
+        _text(self.liquidity_class, "valuation.liquidity_class")
+        _text(self.source, "valuation.source")
+        _money(self.value, "valuation.value")
+        if self.value < 0:
+            raise TrustedYearError("valuation.value must not be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearExpected:
+    ending_cash: Decimal
+    net_income: Decimal
+    investment_purchase: Decimal
+    investment_market_value: Decimal
+    total_assets: Decimal
+    total_liabilities: Decimal
+    ledger_equity: Decimal
+    net_worth_adjustment: Decimal
+
+    def __post_init__(self) -> None:
+        for field in self.__dataclass_fields__:
+            _money(getattr(self, field), f"expected.{field}")
+        if (
+            self.ledger_equity + self.net_income + self.net_worth_adjustment
+            != self.total_assets
+        ):
+            raise TrustedYearError("expected balance-sheet equation does not close")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearScenario:
+    scenario_id: str
+    currency: str
+    opening_cash: Decimal
+    movements: tuple[TrustedYearMovement, ...]
+    position: TrustedYearPosition
+    valuation: TrustedYearValuation
+    expected_manifest: tuple[str, ...]
+    expected: TrustedYearExpected
+
+    def __post_init__(self) -> None:
+        _text(self.scenario_id, "scenario_id")
+        _text(self.currency, "currency")
+        _money(self.opening_cash, "opening_cash")
+        if self.opening_cash <= 0:
+            raise TrustedYearError("opening_cash must be positive")
+        if {movement.type for movement in self.movements} != set(MovementType):
+            raise TrustedYearError(
+                "scenario requires income, expense, and investment purchase"
+            )
+        if not self.expected_manifest or len(set(self.expected_manifest)) != len(
+            self.expected_manifest
+        ):
+            raise TrustedYearError("expected_manifest must be non-empty and unique")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedYearProofBinding:
+    proof_id: str
+    scenario_ids: tuple[str, ...]
+    oracle_kind: str
+
+    def __post_init__(self) -> None:
+        _text(self.proof_id, "proof_id")
+        _text(self.oracle_kind, "oracle_kind")
+        if len(self.scenario_ids) != 1 or not self.scenario_ids[0].strip():
+            raise TrustedYearError("a terminal proof must bind exactly one scenario")
+
+
+TRUSTED_YEAR_SCENARIO = TrustedYearScenario(
+    scenario_id="trusted-year-v0",
+    currency="SGD",
+    opening_cash=Decimal("10000.00"),
+    movements=(
+        TrustedYearMovement(
+            "Salary credit", date(2026, 6, 5), MovementType.INCOME, Decimal("5000.00")
+        ),
+        TrustedYearMovement(
+            "Rent debit", date(2026, 6, 10), MovementType.EXPENSE, Decimal("1000.00")
+        ),
+        TrustedYearMovement(
+            "Buy security",
+            date(2026, 6, 15),
+            MovementType.INVESTMENT_PURCHASE,
+            Decimal("1000.00"),
+        ),
+    ),
+    position=TrustedYearPosition(
+        institution="Moomoo",
+        symbol="AAPL",
+        quantity=Decimal("10"),
+        source_value=Decimal("1200.00"),
+        selected_value=Decimal("1250.00"),
+        as_of=date(2026, 12, 31),
+    ),
+    valuation=TrustedYearValuation(
+        component_type="property_value",
+        liquidity_class="illiquid",
+        value=Decimal("100000.00"),
+        source="trusted-year-reviewed-appraisal",
+        as_of=date(2026, 12, 31),
+    ),
+    expected_manifest=(
+        "account",
+        "journal_entry",
+        "journal_line",
+        "pricing_observation",
+        "source_document",
+        "statement_result",
+    ),
+    expected=TrustedYearExpected(
+        ending_cash=Decimal("13000.00"),
+        net_income=Decimal("4000.00"),
+        investment_purchase=Decimal("1000.00"),
+        investment_market_value=Decimal("1250.00"),
+        total_assets=Decimal("115250.00"),
+        total_liabilities=Decimal("0.00"),
+        ledger_equity=Decimal("10000.00"),
+        net_worth_adjustment=Decimal("101250.00"),
+    ),
+)

--- a/common/testing/trusted_year.py
+++ b/common/testing/trusted_year.py
@@ -94,7 +94,10 @@ class TrustedYearExpected:
         for field in self.__dataclass_fields__:
             _money(getattr(self, field), f"expected.{field}")
         if (
-            self.ledger_equity + self.net_income + self.net_worth_adjustment
+            self.total_liabilities
+            + self.ledger_equity
+            + self.net_income
+            + self.net_worth_adjustment
             != self.total_assets
         ):
             raise TrustedYearError("expected balance-sheet equation does not close")

--- a/tests/tooling/test_trusted_year_scenario.py
+++ b/tests/tooling/test_trusted_year_scenario.py
@@ -1,0 +1,71 @@
+"""Structural proofs for the TrustedYearScenario v0 contract (#696)."""
+
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from common.testing.ac_proof import PROOF_ATTR, ac_proof
+from common.testing.generate_critical_proof_matrix import collect_proofs
+from common.testing.trusted_year import (
+    TRUSTED_YEAR_SCENARIO,
+    TrustedYearError,
+    TrustedYearProofBinding,
+)
+
+
+def test_AC_testing_trusted_year_1_scenario_is_small_exact_and_closed() -> None:
+    """AC-testing.trusted-year.1: v0 truth is compact, exact, and closed."""
+    scenario = TRUSTED_YEAR_SCENARIO
+
+    assert scenario.scenario_id == "trusted-year-v0"
+    assert len(scenario.movements) == 3
+    assert len(scenario.expected_manifest) == 6
+    assert all(isinstance(movement.amount, Decimal) for movement in scenario.movements)
+    assert scenario.expected.ending_cash == Decimal("13000.00")
+
+    with pytest.raises(TrustedYearError, match="must be Decimal"):
+        replace(scenario, opening_cash=10000)  # type: ignore[arg-type]
+
+
+def test_AC_testing_capability_proof_2_binding_rejects_stitching() -> None:
+    """AC-testing.capability-proof.2: one proof cannot stitch scenarios."""
+    binding = TrustedYearProofBinding(
+        proof_id="trusted-year-v0-terminal",
+        scenario_ids=(TRUSTED_YEAR_SCENARIO.scenario_id,),
+        oracle_kind="independent_decimal",
+    )
+    assert binding.scenario_ids == ("trusted-year-v0",)
+
+    with pytest.raises(TrustedYearError, match="exactly one scenario"):
+        replace(binding, scenario_ids=("trusted-year-v0", "another-scenario"))
+    with pytest.raises(TrustedYearError, match="oracle_kind is required"):
+        replace(binding, oracle_kind="")
+
+
+def test_AC_testing_capability_proof_1_collector_preserves_scenario_binding() -> None:
+    """AC-testing.capability-proof.1: collection retains execution coordinates."""
+    repo_root = Path(__file__).resolve().parents[2]
+    proof = next(
+        item
+        for item in collect_proofs(repo_root)
+        if item.proof_id == "trusted-year-v0-terminal"
+    )
+
+    assert proof.fields["scenario_id"] == "trusted-year-v0"
+    assert proof.fields["oracle_kind"] == "independent_decimal"
+    assert proof.fields["ci_tier"] == "pr_ci"
+
+    @ac_proof(
+        "runtime-binding",
+        ac_ids=["AC-testing.capability-proof.1"],
+        scenario_id="trusted-year-v0",
+        oracle_kind="independent_decimal",
+    )
+    def runtime_proof() -> None:
+        pass
+
+    metadata = getattr(runtime_proof, PROOF_ATTR)
+    assert metadata.scenario_id == "trusted-year-v0"
+    assert metadata.oracle_kind == "independent_decimal"

--- a/tests/tooling/test_trusted_year_scenario.py
+++ b/tests/tooling/test_trusted_year_scenario.py
@@ -27,6 +27,8 @@ def test_AC_testing_trusted_year_1_scenario_is_small_exact_and_closed() -> None:
 
     with pytest.raises(TrustedYearError, match="must be Decimal"):
         replace(scenario, opening_cash=10000)  # type: ignore[arg-type]
+    with pytest.raises(TrustedYearError, match="balance-sheet equation"):
+        replace(scenario.expected, total_liabilities=Decimal("1.00"))
 
 
 def test_AC_testing_capability_proof_2_binding_rejects_stitching() -> None:


### PR DESCRIPTION
## Summary
- add one testing-owned immutable `TrustedYearScenario` with exact Decimal inputs and an independently authored terminal oracle
- bind one PR-CI proof to one scenario/oracle and preserve the coordinates in both static proof collection and runtime metadata
- execute the reviewed bank -> classification -> ledger -> valuation -> report package path, including exact cash/investment results and frozen list/reopen/export behavior

## Design boundary
- reuses LLM-led category proposals for income/expense and the existing reviewed deterministic rule + explicit intent path for investment purchase
- does not introduce account cash-role fields, a second transaction taxonomy, capability-registry mirrors, source-matrix expansion, deployed replay, or operator evidence

## Dependency resolved
- #1930 and #1938 are merged; this branch is rebased directly onto `main` commit `c885838c` and carries only four testing-owned commits

## Verification
- tooling scenario tests: 3 passed
- trusted-year integration: 1 passed
- scoped coverage: `ac_proof.py` 100%, `trusted_year.py` 93%
- static preflight: passed
- full preflight: 2313 tooling/common tests passed; all relevant gates passed

Closes #696