### PR TITLE
[finance-report-1915-stale-decision-head] Preserve stale audit decision heads

### DIFF
--- a/apps/backend/src/audit/__init__.py
+++ b/apps/backend/src/audit/__init__.py
@@ -28,7 +28,7 @@ from src.audit.base.trace import (
     TraceTargetClass,
     VersionedTraceRef,
 )
-from src.audit.base.trace_repository import TraceRecordRepository
+from src.audit.base.trace_repository import TraceDecisionHead, TraceRecordRepository
 from src.audit.data import TraceConfidenceProjection
 from src.audit.extension import (
     JsonlTraceRecordStore,
@@ -118,6 +118,7 @@ __all__ = [
     "TraceDecisionOutcome",
     "TraceDecisionPolicy",
     "TraceDecisionPolicyRegistry",
+    "TraceDecisionHead",
     "TraceRecord",
     "TraceRecordCodec",
     "TraceRecordPersistenceError",

--- a/apps/backend/src/audit/base/__init__.py
+++ b/apps/backend/src/audit/base/__init__.py
@@ -18,6 +18,7 @@ from src.audit.base.trace import (
     VersionedTraceRef,
     current_heads,
 )
+from src.audit.base.trace_repository import TraceDecisionHead, TraceRecordRepository
 
 __all__ = [
     "TRACE_SCHEMA_VERSION",
@@ -26,8 +27,10 @@ __all__ = [
     "TraceDecisionOutcome",
     "TraceDecisionPolicy",
     "TraceDecisionPolicyRegistry",
+    "TraceDecisionHead",
     "TraceLineage",
     "TraceRecord",
+    "TraceRecordRepository",
     "TraceRecordType",
     "TraceRecordValidationError",
     "TraceResult",

--- a/apps/backend/src/audit/base/trace_repository.py
+++ b/apps/backend/src/audit/base/trace_repository.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
 from src.audit.base.trace import TraceLineage, TraceRecord, TraceScope
+
+
+@dataclass(frozen=True, slots=True)
+class TraceDecisionHead:
+    """The physical decision head and whether its complete ancestry is current."""
+
+    record: TraceRecord
+    ancestry_current: bool
 
 
 class TraceRecordRepository(Protocol):
@@ -19,4 +28,8 @@ class TraceRecordRepository(Protocol):
 
     async def current_decision(self, scope: TraceScope, lineage: TraceLineage) -> TraceRecord | None:
         """Return the singleton head only while its full ancestry is current."""
+        ...
+
+    async def decision_head(self, scope: TraceScope, lineage: TraceLineage) -> TraceDecisionHead | None:
+        """Return the physical head without collapsing stale ancestry into absence."""
         ...

--- a/apps/backend/src/audit/extension/trace_repository.py
+++ b/apps/backend/src/audit/extension/trace_repository.py
@@ -101,10 +101,10 @@ class SqlTraceRecordRepository(TraceRecordRepository):
         lineage: TraceLineage,
     ) -> TraceRecord | None:
         try:
-            head = await self._read_decision_head(scope, lineage)
-            if head is None or not head.ancestry_current:
+            row = await self._decision_head_row(scope, lineage)
+            if row is None or not await self._has_current_ancestry(scope, row.id, frozenset()):
                 return None
-            return head.record
+            return await self._restore(row, frozenset({row.id}))
         except TraceRecordPersistenceError:
             raise
         except (SQLAlchemyError, TraceRecordValidationError, RuntimeError) as exc:

--- a/apps/backend/src/audit/extension/trace_repository.py
+++ b/apps/backend/src/audit/extension/trace_repository.py
@@ -19,7 +19,7 @@ from src.audit.base.trace import (
     TraceScope,
     VersionedTraceRef,
 )
-from src.audit.base.trace_repository import TraceRecordRepository
+from src.audit.base.trace_repository import TraceDecisionHead, TraceRecordRepository
 from src.audit.orm.trace_record import TraceRecordParentRow, TraceRecordRow
 from src.audit.ratio import Ratio
 
@@ -101,14 +101,39 @@ class SqlTraceRecordRepository(TraceRecordRepository):
         lineage: TraceLineage,
     ) -> TraceRecord | None:
         try:
-            row = await self._decision_head_row(scope, lineage)
-            if row is None or not await self._has_current_ancestry(scope, row.id, frozenset()):
+            head = await self._read_decision_head(scope, lineage)
+            if head is None or not head.ancestry_current:
                 return None
-            return await self._restore(row, frozenset({row.id}))
+            return head.record
         except TraceRecordPersistenceError:
             raise
         except (SQLAlchemyError, TraceRecordValidationError, RuntimeError) as exc:
             raise TraceRecordPersistenceError(f"TraceRecord current read failed: {exc}") from exc
+
+    async def decision_head(
+        self,
+        scope: TraceScope,
+        lineage: TraceLineage,
+    ) -> TraceDecisionHead | None:
+        try:
+            return await self._read_decision_head(scope, lineage)
+        except TraceRecordPersistenceError:
+            raise
+        except (SQLAlchemyError, TraceRecordValidationError, RuntimeError) as exc:
+            raise TraceRecordPersistenceError(f"TraceRecord decision-head read failed: {exc}") from exc
+
+    async def _read_decision_head(
+        self,
+        scope: TraceScope,
+        lineage: TraceLineage,
+    ) -> TraceDecisionHead | None:
+        row = await self._decision_head_row(scope, lineage)
+        if row is None:
+            return None
+        return TraceDecisionHead(
+            record=await self._restore(row, frozenset({row.id})),
+            ancestry_current=await self._has_current_ancestry(scope, row.id, frozenset()),
+        )
 
     async def _decision_head_row(
         self,

--- a/apps/backend/src/pricing/extension/valuation_contribution.py
+++ b/apps/backend/src/pricing/extension/valuation_contribution.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit import (
+    SqlTraceRecordRepository,
     TraceAuthorityProfile,
     TraceCausality,
     TraceDecisionOutcome,
@@ -31,7 +32,6 @@ from src.audit import (
     TraceTargetClass,
     VersionedTraceRef,
 )
-from src.audit.extension.trace_repository import SqlTraceRecordRepository
 from src.pricing.base.contribution import (
     MarketValuationSelection,
     ResolvedValuationContribution,
@@ -251,15 +251,16 @@ async def emit_manual_valuation_decision(
     policy = ManualValuationAttestationPolicy()
     repository = SqlTraceRecordRepository(db, pricing_trace_policy_registry())
     scope = TraceScope.tenant(user_id)
-    current = await repository.current_decision(scope, TraceLineage.from_refs(target, policy.assertion))
+    head = await repository.decision_head(scope, TraceLineage.from_refs(target, policy.assertion))
+    current = head.record if head is not None and head.ancestry_current else None
     if current is not None and current.target.version == target.version and current.result is TraceResult.AUTHORITATIVE:
         return current.record_id
 
     previous_decision_id = None
-    if current is not None:
-        if len(current.parent_ids) != 1:
+    if head is not None:
+        if len(head.record.parent_ids) != 1:
             raise ValueError("manual valuation decision must have exactly one input observation")
-        previous_decision_id = current.record_id
+        previous_decision_id = head.record.record_id
 
     occurred_at = datetime.now(UTC)
     execution_id = f"pricing-valuation:{target.id}:{target.version}"
@@ -312,7 +313,19 @@ async def _resolved_market_contribution(
     decision_policy = ResolvedMarketValuationPolicy()
     scope = TraceScope.tenant(user_id)
     repository = SqlTraceRecordRepository(db, pricing_trace_policy_registry())
-    current = await repository.current_decision(scope, TraceLineage.from_refs(target, decision_policy.assertion))
+    head = await repository.decision_head(
+        scope,
+        TraceLineage.from_refs(target, decision_policy.assertion),
+    )
+    if head is not None and not head.ancestry_current:
+        return _unproven(
+            subject=subject,
+            as_of=requested_as_of,
+            policy=policy,
+            reason_code="stale_observation_decision",
+            observation=observation,
+        )
+    current = head.record if head is not None else None
     if current is not None and current.target == target and current.result is TraceResult.AUTHORITATIVE:
         decision = current
     else:

--- a/apps/backend/tests/audit/trace/test_trace_repository.py
+++ b/apps/backend/tests/audit/trace/test_trace_repository.py
@@ -237,7 +237,9 @@ async def test_AC_audit_trace_record_7_decision_head_preserves_absent_current_an
     assert stale is not None
     assert stale.record == decision
     assert stale.ancestry_current is False
+    repository._restore = AsyncMock(wraps=repository._restore)
     assert await repository.current_decision(parent.scope, decision.lineage) is None
+    repository._restore.assert_not_awaited()
 
 
 async def test_repository_replays_policy_instead_of_trusting_decision_fields(db):

--- a/apps/backend/tests/audit/trace/test_trace_repository.py
+++ b/apps/backend/tests/audit/trace/test_trace_repository.py
@@ -196,6 +196,50 @@ async def test_parent_correction_invalidates_authority_without_forking_lineage(d
     assert await repository.current_decision(parent.scope, decision.lineage) == replacement
 
 
+async def test_AC_audit_trace_record_7_decision_head_preserves_absent_current_and_stale_states(db):
+    """AC-audit.trace-record.7: physical presence and ancestry currency are distinct."""
+    policy = decision_policy(assertion_id="typed-decision-head")
+    repository = SqlTraceRecordRepository(
+        db,
+        TraceDecisionPolicyRegistry((policy,)),
+    )
+    parent = observation(assertion_id="typed-decision-head-input")
+    decision = TraceRecord.decision(
+        scope=parent.scope,
+        target=parent.target,
+        policy=policy,
+        execution_id=parent.execution_id,
+        occurred_at=parent.occurred_at,
+        parents=[parent],
+    )
+
+    assert await repository.decision_head(parent.scope, decision.lineage) is None
+
+    await repository.append(parent)
+    await repository.append(decision)
+    current = await repository.decision_head(parent.scope, decision.lineage)
+    assert current is not None
+    assert current.record == decision
+    assert current.ancestry_current is True
+    assert await repository.current_decision(parent.scope, decision.lineage) == decision
+
+    correction = observation(
+        scope=parent.scope,
+        target_version="v2",
+        assertion_id=parent.assertion.id,
+        assertion_version="v2",
+        execution_id="execution-2",
+        supersedes_id=parent.record_id,
+    )
+    await repository.append(correction)
+
+    stale = await repository.decision_head(parent.scope, decision.lineage)
+    assert stale is not None
+    assert stale.record == decision
+    assert stale.ancestry_current is False
+    assert await repository.current_decision(parent.scope, decision.lineage) is None
+
+
 async def test_repository_replays_policy_instead_of_trusting_decision_fields(db):
     policy = decision_policy()
     repository = SqlTraceRecordRepository(

--- a/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
+++ b/apps/backend/tests/pricing/test_resolved_valuation_contribution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
@@ -10,6 +10,14 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import select
 
+from src.audit import (
+    SqlTraceRecordRepository,
+    TraceRecord,
+    TraceRecordType,
+    TraceResult,
+    TraceScope,
+    VersionedTraceRef,
+)
 from src.audit.orm.trace_record import TraceRecordRow
 from src.extraction.orm.layer3 import ManualValuationSnapshot
 from src.pricing import (
@@ -18,6 +26,7 @@ from src.pricing import (
     ResolutionPolicy,
     StockPrice,
     build_manual_valuation_lines,
+    pricing_trace_policy_registry,
     record_manual_valuation,
     resolve_manual_valuation_contributions,
     resolve_selected_market_valuation_contribution,
@@ -27,6 +36,39 @@ from src.reporting.extension.package_document import PackageAssembler
 from src.schemas.portfolio import InvestmentPerformanceMarketValuationSelection
 
 pytestmark = pytest.mark.asyncio
+
+
+async def _supersede_decision_parent(db, *, user_id, decision_id) -> None:
+    repository = SqlTraceRecordRepository(db, pricing_trace_policy_registry())
+    scope = TraceScope.tenant(user_id)
+    decision = await repository.get(scope, decision_id)
+    assert decision is not None
+    assert len(decision.parent_ids) == 1
+    selected_observation = await repository.get(scope, decision.parent_ids[0])
+    assert selected_observation is not None
+    correction = TraceRecord.observation(
+        scope=scope,
+        target=VersionedTraceRef(
+            selected_observation.target.kind,
+            selected_observation.target.id,
+            f"{selected_observation.target.version}:corrected",
+        ),
+        target_class=selected_observation.target_class,
+        assertion=VersionedTraceRef(
+            selected_observation.assertion.kind,
+            selected_observation.assertion.id,
+            f"{selected_observation.assertion.version}:corrected",
+        ),
+        authority=selected_observation.authority,
+        result=TraceResult.PASS,
+        execution_id=f"{selected_observation.execution_id}:corrected",
+        evidence_manifest_digest="d" * 64,
+        occurred_at=selected_observation.occurred_at + timedelta(microseconds=1),
+        score=selected_observation.score,
+        reason_code="pricing_selection_corrected",
+        supersedes_id=selected_observation.record_id,
+    )
+    await repository.append(correction)
 
 
 async def test_AC_pricing_valuation_contribution_1_manual_write_emits_and_supersedes_decision(db, test_user):
@@ -52,6 +94,12 @@ async def test_AC_pricing_valuation_contribution_1_manual_write_emits_and_supers
     assert first_contribution.is_authoritative
     assert first_contribution.observation_id == first.id
     assert first_contribution.decision_id is not None
+
+    await _supersede_decision_parent(
+        db,
+        user_id=test_user.id,
+        decision_id=first_contribution.decision_id,
+    )
 
     second = await record_manual_valuation(
         db,
@@ -167,6 +215,54 @@ async def test_AC_pricing_valuation_contribution_3_missing_or_stale_decision_is_
     )
     assert not cross_tenant.is_authoritative
     assert cross_tenant.reason_code == "no_eligible_observation"
+
+    market_row = StockPrice(
+        symbol="STALEHEAD",
+        price=Decimal("125.05"),
+        currency="SGD",
+        price_date=date(2026, 6, 15),
+        source="recorded-provider",
+    )
+    db.add(market_row)
+    await db.flush()
+    market = await resolve_valuation_contribution(
+        db,
+        user_id=test_user.id,
+        subject=PriceableSubject.security("STALEHEAD"),
+        as_of=date(2026, 6, 15),
+        policy=ResolutionPolicy(max_age_days=0),
+    )
+    assert market.is_authoritative
+    assert market.decision_id is not None
+
+    await _supersede_decision_parent(
+        db,
+        user_id=test_user.id,
+        decision_id=market.decision_id,
+    )
+
+    stale = await resolve_valuation_contribution(
+        db,
+        user_id=test_user.id,
+        subject=PriceableSubject.security("STALEHEAD"),
+        as_of=date(2026, 6, 15),
+        policy=ResolutionPolicy(max_age_days=0),
+    )
+    decisions = tuple(
+        (
+            await db.execute(
+                select(TraceRecordRow.id)
+                .where(TraceRecordRow.scope_id == str(test_user.id))
+                .where(TraceRecordRow.record_type == TraceRecordType.DECISION)
+            )
+        ).scalars()
+    )
+
+    assert not stale.is_authoritative
+    assert stale.observation_id == market.observation_id
+    assert stale.decision_id is None
+    assert stale.reason_code == "stale_observation_decision"
+    assert decisions == (market.decision_id,)
 
 
 async def test_AC_pricing_valuation_contribution_4_rollback_is_atomic(db, test_user):

--- a/common/audit/base/__init__.py
+++ b/common/audit/base/__init__.py
@@ -18,6 +18,7 @@ from common.audit.base.trace import (
     VersionedTraceRef,
     current_heads,
 )
+from common.audit.base.trace_repository import TraceDecisionHead, TraceRecordRepository
 
 __all__ = [
     "TRACE_SCHEMA_VERSION",
@@ -26,8 +27,10 @@ __all__ = [
     "TraceDecisionOutcome",
     "TraceDecisionPolicy",
     "TraceDecisionPolicyRegistry",
+    "TraceDecisionHead",
     "TraceLineage",
     "TraceRecord",
+    "TraceRecordRepository",
     "TraceRecordType",
     "TraceRecordValidationError",
     "TraceResult",

--- a/common/audit/base/trace_repository.py
+++ b/common/audit/base/trace_repository.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
 from common.audit.base.trace import TraceLineage, TraceRecord, TraceScope
+
+
+@dataclass(frozen=True, slots=True)
+class TraceDecisionHead:
+    """The physical decision head and whether its complete ancestry is current."""
+
+    record: TraceRecord
+    ancestry_current: bool
 
 
 class TraceRecordRepository(Protocol):
@@ -21,4 +30,10 @@ class TraceRecordRepository(Protocol):
         self, scope: TraceScope, lineage: TraceLineage
     ) -> TraceRecord | None:
         """Return the singleton head only while its full ancestry is current."""
+        ...
+
+    async def decision_head(
+        self, scope: TraceScope, lineage: TraceLineage
+    ) -> TraceDecisionHead | None:
+        """Return the physical head without collapsing stale ancestry into absence."""
         ...

--- a/common/audit/contract.py
+++ b/common/audit/contract.py
@@ -183,6 +183,11 @@ CONTRACT = PackageContract(
             impl="extension/trace_repository.py",
         ),
         Unit(
+            name="TraceDecisionHead",
+            kind=Kind.VALUE_OBJECT,
+            module="base/trace_repository.py",
+        ),
+        Unit(
             name="TraceConfidenceProjection",
             kind=Kind.PROJECTION,
             module="data/trace_confidence.py",
@@ -235,6 +240,7 @@ CONTRACT = PackageContract(
         "TraceDecisionOutcome",
         "TraceDecisionPolicy",
         "TraceDecisionPolicyRegistry",
+        "TraceDecisionHead",
         "TraceRecordType",
         "TraceResult",
         "VersionedTraceRef",
@@ -1567,6 +1573,22 @@ CONTRACT = PackageContract(
             test=(
                 "apps/backend/tests/audit/trace/test_trace_decision_projection.py"
                 "::test_AC_audit_trace_record_6_current_projection_matches_repository_current_ancestry"
+            ),
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-audit.trace-record.7",
+            statement=(
+                "The TraceRecord repository exposes a typed physical decision head that "
+                "distinguishes an absent lineage from a head whose complete ancestry is "
+                "current or stale; current_decision remains the fail-closed authoritative "
+                "view, while a writer can supersede the exact stale head without guessing "
+                "from a missing result or importing audit persistence internals."
+            ),
+            test=(
+                "apps/backend/tests/audit/trace/test_trace_repository.py"
+                "::test_AC_audit_trace_record_7_decision_head_preserves_absent_current_and_stale_states"
             ),
             priority="P0",
             status="done",

--- a/common/audit/readme.md
+++ b/common/audit/readme.md
@@ -64,6 +64,15 @@ supersession. Observations may coexist across executions. Only authoritative
 decision heads are singleton, serialized under a transaction-scoped advisory
 lock so authority cannot fork.
 
+The repository keeps two deliberately different reads. `current_decision()` is
+the fail-closed authority view and returns a record only while its complete
+ancestry is current. `decision_head()` returns a `TraceDecisionHead` containing
+the physical singleton head plus `ancestry_current`; this prevents a writer from
+collapsing "no decision has ever existed" and "a decision exists but its evidence
+was superseded" into the same `None` state. Cross-package consumers use this
+typed port rather than reading audit tables or recovering the physical head from
+timestamps.
+
 The production repository stores common fields in typed columns and parents in
 scope-bound link rows. ORM guards and PostgreSQL triggers reject update/delete,
 and a sealed parent count prevents a later link insert from rewriting a decision.

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -1028,7 +1028,9 @@ CONTRACT = PackageContract(
             statement=(
                 "An absent, stale, rejected, superseded, cross-tenant, or "
                 "target-mismatched valuation decision returns an explicit unproven "
-                "contribution; source, basis, rank, or freshness never grants trust."
+                "contribution; a stale physical authority head is not mistaken for a "
+                "never-authorized lineage or appended as a fork, and source, basis, "
+                "rank, or freshness never grants trust."
             ),
             test=(
                 "apps/backend/tests/pricing/test_resolved_valuation_contribution.py"

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -113,6 +113,13 @@ may display the value as a draft input but cannot call the resulting document
 trusted. A frozen package stores the returned IDs/digests and never re-runs
 this resolution when it is reopened or exported.
 
+Pricing distinguishes a lineage with no decision from one whose physical
+decision head has stale ancestry through audit's `TraceDecisionHead`. A first
+market selection may create authority only for the former; the latter returns
+`stale_observation_decision` without attempting an authority fork. An explicit
+new manual fact may supersede that exact physical head, preserving one linear
+decision lineage.
+
 For market-priced holdings, the investment schedule publishes the exact
 `MarketValuationSelection` identity it rendered. Reporting passes that typed
 selection back to pricing; pricing re-resolves under its policy and accepts it


### PR DESCRIPTION
## Summary
- publish a typed `TraceDecisionHead` that distinguishes absent, current, and stale-ancestry decision lineages
- keep `current_decision()` fail-closed while allowing explicit writers to supersede the exact physical head
- make automatic market valuation resolution return `stale_observation_decision` instead of attempting an authority fork

## Root cause
`current_decision()` collapsed two states into `None`: no decision had ever existed, or a physical decision head existed but its evidence ancestry was stale. Pricing interpreted both as first authorization and emitted a decision without `supersedes_id`; audit correctly rejected the fork. The missing proof was a mutation test that superseded the selected market observation and re-ran resolution.

## Proof
- red first: audit typed-head regression failed with missing `decision_head`; pricing mutation failed with `TraceRecordPersistenceError`
- `28 passed` across the complete audit repository and pricing contribution test files
- full diff-aware preflight: `2267 passed`, all 7 selected gates green
- final static preflight: all 6 selected gates green

Closes #1915
Relates to #696 and #950