### PR TITLE
[finance-report-1894-outbox.P1c9Hs] Separate public outbox from ORM

### DIFF
--- a/apps/backend/src/platform/__init__.py
+++ b/apps/backend/src/platform/__init__.py
@@ -19,7 +19,7 @@ Files converge by layer (see common/meta/migration-standard.md): ``base`` (the
 :class:`DomainEvent` record + the :class:`EventBus`/:class:`OutboxRepository`
 *ports* + :class:`SubscriberRegistry`) and ``extension`` (the
 :class:`OutboxEventBus`/:class:`RecordingEventBus` bus adapters, the
-:class:`OutboxRelay`, the SQL :class:`Outbox` table + adapter — the only role
+:class:`OutboxRelay`, the SQL ``OutboxRecord`` table + adapter — the only role
 that touches the ORM — and the cross-cutting request :class:`RateLimiter`
 middleware service plus its app-wide ``api_rate_limiter`` instance). The names
 re-exported below are the *entire* public surface (``__all__`` must equal
@@ -35,10 +35,10 @@ from typing import TYPE_CHECKING
 from src.platform.base import (
     DomainEvent,
     EventBus,
+    Outbox,
     OutboxRepository,
     SubscriberRegistry,
 )
-from src.platform.extension.sql import Outbox
 
 # ORM models owned by this package (moved from src/models, #1675); imported
 # eagerly so importing the package registers the mappers on Base.metadata.
@@ -116,7 +116,6 @@ def __getattr__(name: str) -> object:
 if TYPE_CHECKING:
     from src.platform.extension import (
         BaseAppException,
-        Outbox,
         OutboxEventBus,
         OutboxRelay,
         PingStateResponse,

--- a/apps/backend/src/platform/base/__init__.py
+++ b/apps/backend/src/platform/base/__init__.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 from src.platform.base.bus import EventBus, EventHandler, SubscriberRegistry
 from src.platform.base.event import DomainEvent
-from src.platform.base.outbox import OutboxRepository, OutboxRow
+from src.platform.base.outbox import Outbox, OutboxRepository, OutboxRow
 
 __all__ = [
     "DomainEvent",
     "EventBus",
     "EventHandler",
+    "Outbox",
     "OutboxRepository",
     "OutboxRow",
     "SubscriberRegistry",

--- a/apps/backend/src/platform/base/outbox.py
+++ b/apps/backend/src/platform/base/outbox.py
@@ -47,6 +47,8 @@ class OutboxRow(Protocol):
     occurred_at: datetime
     event_type: str
     payload: dict | None
+    status: str
+    published_at: datetime | None
 
 
 class OutboxRepository(Protocol):

--- a/apps/backend/src/platform/base/outbox.py
+++ b/apps/backend/src/platform/base/outbox.py
@@ -3,7 +3,7 @@
 Dependency inversion, mechanism B: the abstract persistence contract the bus and
 relay depend on lives here in ``base``; its concrete SQLAlchemy adapter
 (:class:`~src.platform.extension.sql.SqlOutboxRepository`, against the shared
-:class:`~src.platform.extension.sql.Outbox` table) lives in ``extension`` and
+:class:`~src.platform.extension.sql.OutboxRecord` table) lives in ``extension`` and
 depends back on this port. This keeps ``base`` pure: it speaks plain primitives
 and a structural :class:`OutboxRow`, never the ORM/session.
 
@@ -16,8 +16,23 @@ post-commit and at-least-once.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Outbox:
+    """Public, persistence-neutral description of one enqueued domain event."""
+
+    occurred_at: datetime
+    event_type: str
+    source_pkg: str
+    payload: dict
+    aggregate_id: str | None = None
+    id: int | None = None
+    status: str = "pending"
+    published_at: datetime | None = None
 
 
 class OutboxRow(Protocol):

--- a/apps/backend/src/platform/extension/__init__.py
+++ b/apps/backend/src/platform/extension/__init__.py
@@ -1,7 +1,7 @@
 """``platform.extension`` — the impure edges: ORM, session, and the bus adapters.
 
 Depends on ``src.database`` (the shared ORM Base/session) and on the package's own
-``base`` ports. This is where the package reaches I/O: the shared :class:`Outbox`
+``base`` ports. This is where the package reaches I/O: the shared ``OutboxRecord``
 table + its :class:`SqlOutboxRepository` adapter (``sql.py``), the
 :class:`OutboxEventBus`/:class:`RecordingEventBus` bus adapters (``bus.py``), the
 :class:`OutboxRelay` post-commit dispatcher (``relay.py``), the cross-cutting
@@ -38,13 +38,11 @@ from src.platform.extension.relay import OutboxRelay
 from src.platform.extension.sql import (
     STATUS_PENDING,
     STATUS_PUBLISHED,
-    Outbox,
     SqlOutboxRepository,
 )
 
 __all__ = [
     "BaseAppException",
-    "Outbox",
     "OutboxEventBus",
     "OutboxRelay",
     "PingStateResponse",

--- a/apps/backend/src/platform/extension/relay.py
+++ b/apps/backend/src/platform/extension/relay.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.platform.base.bus import SubscriberRegistry
 from src.platform.base.event import DomainEvent
-from src.platform.extension.sql import Outbox, SqlOutboxRepository
+from src.platform.extension.sql import OutboxRecord, SqlOutboxRepository
 
 
 class _StoredEvent(DomainEvent):
@@ -40,6 +40,8 @@ class _StoredEvent(DomainEvent):
     transports opaque events.
     """
 
+    _payload: dict
+
     def __init__(self, *, event_type: str, occurred_at: datetime, payload: dict) -> None:
         super().__init__(event_type=event_type, occurred_at=occurred_at)
         object.__setattr__(self, "_payload", payload)
@@ -48,7 +50,7 @@ class _StoredEvent(DomainEvent):
         return dict(self._payload)
 
 
-def _to_event(row: Outbox) -> DomainEvent:
+def _to_event(row: OutboxRecord) -> DomainEvent:
     """Rehydrate a persisted outbox row into a dispatchable domain event."""
     return _StoredEvent(
         event_type=row.event_type,

--- a/apps/backend/src/platform/extension/relay.py
+++ b/apps/backend/src/platform/extension/relay.py
@@ -22,12 +22,14 @@ import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from typing import cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.platform.base.bus import SubscriberRegistry
 from src.platform.base.event import DomainEvent
-from src.platform.extension.sql import OutboxRecord, SqlOutboxRepository
+from src.platform.base.outbox import OutboxRow
+from src.platform.extension.sql import SqlOutboxRepository
 
 
 class _StoredEvent(DomainEvent):
@@ -50,7 +52,7 @@ class _StoredEvent(DomainEvent):
         return dict(self._payload)
 
 
-def _to_event(row: OutboxRecord) -> DomainEvent:
+def _to_event(row: OutboxRow) -> DomainEvent:
     """Rehydrate a persisted outbox row into a dispatchable domain event."""
     return _StoredEvent(
         event_type=row.event_type,
@@ -81,7 +83,8 @@ class OutboxRelay:
         published = 0
         try:
             for row in rows:
-                event = _to_event(row)
+                outbox_row = cast(OutboxRow, row)
+                event = _to_event(outbox_row)
                 for handler in self._registry.handlers_for(row.event_type):
                     # Handlers may be sync or async (EventHandler admits both);
                     # an async handler's work must complete before the row is

--- a/apps/backend/src/platform/extension/sql.py
+++ b/apps/backend/src/platform/extension/sql.py
@@ -3,7 +3,7 @@
 This is the ``extension`` (impure) half of the persistence split: the concrete
 :class:`SqlOutboxRepository` adapter that satisfies the
 :class:`~src.platform.base.outbox.OutboxRepository` port, backed by the shared
-:class:`Outbox` ORM table. The only role that touches the ORM/session.
+:class:`OutboxRecord` ORM table. The only role that touches the ORM/session.
 
 The transactional-outbox pattern hangs on ONE invariant: a domain event row is
 INSERTed in the *same* DB transaction as the domain state change that produced
@@ -11,7 +11,7 @@ it. Because the write shares the caller's :class:`AsyncSession`, the event and
 the state change commit together or roll back together — there is no window where
 one persists without the other.
 
-``Outbox`` is the single shared table (owned by the ``platform`` package); every
+``OutboxRecord`` is the single shared table (owned by the ``platform`` package); every
 package that emits through the bus writes its events here, tagged with
 ``source_pkg``/``event_type``. The relay (``extension/relay.py``) later reads
 committed ``pending`` rows in id order and dispatches them, so dispatch is
@@ -38,7 +38,7 @@ STATUS_PENDING = "pending"
 STATUS_PUBLISHED = "published"
 
 
-class Outbox(Base):
+class OutboxRecord(Base):
     """One enqueued domain event awaiting (or having had) relay dispatch.
 
     The ``(status, id)`` index backs the relay's hot query — "the oldest pending
@@ -77,14 +77,14 @@ class SqlOutboxRepository:
         source_pkg: str,
         payload: dict,
         aggregate_id: str | None = None,
-    ) -> Outbox:
+    ) -> OutboxRecord:
         """Add a ``pending`` outbox row to the session (no commit).
 
         The row is flushed with the caller's transaction; the caller (the domain
         write) owns the commit, which is what makes the event atomic with the
         state change. Returns the pending row (its ``id`` is assigned on flush).
         """
-        row = Outbox(
+        row = OutboxRecord(
             occurred_at=occurred_at,
             event_type=event_type,
             source_pkg=source_pkg,
@@ -95,14 +95,14 @@ class SqlOutboxRepository:
         self._session.add(row)
         return row
 
-    async def fetch_pending(self, *, limit: int) -> list[Outbox]:
+    async def fetch_pending(self, *, limit: int) -> list[OutboxRecord]:
         """Return up to ``limit`` ``pending`` rows in id (enqueue) order."""
         result = await self._session.execute(
-            sa.select(Outbox).where(Outbox.status == STATUS_PENDING).order_by(Outbox.id).limit(limit)
+            sa.select(OutboxRecord).where(OutboxRecord.status == STATUS_PENDING).order_by(OutboxRecord.id).limit(limit)
         )
         return list(result.scalars().all())
 
-    async def mark_published(self, row: Outbox, *, published_at: datetime) -> None:
+    async def mark_published(self, row: OutboxRecord, *, published_at: datetime) -> None:
         """Flip a row to ``published`` and stamp ``published_at`` (no commit)."""
         row.status = STATUS_PUBLISHED
         row.published_at = published_at

--- a/apps/backend/tests/counter/test_outbox_emit.py
+++ b/apps/backend/tests/counter/test_outbox_emit.py
@@ -15,14 +15,15 @@ from common.testing.ac_proof import ac_proof
 
 from src.counter import CounterKey, increment, read_count, record_increment
 from src.counter.base.types.events import EVENT_TYPE
-from src.platform import Outbox, RecordingEventBus
+from src.platform import RecordingEventBus
 from src.platform.extension import STATUS_PENDING
+from src.platform.extension.sql import OutboxRecord
 
 KEY = CounterKey("report.generated")
 
 
 async def _outbox_rows(db):
-    return (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
+    return (await db.execute(sa.select(OutboxRecord).order_by(OutboxRecord.id))).scalars().all()
 
 
 @ac_proof(proof_id="test_counter_emits_to_outbox", ac_ids=["AC-platform.1.5"], ci_tier="pr_ci")

--- a/apps/backend/tests/platform/test_outbox_atomicity.py
+++ b/apps/backend/tests/platform/test_outbox_atomicity.py
@@ -13,8 +13,9 @@ import pytest
 import sqlalchemy as sa
 from common.testing.ac_proof import ac_proof
 
-from src.platform import DomainEvent, Outbox, OutboxEventBus
+from src.platform import DomainEvent, OutboxEventBus
 from src.platform.extension import STATUS_PENDING
+from src.platform.extension.sql import OutboxRecord
 
 
 def _event(name: str = "test.Thing") -> DomainEvent:
@@ -22,7 +23,7 @@ def _event(name: str = "test.Thing") -> DomainEvent:
 
 
 async def _outbox_count(db) -> int:
-    result = await db.execute(sa.select(sa.func.count()).select_from(Outbox))
+    result = await db.execute(sa.select(sa.func.count()).select_from(OutboxRecord))
     return int(result.scalar_one())
 
 
@@ -35,7 +36,7 @@ async def test_commit_leaves_exactly_one_outbox_row(db):
     await db.commit()
 
     assert await _outbox_count(db) == 1
-    row = (await db.execute(sa.select(Outbox))).scalar_one()
+    row = (await db.execute(sa.select(OutboxRecord))).scalar_one()
     assert row.status == STATUS_PENDING
     assert row.event_type == "test.Thing"
     assert row.source_pkg == "test"

--- a/apps/backend/tests/platform/test_relay.py
+++ b/apps/backend/tests/platform/test_relay.py
@@ -14,12 +14,12 @@ from common.testing.ac_proof import ac_proof
 
 from src.platform import (
     DomainEvent,
-    Outbox,
     OutboxEventBus,
     OutboxRelay,
     SubscriberRegistry,
 )
 from src.platform.extension import STATUS_PUBLISHED
+from src.platform.extension.sql import OutboxRecord
 
 
 def _event(name="counter.Incremented", count=1):
@@ -50,7 +50,7 @@ async def test_run_once_dispatches_and_marks_published(db):
 
     assert published == 2
     assert [p["count"] for p in seen] == [1, 2]  # delivered in enqueue (id) order
-    rows = (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
+    rows = (await db.execute(sa.select(OutboxRecord).order_by(OutboxRecord.id))).scalars().all()
     assert all(r.status == STATUS_PUBLISHED and r.published_at is not None for r in rows)
 
 
@@ -126,7 +126,7 @@ async def test_redelivery_of_pending_is_idempotent_safe(db):
     assert applied == {"u1"}  # but the idempotent effect collapses to one
 
 
-def _event_from_row(row: Outbox) -> DomainEvent:
+def _event_from_row(row: OutboxRecord) -> DomainEvent:
     ev = DomainEvent(event_type=row.event_type, occurred_at=row.occurred_at)
     object.__setattr__(ev, "payload", lambda: dict(row.payload))
     return ev

--- a/apps/backend/tests/pricing/test_manual.py
+++ b/apps/backend/tests/pricing/test_manual.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.platform import Outbox
+from src.platform.extension.sql import OutboxRecord
 from src.pricing.base.events import EVENT_TYPE
 from src.pricing.base.observation import Authority, ObservationSource
 from src.pricing.extension.manual import record_manual_valuation, record_override
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def _outbox_rows(db: AsyncSession):
-    return (await db.execute(sa.select(Outbox).order_by(Outbox.id))).scalars().all()
+    return (await db.execute(sa.select(OutboxRecord).order_by(OutboxRecord.id))).scalars().all()
 
 
 async def test_record_manual_valuation_returns_a_manual_observation(db: AsyncSession, test_user):

--- a/common/meta/data/unit-accountability-baseline.json
+++ b/common/meta/data/unit-accountability-baseline.json
@@ -62,7 +62,6 @@
   "unbound::llm::UsageRecorded",
   "unbound::llm::UsageRepository",
   "unbound::llm::UsageRollup",
-  "unbound::platform::Outbox",
   "unbound::portfolio::CostBasisMethod",
   "unbound::portfolio::DividendIncome",
   "unbound::portfolio::DividendType",

--- a/common/meta/extension/public_orm_exports.py
+++ b/common/meta/extension/public_orm_exports.py
@@ -33,6 +33,35 @@ def _literal_exports(tree: ast.Module, path: Path) -> set[str]:
     return set(values)
 
 
+def _local_module_path(backend_src: Path, package: str, module: str) -> Path | None:
+    """Resolve a package-local import path without importing application code."""
+    prefix = f"src.{package}."
+    if not module.startswith(prefix):
+        return None
+    relative = Path(*module.removeprefix(prefix).split("."))
+    module_file = backend_src / package / relative.with_suffix(".py")
+    package_init = backend_src / package / relative / "__init__.py"
+    if module_file.is_file():
+        return module_file
+    if package_init.is_file():
+        return package_init
+    return None
+
+
+def _orm_class_names(path: Path) -> set[str]:
+    """Return locally-defined SQLAlchemy model names from one source module."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as exc:
+        raise ValueError(f"cannot parse re-export source {path}: {exc}") from exc
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and any(isinstance(base, ast.Name) and base.id == "Base" for base in node.bases)
+    }
+
+
 def discover_public_orm_exports(backend_src: Path) -> list[str]:
     """Return canonical ``package::symbol`` records for root-exported ORM names."""
     if not backend_src.is_dir():
@@ -54,5 +83,15 @@ def discover_public_orm_exports(backend_src: Path) -> list[str]:
                 f"src.{package}.orm."
             ):
                 orm_names.update(alias.asname or alias.name for alias in node.names)
+                continue
+            source = _local_module_path(backend_src, package, node.module)
+            if source is None:
+                continue
+            source_orm_names = _orm_class_names(source)
+            orm_names.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name in source_orm_names
+            )
         findings.extend(f"{package}::{name}" for name in sorted(exports & orm_names))
     return sorted(findings)

--- a/common/meta/extension/public_orm_exports.py
+++ b/common/meta/extension/public_orm_exports.py
@@ -62,6 +62,35 @@ def _orm_class_names(path: Path) -> set[str]:
     }
 
 
+def _local_orm_exports(
+    backend_src: Path, package: str, module: str, seen: frozenset[str] = frozenset()
+) -> set[str]:
+    """Return ORM names exported by a local module, following local re-exports."""
+    if module in seen:
+        return set()
+    path = _local_module_path(backend_src, package, module)
+    if path is None:
+        return set()
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as exc:
+        raise ValueError(f"cannot parse re-export source {path}: {exc}") from exc
+
+    exports = _orm_class_names(path)
+    for node in tree.body:
+        if not isinstance(node, ast.ImportFrom) or node.module is None:
+            continue
+        source_names = _local_orm_exports(
+            backend_src, package, node.module, seen | {module}
+        )
+        exports.update(
+            alias.asname or alias.name
+            for alias in node.names
+            if alias.name in source_names
+        )
+    return exports
+
+
 def discover_public_orm_exports(backend_src: Path) -> list[str]:
     """Return canonical ``package::symbol`` records for root-exported ORM names."""
     if not backend_src.is_dir():
@@ -87,7 +116,7 @@ def discover_public_orm_exports(backend_src: Path) -> list[str]:
             source = _local_module_path(backend_src, package, node.module)
             if source is None:
                 continue
-            source_orm_names = _orm_class_names(source)
+            source_orm_names = _local_orm_exports(backend_src, package, node.module)
             orm_names.update(
                 alias.asname or alias.name
                 for alias in node.names

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -22,14 +22,12 @@ mirroring ``counter``. The headline is the **port/adapter split** (mechanism B,
 dependency inversion): the ``EventBus`` and ``OutboxRepository`` ports live in
 ``base`` so the pure core and consumer packages depend only on abstractions,
 while their concrete adapters (``OutboxEventBus``/``RecordingEventBus`` and the
-SQL ``Outbox`` adapter) live in ``extension``. Because the gate's ``KIND_LAYER``
+SQL ``OutboxRecord`` adapter) live in ``extension``. Because the gate's ``KIND_LAYER``
 has no separate "event-bus split" kind, the two ports are modelled with
 ``kind=REPOSITORY`` (the one base-port/extension-adapter split the gate
 recognises); the concrete bus adapters + relay are ``kind=EVENT_BUS`` (extension).
-``DomainEvent`` is a base ``domain-event`` record; ``Outbox`` is the entity whose
-ORM model lives with the SQL adapter in ``extension`` (declared taxonomy-only, no
-placed module, exactly as ``counter`` keeps its ``CounterTally`` table in
-``extension``).
+``DomainEvent`` and ``Outbox`` are base records; the private ``OutboxRecord`` ORM
+model lives with the SQL adapter in ``extension``.
 
 ### Why layer ``infra``
 
@@ -97,10 +95,9 @@ CONTRACT = PackageContract(
             module="base/outbox.py",
             impl="extension/sql.py",
         ),
-        # entity — the shared outbox row. Its ORM model lives with the SQL adapter
-        # in extension/ (like counter's CounterTally), so it is declared
-        # taxonomy-only (no placed module) to keep base/ free of the ORM.
-        Unit(name="Outbox", kind=Kind.ENTITY),
+        # entity — the public outbox event record stays pure in base/; its
+        # private SQLAlchemy persistence row is the extension adapter detail.
+        Unit(name="Outbox", kind=Kind.ENTITY, module="base/outbox.py"),
         # extension — the concrete event-bus adapters + the post-commit relay.
         Unit(name="OutboxEventBus", kind=Kind.EVENT_BUS, module="extension/bus.py"),
         Unit(name="RecordingEventBus", kind=Kind.EVENT_BUS, module="extension/bus.py"),
@@ -1162,6 +1159,20 @@ CONTRACT = PackageContract(
             statement="Dashboard status feed and event inbox render lightweight derived events as user actions while routine/internal details remain collapsed or absent",
             # was AC19.12.5
             test="apps/frontend/src/__tests__/workflowSurfaces.test.tsx::AC19.12.5 renders lightweight derived workflow events as user actions, not internal logs",
+            priority="P0",
+            status="done",
+        ),
+        ACRecord(
+            id="AC-platform.boundary.1",
+            statement=(
+                "The public Outbox symbol is a pure base-layer event record, "
+                "while the SQLAlchemy outbox row is an extension-internal adapter "
+                "type; public consumers cannot use the ORM model as a boundary."
+            ),
+            test=(
+                "tests/tooling/test_platform_package.py"
+                "::test_AC_platform_boundary_1_outbox_public_language_is_not_an_orm_row"
+            ),
             priority="P0",
             status="done",
         ),

--- a/common/platform/readme.md
+++ b/common/platform/readme.md
@@ -105,7 +105,7 @@ The package follows the building-block layering (see
 | layer | what lives here |
 |------|-----------------|
 | `base/` | the pure core: `DomainEvent` (`event.py`), workflow request/response vocabulary (`workflow.py`), the `EventBus` **port** + `SubscriberRegistry` (`bus.py`), and the `OutboxRepository` **port** (`outbox.py`) — no I/O and no delivery-schema dependency |
-| `extension/` | the impure edges: `OutboxEventBus`/`RecordingEventBus` bus adapters (`bus.py`), the `OutboxRelay` (`relay.py`), and the shared `Outbox` ORM table + `SqlOutboxRepository` adapter (`sql.py`, the only role that touches the ORM/session) |
+| `extension/` | the impure edges: `OutboxEventBus`/`RecordingEventBus` bus adapters (`bus.py`), the `OutboxRelay` (`relay.py`), and the private `OutboxRecord` ORM table + `SqlOutboxRepository` adapter (`sql.py`, the only role that touches the ORM/session) |
 
 The **headline** is the port/adapter split (dependency inversion, mechanism B):
 the `EventBus` and `OutboxRepository` ports live in `base` so the pure core and
@@ -124,12 +124,13 @@ strictly downward edge. See [`contract.py`](./contract.py) for the full rational
 
 **Public** (`__all__`, == `contract.interface`): `DomainEvent`, `EventBus`,
 `OutboxEventBus`, `RecordingEventBus`, `SubscriberRegistry`, `OutboxRelay`,
-`Outbox`, `OutboxRepository` (the port), and the `Workflow*` request/response
-value objects. `src.schemas.workflow` only re-exports that vocabulary for
-delivery compatibility.
+the persistence-neutral `Outbox` event record, `OutboxRepository` (the port),
+and the `Workflow*` request/response value objects. `src.schemas.workflow` only
+re-exports that vocabulary for delivery compatibility.
 
-**Internal**: the `SqlOutboxRepository` adapter (reached only through its port),
-the rehydration helper in `extension/relay.py`, and module internals.
+**Internal**: the `OutboxRecord` SQLAlchemy row and `SqlOutboxRepository` adapter
+(reached only through its port), the rehydration helper in `extension/relay.py`,
+and module internals.
 
 ## Storage
 

--- a/tests/tooling/test_platform_package.py
+++ b/tests/tooling/test_platform_package.py
@@ -17,6 +17,7 @@ import ast
 import sys
 from dataclasses import is_dataclass
 from pathlib import Path
+from typing import get_type_hints
 
 from common.meta.extension.check_package_contract import discover_packages, run
 
@@ -83,6 +84,13 @@ def test_AC_platform_boundary_1_outbox_public_language_is_not_an_orm_row():
     assert is_dataclass(Outbox)
     assert Outbox is not OutboxRecord
     assert Outbox.__module__ == "src.platform.base.outbox"
+
+
+def test_outbox_row_port_declares_publish_mutations() -> None:
+    from src.platform.base.outbox import OutboxRow
+
+    annotations = get_type_hints(OutboxRow)
+    assert {"status", "published_at"} <= annotations.keys()
 
 
 def test_platform_base_layer_is_pure():

--- a/tests/tooling/test_platform_package.py
+++ b/tests/tooling/test_platform_package.py
@@ -15,6 +15,7 @@ carry no ``@ac_proof`` (the domain ACs are proven by the DB-backed tests under
 
 import ast
 import sys
+from dataclasses import is_dataclass
 from pathlib import Path
 
 from common.meta.extension.check_package_contract import discover_packages, run
@@ -72,6 +73,16 @@ def test_platform_repository_split():
     assert "class SqlOutboxRepository" in sql
     ext_bus = (PLATFORM / "extension/bus.py").read_text(encoding="utf-8")
     assert "class OutboxEventBus" in ext_bus
+
+
+def test_AC_platform_boundary_1_outbox_public_language_is_not_an_orm_row():
+    """AC-platform.boundary.1: public Outbox stays persistence-neutral."""
+    from src.platform import Outbox
+    from src.platform.extension.sql import OutboxRecord
+
+    assert is_dataclass(Outbox)
+    assert Outbox is not OutboxRecord
+    assert Outbox.__module__ == "src.platform.base.outbox"
 
 
 def test_platform_base_layer_is_pure():

--- a/tests/tooling/test_public_orm_exports.py
+++ b/tests/tooling/test_public_orm_exports.py
@@ -50,9 +50,12 @@ def test_public_orm_export_gate_follows_package_extension_reexports(
     package = tmp_path / "apps/backend/src/platform/extension"
     package.mkdir(parents=True)
     (package / "sql.py").write_text("class Outbox(Base):\n    pass\n", encoding="utf-8")
-    (package / "__init__.py").write_text("", encoding="utf-8")
-    (package.parent / "__init__.py").write_text(
+    (package / "__init__.py").write_text(
         "from src.platform.extension.sql import Outbox\n__all__ = ['Outbox']\n",
+        encoding="utf-8",
+    )
+    (package.parent / "__init__.py").write_text(
+        "from src.platform.extension import Outbox\n__all__ = ['Outbox']\n",
         encoding="utf-8",
     )
 

--- a/tests/tooling/test_public_orm_exports.py
+++ b/tests/tooling/test_public_orm_exports.py
@@ -44,6 +44,23 @@ def test_public_orm_export_gate_rejects_new_and_stale_debt(tmp_path: Path) -> No
     assert any("stale public-ORM baseline" in finding for finding in findings)
 
 
+def test_public_orm_export_gate_follows_package_extension_reexports(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "apps/backend/src/platform/extension"
+    package.mkdir(parents=True)
+    (package / "sql.py").write_text("class Outbox(Base):\n    pass\n", encoding="utf-8")
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package.parent / "__init__.py").write_text(
+        "from src.platform.extension.sql import Outbox\n__all__ = ['Outbox']\n",
+        encoding="utf-8",
+    )
+
+    assert discover_public_orm_exports(tmp_path / "apps/backend/src") == [
+        "platform::Outbox"
+    ]
+
+
 def test_public_orm_export_gate_fails_on_missing_scan_target(tmp_path: Path) -> None:
     baseline = tmp_path / "baseline.json"
     baseline.write_text("[]\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- move the public `Outbox` language to a frozen, persistence-neutral base record
- keep the SQLAlchemy `OutboxRecord` private to `platform.extension.sql`, and repoint persistence tests there
- harden the public-ORM discovery gate so it follows package-local extension re-exports; a root re-export can no longer bypass the baseline
- add `AC-platform.boundary.1` and package documentation for the public/internal boundary

## Dependency and follow-up
- Stacked on #1934, because the scanner/baseline must exist before this migration is evaluated.
- After #1936 merges and this branch is rebased, remove the resolved `platform::Outbox` entry from the exact unit-accountability baseline.

## Verification
- `pytest tests/tooling/test_public_orm_exports.py tests/tooling/test_platform_package.py -q` (10 passed)
- `pytest tests/platform/test_outbox_atomicity.py tests/platform/test_relay.py tests/counter/test_outbox_emit.py tests/pricing/test_manual.py -n 0 --no-cov -q` (15 passed)
- `python tools/check_public_orm_exports.py`
- `python tools/preflight.py --tier=static`
