### PR TITLE
[finance-report-1897-context-adoption] Complete bounded-context adoption

### DIFF
--- a/common/advisor/contract.py
+++ b/common/advisor/contract.py
@@ -75,6 +75,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Kind,
     PackageContract,
     Unit,
@@ -111,6 +113,84 @@ CONTRACT = PackageContract(
         "workflow",
     ],
     roles=["base", "extension", "data"],
+    context=ContextScope(
+        purpose=(
+            "Provide a read-only application layer that aggregates trusted financial "
+            "facts and lets the LLM explain them without owning domain state."
+        ),
+        in_scope=[
+            "read-only cross-domain financial context aggregation",
+            "advisor guardrails, citations, and streamed explanations",
+            "advisor-owned chat session persistence",
+        ],
+        out_of_scope=[
+            "ledger or other domain-state mutation",
+            "ownership of portfolio, reporting, reconciliation, or workflow policy",
+            "LLM provider transport and model configuration",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="advisor",
+            mode="published-language",
+            reason="Formats audit-owned monetary values for explanations.",
+        ),
+        ContextRelation(
+            provider="ledger",
+            consumer="advisor",
+            mode="published-language",
+            reason="Reads ledger-owned account vocabulary and confidence ranking.",
+        ),
+        ContextRelation(
+            provider="llm",
+            consumer="advisor",
+            mode="published-language",
+            reason="Uses the LLM package facade for bound streaming and provider selection.",
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="advisor",
+            mode="published-language",
+            reason="Uses shared logging and error identifiers without owning observability policy.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="advisor",
+            mode="composition",
+            reason="Uses cross-cutting persistence mixins and application-support vocabulary, not platform workflow ownership.",
+        ),
+        ContextRelation(
+            provider="portfolio",
+            consumer="advisor",
+            mode="projection",
+            reason="Reads portfolio summaries and active symbols as explanation context.",
+        ),
+        ContextRelation(
+            provider="pricing",
+            consumer="advisor",
+            mode="projection",
+            reason="Reads market-data scope status as explanation context.",
+        ),
+        ContextRelation(
+            provider="reconciliation",
+            consumer="advisor",
+            mode="projection",
+            reason="Reads reconciliation statistics without changing matching policy.",
+        ),
+        ContextRelation(
+            provider="reporting",
+            consumer="advisor",
+            mode="projection",
+            reason="Reads report summaries and readiness as deterministic grounding facts.",
+        ),
+        ContextRelation(
+            provider="workflow",
+            consumer="advisor",
+            mode="projection",
+            reason="Reads workflow status and next-action summaries for user guidance.",
+        ),
+    ],
     units=[
         # ── base: aggregate root + entity + value language ──
         # ChatSession/ChatMessage + enums live in orm/chat.py (the package's

--- a/common/advisor/readme.md
+++ b/common/advisor/readme.md
@@ -75,6 +75,15 @@ invariant is P0 across all delivery tiers.
 
 ## Read context (bounded, read-only)
 
+## Bounded-context decision
+
+`advisor` is an application-layer read model and explanation boundary, not a
+domain owner. It may aggregate stable projections from domain packages and ask
+`llm` to phrase grounded facts, but it cannot write their state or redefine
+their policy. Its complete, consumer-owned relationship classification lives in
+[`contract.py`](./contract.py); the `platform` relationship is explicitly
+composition support, while domain reads are published language or projections.
+
 The advisor aggregates context from:
 
 | Source | What it reads | How the advisor reads it |

--- a/common/audit/contract.py
+++ b/common/audit/contract.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -83,6 +84,22 @@ CONTRACT = PackageContract(
     # LLM: a pure-code (CODE-ONLY) package, like ``meta`` and the value packages.
     tier="CODE-ONLY",
     depends_on=[],
+    context=ContextScope(
+        purpose=(
+            "Own the shared numeric and executable-assurance language that every "
+            "financial context can consume without transferring business-state ownership."
+        ),
+        in_scope=[
+            "cross-runtime financial value types and numeric invariants",
+            "append-only TraceRecord assurance vocabulary and projections",
+            "promotion and evidence-language policy",
+        ],
+        out_of_scope=[
+            "ledger, portfolio, reporting, or other business-domain state ownership",
+            "cross-domain workflow, transaction, purge, or lifecycle orchestration",
+            "application delivery, provider configuration, or user-facing policy",
+        ],
+    ),
     # The Shared Kernel value language audit governs, declared as value-object
     # units (the taxonomy; no module path — audit has no physical base/extension
     # split of its own except for the TraceRecord boundary, and the canonical

--- a/common/audit/readme.md
+++ b/common/audit/readme.md
@@ -9,6 +9,17 @@
 
 ## What audit governs
 
+## Bounded-context decision
+
+`audit` owns the shared numeric and executable-assurance language, not a
+business domain. Its value types, promotion vocabulary, and `TraceRecord`
+assurance records are reusable published language for other contexts; consuming
+them never transfers ownership of ledger, portfolio, reporting, or workflow
+state to `audit`. The package also does not orchestrate cross-domain
+transactions, lifecycle operations, delivery, or provider configuration. Its
+complete context boundary is machine-declared in
+[`contract.py`](./contract.py).
+
 - **`audit.base`** — the value language: the cross-runtime Shared-Kernel value
   types (`Money` / `Currency` / `ExchangeRate` / `MoneyTolerance` /
   `CurrencyBalances` / `Ratio` / `Quantity` / `Unit` / `UnitPrice`), plus audit's

--- a/common/audit/readme.md
+++ b/common/audit/readme.md
@@ -9,7 +9,7 @@
 
 ## What audit governs
 
-## Bounded-context decision
+### Bounded-context decision
 
 `audit` owns the shared numeric and executable-assurance language, not a
 business domain. Its value types, promotion vocabulary, and `TraceRecord`

--- a/common/counter/contract.py
+++ b/common/counter/contract.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from common.meta.package_contract import (
     ACRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -30,6 +32,33 @@ CONTRACT = PackageContract(
     # Every AC in the roadmap inherits this tier.
     tier="CODE-ONLY",
     depends_on=["platform"],
+    context=ContextScope(
+        purpose=(
+            "Own reusable per-user and global named-event tallies, with a narrow "
+            "counter value language and one counter-owned increment event."
+        ),
+        in_scope=[
+            "CounterKey and non-negative Count vocabulary",
+            "per-user and global tally operations and repository port",
+            "emission of the counter.Incremented event after a counter mutation",
+        ],
+        out_of_scope=[
+            "business-domain metrics, reporting interpretation, or product analytics",
+            "generic event-bus or outbox persistence ownership",
+            "workflow, application routing, or cross-domain orchestration",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="platform",
+            consumer="counter",
+            mode="consumer-port",
+            reason=(
+                "Consumes the platform EventBus/outbox port to publish the "
+                "counter-owned Incremented event atomically without owning the substrate."
+            ),
+        )
+    ],
     roles=["base", "extension"],
     units=[
         # base — pure value objects + the domain event type.

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -11,7 +11,7 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
 `counter` owns the small tally model: namespaced keys, non-negative counts, and
 the `counter.Incremented` fact emitted when its own tally changes. It consumes

--- a/common/counter/readme.md
+++ b/common/counter/readme.md
@@ -11,6 +11,15 @@
 
 ## Why
 
+## Bounded-context decision
+
+`counter` owns the small tally model: namespaced keys, non-negative counts, and
+the `counter.Incremented` fact emitted when its own tally changes. It consumes
+the `platform` EventBus/outbox as a consumer port rather than owning generic
+event delivery. It does not own reporting interpretation, business metrics,
+workflow, routing, or cross-domain orchestration. The machine-readable context
+boundary and relationship are declared in [`contract.py`](./contract.py).
+
 Insight reports ask "**how many times did X happen** — overall, or for this
 user?". `counter` is the small, reusable middleware capability that answers that:
 it tallies named events per user and lets a report read either the per-user count

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -59,6 +59,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -88,6 +90,87 @@ CONTRACT = PackageContract(
         # ``register_fx_rate_provider``, also wired by main.py — extraction
         # no longer imports either package directly.
         "runtime",
+    ],
+    context=ContextScope(
+        purpose=(
+            "Own source-document ingestion, parsing, validation, and evidence lineage "
+            "that turn supported financial documents into reviewable source facts."
+        ),
+        in_scope=[
+            "uploaded-document and statement source lifecycle, parsed facts, and provenance",
+            "document parsing, confidence/balance validation, review disposition, and corrections",
+            "extraction-owned AtomicTransaction/position facts and source-to-fact evidence lineage",
+        ],
+        out_of_scope=[
+            "double-entry journal ownership, account policy, and final ledger facts",
+            "model-provider configuration, shared financial value/assurance ownership, and storage infrastructure",
+            "portfolio valuation, pricing resolution, reconciliation matching, and report presentation",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="extraction",
+            mode="published-language",
+            reason=(
+                "Uses audit monetary, quantity, source-type, and invariant language while "
+                "retaining source-document semantics."
+            ),
+        ),
+        ContextRelation(
+            provider="audit",
+            consumer="extraction",
+            mode="consumer-port",
+            reason=(
+                "Consumes audit TraceRecord ports to attach evidence to extraction decisions "
+                "without owning assurance authority or persistence."
+            ),
+        ),
+        ContextRelation(
+            provider="identity",
+            consumer="extraction",
+            mode="published-language",
+            reason="Uses the identity-owned user language to scope source documents and parsing work.",
+        ),
+        ContextRelation(
+            provider="ledger",
+            consumer="extraction",
+            mode="consumer-port",
+            reason=(
+                "Uses ledger command and account ports to submit reviewed, dispositioned "
+                "financial facts without owning double-entry state."
+            ),
+        ),
+        ContextRelation(
+            provider="llm",
+            consumer="extraction",
+            mode="published-language",
+            reason=(
+                "Uses the LLM facade's typed OCR/vision/JSON call language while keeping "
+                "document parsing and acceptance policy in extraction."
+            ),
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="extraction",
+            mode="published-language",
+            reason="Uses published safe logging, PII, and parse-outcome telemetry language.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="extraction",
+            mode="composition",
+            reason="Uses platform persistence mixins and shared application exceptions without owning the substrate.",
+        ),
+        ContextRelation(
+            provider="runtime",
+            consumer="extraction",
+            mode="consumer-port",
+            reason=(
+                "Consumes the runtime storage port and redaction helper for source content "
+                "without owning environment dependency configuration."
+            ),
+        ),
     ],
     roles=["base", "extension", "data"],
     units=[

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -99,7 +99,7 @@ CONTRACT = PackageContract(
         in_scope=[
             "uploaded-document and statement source lifecycle, parsed facts, and provenance",
             "document parsing, confidence/balance validation, review disposition, and corrections",
-            "extraction-owned AtomicTransaction/position facts and source-to-fact evidence lineage",
+            "extraction-owned AtomicTransaction and AtomicPosition facts and source-to-fact evidence lineage",
         ],
         out_of_scope=[
             "double-entry journal ownership, account policy, and final ledger facts",

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -20,6 +20,17 @@ This document defines the Single Source of Truth for the document extraction fea
 
 ## Overview
 
+## Bounded-context decision
+
+`extraction` owns the source-document-to-fact boundary: ingestion, parsing,
+validation, review disposition, correction, and provenance. It consumes audit
+value/evidence ports, identity's user language, ledger command ports, the LLM
+facade, observability language, platform composition, and runtime storage ports
+without taking ownership of those concerns. It does not own final ledger facts,
+provider configuration, valuation resolution, reconciliation matching, or
+report presentation. The machine-readable boundary and relationships are in
+[`contract.py`](./contract.py).
+
 The extraction pipeline parses financial statements (PDFs, images, CSVs) with the configured AI provider. PDF/image uploads use `OCR_MODEL` (default `glm-4.6v`) as the OCR-capable model. When `OCR_MODEL` is a separate model from `VISION_MODEL`, the service uses the provider layout parser first, then structures Markdown with `PRIMARY_MODEL` (default `glm-5.1`). When `OCR_MODEL` equals `VISION_MODEL`, the service skips layout parsing and uses the shared vision OCR path directly. Z.AI PDF vision extraction renders the uploaded PDF bytes into a bounded set of in-memory PNG `image_url` payloads; short-lived external URLs are used only when no bytes are available. Inline base64 PDF payloads are reserved for dedicated layout parsing and non-Z.AI compatibility. JSON extraction disables GLM thinking by default and caps output tokens to keep provider latency bounded. Uploads immediately create a `parsing` record, and a background worker updates the statement once parsing completes.
 
 ## Statement ingestion application boundary

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -20,7 +20,7 @@ This document defines the Single Source of Truth for the document extraction fea
 
 ## Overview
 
-## Bounded-context decision
+### Bounded-context decision
 
 `extraction` owns the source-document-to-fact boundary: ingestion, parsing,
 validation, review disposition, correction, and provenance. It consumes audit

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -47,6 +47,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -67,6 +69,42 @@ CONTRACT = PackageContract(
     # the edge rule; the former flat src.logger / src.utils now live inside the
     # observability / platform packages, so those imports are governed edges.)
     depends_on=["platform", "observability"],
+    context=ContextScope(
+        purpose=(
+            "Own user identity, authentication, user-scoped credentials, and AI "
+            "feedback without owning the financial domains a user may access."
+        ),
+        in_scope=[
+            "User aggregate, normalized account identity, and AI-feedback records",
+            "JWT/OAuth authentication, password security, and current-user resolution",
+            "identity-owned registration, login, and user-profile compatibility operations",
+        ],
+        out_of_scope=[
+            "ledger, statement, portfolio, reporting, or reconciliation state and policy",
+            "generic request limiting, HTTP error vocabulary, or persistence substrate ownership",
+            "cross-domain workflow or application-level authorization decisions",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="platform",
+            consumer="identity",
+            mode="consumer-port",
+            reason=(
+                "Consumes platform rate-limiting and request-error ports while identity "
+                "retains authentication and account policy."
+            ),
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="identity",
+            mode="published-language",
+            reason=(
+                "Uses published safe logging and security-warning language without "
+                "owning telemetry policy."
+            ),
+        ),
+    ],
     roles=["base", "extension"],
     units=[
         # base — the auth value objects (the published wire language).

--- a/common/identity/contract.py
+++ b/common/identity/contract.py
@@ -75,7 +75,7 @@ CONTRACT = PackageContract(
             "feedback without owning the financial domains a user may access."
         ),
         in_scope=[
-            "User aggregate, normalized account identity, and AI-feedback records",
+            "User aggregate, normalized email identity, and AI-feedback records",
             "JWT/OAuth authentication, password security, and current-user resolution",
             "identity-owned registration, login, and user-profile compatibility operations",
         ],

--- a/common/identity/readme.md
+++ b/common/identity/readme.md
@@ -14,6 +14,16 @@
 
 ## Why
 
+## Bounded-context decision
+
+`identity` owns accounts, authentication credentials, current-user resolution,
+and user AI-feedback—not the financial state or policy a user can access. It
+consumes `platform` rate-limiting/request-error ports and `observability` safe
+logging language without taking ownership of either substrate. Cross-domain
+workflow and application-level authorization decisions remain outside this
+context. The machine-readable boundary and relationships are in
+[`contract.py`](./contract.py).
+
 Every user-scoped request must resolve identity from a cryptographic token, and
 new users must register / log in. `identity` is the package that owns that: a
 mandatory JWT/OAuth2 identity system, the `User` aggregate it authenticates

--- a/common/identity/readme.md
+++ b/common/identity/readme.md
@@ -14,10 +14,10 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
-`identity` owns accounts, authentication credentials, current-user resolution,
-and user AI-feedback—not the financial state or policy a user can access. It
+`identity` owns user accounts, authentication credentials, current-user resolution,
+and user AI-feedback — not the financial state or policy a user can access. It
 consumes `platform` rate-limiting/request-error ports and `observability` safe
 logging language without taking ownership of either substrate. Cross-domain
 workflow and application-level authorization decisions remain outside this

--- a/common/ledger/contract.py
+++ b/common/ledger/contract.py
@@ -84,6 +84,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -112,6 +114,57 @@ CONTRACT = PackageContract(
     # same rank as ledger, and extraction already depends_on ledger — a direct
     # edge would cycle).
     depends_on=["audit", "observability", "platform"],
+    context=ContextScope(
+        purpose=(
+            "Own double-entry financial facts: accounts, journal entries, posting "
+            "and voiding rules, and processing-account transfer semantics."
+        ),
+        in_scope=[
+            "ledger account, journal-entry, journal-line, and processing-account state",
+            "double-entry, currency-balance, posting, voiding, and immutability rules",
+            "ledger-owned decision-anchored financial-write boundary and balance projections",
+        ],
+        out_of_scope=[
+            "shared money, provenance, or assurance-language ownership",
+            "generic persistence, telemetry, event delivery, or external FX-provider ownership",
+            "reconciliation matching, report presentation, and cross-domain workflow orchestration",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="ledger",
+            mode="published-language",
+            reason=(
+                "Uses audit-owned Money, Currency, source-type, and assurance value "
+                "language while retaining all double-entry semantics."
+            ),
+        ),
+        ContextRelation(
+            provider="audit",
+            consumer="ledger",
+            mode="consumer-port",
+            reason=(
+                "Consumes audit TraceRecord repository/emitter ports for decision "
+                "evidence rather than owning assurance persistence or authority policy."
+            ),
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="ledger",
+            mode="published-language",
+            reason="Uses published safe logging language for ledger operational diagnostics.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="ledger",
+            mode="composition",
+            reason=(
+                "Uses platform persistence mixins for ledger ORM rows without owning "
+                "the shared persistence substrate."
+            ),
+        ),
+    ],
     roles=["base", "extension", "data"],
     units=[
         # base — the pure double-entry core.

--- a/common/ledger/readme.md
+++ b/common/ledger/readme.md
@@ -24,6 +24,16 @@
 
 # Double-Entry Bookkeeping Domain Model SSOT
 
+## Bounded-context decision
+
+`ledger` owns accounts, journal facts, double-entry validation, posting/voiding,
+and processing-account transfer semantics. It consumes `audit`'s shared value
+language plus assurance ports, `observability`'s logging language, and
+`platform` persistence composition without acquiring ownership of any of those
+subsystems. Reconciliation matching, report presentation, external FX provision,
+and cross-domain workflow remain outside the ledger context. The machine-readable
+boundary and relationships are declared in [`contract.py`](./contract.py).
+
 > **SSOT Key**: `accounting`
 > **Core Definition**: Accounting equation, account classification, and entry rules for double-entry bookkeeping.
 

--- a/common/llm/contract.py
+++ b/common/llm/contract.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -65,6 +67,42 @@ CONTRACT = PackageContract(
     # mixins (UUIDMixin/TimestampMixin), moved from src/models/base.py to
     # platform.orm.base. Same-rank edge (both infra, L1), acyclic.
     depends_on=["observability", "platform"],
+    context=ContextScope(
+        purpose=(
+            "Own model-provider interaction: typed scenes and bindings, provider "
+            "secrets, deterministic cassettes, and the provider-facing client boundary."
+        ),
+        in_scope=[
+            "protocol-family, model, scene, and scene-binding language",
+            "provider-secret handling, routing, catalogues, and usage measurement",
+            "input-keyed cassette record/replay and model-call evaluation mechanisms",
+        ],
+        out_of_scope=[
+            "extraction, advisor, or reconciliation business prompts and decisions",
+            "runtime dependency presence, environment substitution, or deployment policy",
+            "generic telemetry policy or persistence-substrate ownership",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="observability",
+            consumer="llm",
+            mode="published-language",
+            reason=(
+                "Uses published safe logging and AI-provider-call telemetry while "
+                "retaining model usage semantics in the llm context."
+            ),
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="llm",
+            mode="composition",
+            reason=(
+                "Uses platform persistence mixins for LLM configuration rows without "
+                "owning the generic persistence substrate."
+            ),
+        ),
+    ],
     roles=["base", "extension", "data"],
     units=[
         # ── base: the frozen value language (mechanism A) ──

--- a/common/llm/readme.md
+++ b/common/llm/readme.md
@@ -17,6 +17,16 @@
 
 # LLM Provider Abstraction SSOT
 
+## Bounded-context decision
+
+`llm` owns the provider-facing model boundary: scenes, bindings, secrets,
+routing, deterministic cassettes, and provider-call evaluation machinery. It
+consumes `observability` as published logging/telemetry language and `platform`
+only as persistence composition support. It does not own callers' prompts or
+business decisions, runtime dependency presence, generic telemetry policy, or
+the persistence substrate. Its machine-readable context boundary is in
+[`contract.py`](./contract.py).
+
 > **SSOT Key**: `llm_provider_abstraction`
 > **Core Definition**: How the backend talks to language models — the three
 > orthogonal axes (protocol family × model × scene), the scene→model binding, and

--- a/common/meta/contract.py
+++ b/common/meta/contract.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -36,6 +37,22 @@ CONTRACT = PackageContract(
     # L0 depends on nothing: the tier vocabulary (base/authority_matrix.py) and
     # the five-layer topology (base/layering.py) are meta's own base modules.
     depends_on=[],
+    context=ContextScope(
+        purpose=(
+            "Define the package-governance language and compute the validations, "
+            "indexes, and impact evidence that keep package boundaries auditable."
+        ),
+        in_scope=[
+            "package-contract vocabulary and topology",
+            "computed package governance indexes and reports",
+            "contract and SSOT validation gates",
+        ],
+        out_of_scope=[
+            "individual package business goals and domain policy",
+            "product direction and prioritization",
+            "runtime delivery and application composition",
+        ],
+    ),
     roles=["base", "extension", "data"],
     units=[
         # base — the pure model: the PackageContract aggregate root + its value

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -6,7 +6,6 @@
   "identity",
   "ledger",
   "llm",
-  "meta",
   "observability",
   "portfolio",
   "pricing",

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -8,7 +8,6 @@
   "llm",
   "meta",
   "observability",
-  "platform",
   "portfolio",
   "pricing",
   "reconciliation",

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -1,11 +1,1 @@
-[
-  "counter",
-  "extraction",
-  "ledger",
-  "llm",
-  "observability",
-  "portfolio",
-  "reconciliation",
-  "runtime",
-  "workflow"
-]
+[]

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -6,7 +6,6 @@
   "observability",
   "portfolio",
   "reconciliation",
-  "reporting",
   "runtime",
   "workflow"
 ]

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -5,7 +5,6 @@
   "llm",
   "observability",
   "portfolio",
-  "pricing",
   "reconciliation",
   "reporting",
   "runtime",

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -1,7 +1,6 @@
 [
   "counter",
   "extraction",
-  "identity",
   "ledger",
   "llm",
   "observability",

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -12,6 +12,5 @@
   "reconciliation",
   "reporting",
   "runtime",
-  "testing",
   "workflow"
 ]

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -1,5 +1,4 @@
 [
-  "audit",
   "counter",
   "extraction",
   "identity",

--- a/common/meta/data/context-contract-baseline.json
+++ b/common/meta/data/context-contract-baseline.json
@@ -1,5 +1,4 @@
 [
-  "advisor",
   "audit",
   "counter",
   "extraction",

--- a/common/observability/contract.py
+++ b/common/observability/contract.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextScope,
     Invariant,
     PackageContract,
 )
@@ -37,6 +38,22 @@ CONTRACT = PackageContract(
     status="active",
     tier="CODE-ONLY",
     depends_on=[],
+    context=ContextScope(
+        purpose=(
+            "Own the cross-cutting observability language that makes runtime behavior "
+            "and safe operational evidence visible without owning the behavior observed."
+        ),
+        in_scope=[
+            "vendor-neutral telemetry, metrics, and request identifiers",
+            "structured audit and security logging with PII-safe error summaries",
+            "operator-facing OpenPanel query tooling",
+        ],
+        out_of_scope=[
+            "business-domain state, financial policy, or domain-event ownership",
+            "application workflow, transaction, or lifecycle orchestration",
+            "product analytics interpretation or user-facing application decisions",
+        ],
+    ),
     implementations={"be": "apps/backend/src/observability", "fe": None},
     units=[],
     interface=[

--- a/common/observability/readme.md
+++ b/common/observability/readme.md
@@ -5,6 +5,15 @@
 
 ## What
 
+## Bounded-context decision
+
+`observability` owns cross-cutting telemetry and safe operational evidence, not
+the business behavior it observes. It publishes request/metrics/logging language
+and operator tooling while leaving financial policy, domain events, application
+workflow, lifecycle operations, and product decisions to their owning contexts.
+The machine-readable responsibility boundary is in
+[`contract.py`](./contract.py).
+
 Two cohesive surfaces under one `infra` package:
 
 1. **Backend observability language** (BE implementation:

--- a/common/platform/contract.py
+++ b/common/platform/contract.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 from common.meta.package_contract import (
     ACRecord,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -77,6 +78,22 @@ CONTRACT = PackageContract(
     # ``api_rate_limiter`` instance is wired at the composition root (src.main),
     # so the substrate stays config-free.
     depends_on=[],
+    context=ContextScope(
+        purpose=(
+            "Provide reusable runtime infrastructure for transactional domain-event "
+            "delivery, request-rate protection, and structural persistence support."
+        ),
+        in_scope=[
+            "transactional outbox and generic event dispatch",
+            "process-wide request rate limiting",
+            "shared structural ORM mixins",
+        ],
+        out_of_scope=[
+            "domain workflow and saga semantics",
+            "business-domain state and policy",
+            "HTTP route ownership and application composition",
+        ],
+    ),
     roles=["base", "extension"],
     units=[
         # base — the domain-event record (the textbook mechanism-C type).

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -130,7 +130,7 @@ CONTRACT = PackageContract(
             provider="platform",
             consumer="portfolio",
             mode="composition",
-            reason="Uses platform persistence mixins without owning generic persistence behavior.",
+            reason="Uses platform ORM persistence mixins without owning generic persistence behavior.",
         ),
         ContextRelation(
             provider="pricing",

--- a/common/portfolio/contract.py
+++ b/common/portfolio/contract.py
@@ -51,6 +51,8 @@ from __future__ import annotations
 
 from common.meta.package_contract import (
     ACRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -76,6 +78,69 @@ CONTRACT = PackageContract(
         "observability",
         "platform",
         "pricing",
+    ],
+    context=ContextScope(
+        purpose=(
+            "Own investment position accounting: lots, cost basis, position quantity, "
+            "and realized or unrealized performance over accounting facts."
+        ),
+        in_scope=[
+            "ManagedPosition, investment lots, investment transactions, and dividend position math",
+            "cost-basis selection, holdings, allocation, and portfolio performance projections",
+            "portfolio-owned trade accounting inputs before ledger posting",
+        ],
+        out_of_scope=[
+            "source-document/AtomicPosition lifecycle and extraction provenance",
+            "double-entry journal ownership or price/FX observation and resolution ownership",
+            "shared value language, telemetry/persistence substrate, report presentation, and workflow",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="portfolio",
+            mode="published-language",
+            reason="Uses audit Money, Quantity, UnitPrice, and Ratio language for position accounting.",
+        ),
+        ContextRelation(
+            provider="extraction",
+            consumer="portfolio",
+            mode="projection",
+            reason=(
+                "Reads extraction-owned AtomicPosition and managed-position snapshots as "
+                "brokerage input without owning document facts or provenance."
+            ),
+        ),
+        ContextRelation(
+            provider="ledger",
+            consumer="portfolio",
+            mode="consumer-port",
+            reason=(
+                "Submits balanced trade and dividend entries through ledger ports while "
+                "retaining portfolio lot and cost-basis semantics."
+            ),
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="portfolio",
+            mode="published-language",
+            reason="Uses published safe logging language for portfolio calculation diagnostics.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="portfolio",
+            mode="composition",
+            reason="Uses platform persistence mixins without owning generic persistence behavior.",
+        ),
+        ContextRelation(
+            provider="pricing",
+            consumer="portfolio",
+            mode="published-language",
+            reason=(
+                "Consumes pricing valuation and FX-resolution language but never fetches, "
+                "stores, or resolves price observations itself."
+            ),
+        ),
     ],
     roles=["base", "extension", "data"],
     units=[

--- a/common/portfolio/readme.md
+++ b/common/portfolio/readme.md
@@ -10,6 +10,16 @@
 
 ## Why
 
+## Bounded-context decision
+
+`portfolio` owns investment position accounting: lots, cost basis, quantities,
+and performance. It consumes extraction position projections, ledger posting
+ports, pricing resolution language, audit value types, observability logging,
+and platform persistence composition without owning any of them. It does not
+own source-document lifecycle, journal facts, price observations, reporting
+presentation, or workflow. The machine-readable boundary and relationships are
+in [`contract.py`](./contract.py).
+
 Buying, selling, and receiving a dividend on an investment needs the same
 double-entry discipline as any other cash movement, plus position bookkeeping
 double-entry doesn't cover: which lot did this sale consume, at what cost

--- a/common/portfolio/readme.md
+++ b/common/portfolio/readme.md
@@ -10,7 +10,7 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
 `portfolio` owns investment position accounting: lots, cost basis, quantities,
 and performance. It consumes extraction position projections, ledger posting

--- a/common/pricing/contract.py
+++ b/common/pricing/contract.py
@@ -62,6 +62,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -80,6 +82,72 @@ CONTRACT = PackageContract(
     # package, so it's never governed by depends_on — no other package
     # declares it either despite importing it directly.
     depends_on=["audit", "extraction", "platform", "observability"],
+    context=ContextScope(
+        purpose=(
+            "Own price and valuation observations, their bitemporal authority, and "
+            "the policy-driven resolution of a subject's value at a time."
+        ),
+        in_scope=[
+            "PriceObservation, PriceableSubject, authority, staleness, and resolution policy",
+            "FX rate lookup, valuation observation ingestion, and manual/override observations",
+            "pricing-owned PriceObserved events and decision-backed valuation contributions",
+        ],
+        out_of_scope=[
+            "document extraction facts and re-parse lifecycle",
+            "shared money arithmetic and assurance-language ownership",
+            "portfolio position ownership, report presentation, and cross-domain workflow",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="pricing",
+            mode="published-language",
+            reason=(
+                "Uses audit Money, exchange-rate arithmetic, and assurance value language "
+                "while pricing owns rate lookup and valuation selection."
+            ),
+        ),
+        ContextRelation(
+            provider="audit",
+            consumer="pricing",
+            mode="consumer-port",
+            reason=(
+                "Consumes audit decision-evidence repository/emitter ports rather than "
+                "owning assurance authority or its persistence."
+            ),
+        ),
+        ContextRelation(
+            provider="extraction",
+            consumer="pricing",
+            mode="event",
+            reason=(
+                "Ingests extraction-owned statement-price facts as id-referenced copies "
+                "after PriceObserved events; no extraction lifecycle is owned here."
+            ),
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="pricing",
+            mode="consumer-port",
+            reason=(
+                "Uses platform EventBus/outbox ports to publish pricing events atomically "
+                "with pricing-owned observations."
+            ),
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="pricing",
+            mode="composition",
+            reason="Uses platform persistence mixins without owning the shared persistence substrate.",
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="pricing",
+            mode="published-language",
+            reason="Uses published safe logging language for provider and resolution diagnostics.",
+        ),
+    ],
     roles=["base", "extension", "data"],
     units=[
         # ── base: the pure observation + subject-identity + policy language ──

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -14,7 +14,7 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
 `pricing` owns observations of value and the explicit policy that resolves a
 subject's value at a point in time. It ingests extraction-owned statement price

--- a/common/pricing/readme.md
+++ b/common/pricing/readme.md
@@ -14,6 +14,16 @@
 
 ## Why
 
+## Bounded-context decision
+
+`pricing` owns observations of value and the explicit policy that resolves a
+subject's value at a point in time. It ingests extraction-owned statement price
+facts by event, consumes `audit` value language and assurance ports, and uses
+`platform` only for event/persistence support. It does not own document
+lifecycle, shared financial arithmetic, portfolio positions, report presentation,
+or workflow. The machine-readable boundary and relationships are in
+[`contract.py`](./contract.py).
+
 Pre-migration, "what is X worth at time T" was scattered across 5 tables with
 3 incompatible key vocabularies (`FxRate`, `StockPrice`, `MarketDataOverride`,
 `ManualValuationSnapshot`, plus statement-extracted unit prices), and the

--- a/common/reconciliation/contract.py
+++ b/common/reconciliation/contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -40,6 +42,75 @@ CONTRACT = PackageContract(
         "observability",
         "platform",
         "pricing",
+    ],
+    context=ContextScope(
+        purpose=(
+            "Own the confidence-scored matching and review lifecycle that links "
+            "independent source transactions to ledger facts without merging either source."
+        ),
+        in_scope=[
+            "ReconciliationMatch lifecycle, candidate generation, scoring, and review decisions",
+            "many-to-one and FX transfer matching, anomaly and consistency diagnostics",
+            "reconciliation statistics and match-outcome evidence",
+        ],
+        out_of_scope=[
+            "source-document and AtomicTransaction ownership",
+            "journal-entry ownership, double-entry posting, and price-observation resolution",
+            "shared money, model-provider, telemetry, persistence, and workflow ownership",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="reconciliation",
+            mode="published-language",
+            reason="Uses audit monetary, ratio, provenance, and promotion language for matching evidence.",
+        ),
+        ContextRelation(
+            provider="extraction",
+            consumer="reconciliation",
+            mode="projection",
+            reason=(
+                "Reads extraction-owned AtomicTransaction facts and reviewed dispositions "
+                "as one side of matching without owning source parsing or provenance."
+            ),
+        ),
+        ContextRelation(
+            provider="ledger",
+            consumer="reconciliation",
+            mode="published-language",
+            reason=(
+                "Uses ledger journal/account language as the independent accounting side of "
+                "a match without posting or owning journal facts."
+            ),
+        ),
+        ContextRelation(
+            provider="llm",
+            consumer="reconciliation",
+            mode="published-language",
+            reason=(
+                "Uses the LLM semantic-score facade as an advisory signal while the match "
+                "decision and safe fallback remain reconciliation-owned."
+            ),
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="reconciliation",
+            mode="published-language",
+            reason="Uses published safe logging and reconciliation-outcome telemetry language.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="reconciliation",
+            mode="composition",
+            reason="Uses platform persistence mixins without owning generic persistence behavior.",
+        ),
+        ContextRelation(
+            provider="pricing",
+            consumer="reconciliation",
+            mode="published-language",
+            reason="Uses pricing FX-conversion language for cross-currency transfer matching.",
+        ),
     ],
     roles=["base", "extension", "data"],
     units=[

--- a/common/reconciliation/readme.md
+++ b/common/reconciliation/readme.md
@@ -10,6 +10,15 @@
 
 ## Why
 
+## Bounded-context decision
+
+`reconciliation` owns scored matching and review decisions between independent
+extraction and ledger facts. It consumes extraction projections, ledger
+language, pricing FX conversion, audit value/provenance language, an advisory
+LLM score, observability language, and platform persistence composition. It does
+not own either source fact, journal posting, price resolution, or workflow. The
+machine-readable boundary and relationships are in [`contract.py`](./contract.py).
+
 Extracted bank transactions and manually/portfolio-posted journal entries are
 two independent records of the same real-world event; `reconciliation` decides
 whether they refer to the same thing, at what confidence, and routes anything

--- a/common/reconciliation/readme.md
+++ b/common/reconciliation/readme.md
@@ -10,7 +10,7 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
 `reconciliation` owns scored matching and review decisions between independent
 extraction and ledger facts. It consumes extraction projections, ledger

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -52,6 +54,72 @@ CONTRACT = PackageContract(
         "portfolio",
         "pricing",
         "reconciliation",
+    ],
+    context=ContextScope(
+        purpose=(
+            "Own deterministic financial report assembly, framework disclosure, and "
+            "frozen report snapshots over trusted facts from other contexts."
+        ),
+        in_scope=[
+            "financial statement and net-worth calculation views",
+            "ReportSnapshot, report-line, framework-policy, readiness, and disclosure language",
+            "report-package assembly and traceability of the exact facts a report freezes",
+        ],
+        out_of_scope=[
+            "source-document parsing, ledger posting, position accounting, matching, or valuation resolution",
+            "shared financial value/assurance ownership and generic telemetry or persistence substrate",
+            "cross-domain workflow execution and user-facing delivery routing",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="audit",
+            consumer="reporting",
+            mode="published-language",
+            reason="Uses audit monetary, source-type, and assurance language for report calculations and disclosure.",
+        ),
+        ContextRelation(
+            provider="extraction",
+            consumer="reporting",
+            mode="projection",
+            reason="Reads statement contributions and source-fact projections without owning document lifecycle.",
+        ),
+        ContextRelation(
+            provider="ledger",
+            consumer="reporting",
+            mode="projection",
+            reason="Reads posted ledger and account projections without creating or changing journal facts.",
+        ),
+        ContextRelation(
+            provider="observability",
+            consumer="reporting",
+            mode="published-language",
+            reason="Uses published safe logging and error-identification language for report generation diagnostics.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="reporting",
+            mode="composition",
+            reason="Uses platform persistence mixins and request-error helpers without owning the substrate.",
+        ),
+        ContextRelation(
+            provider="portfolio",
+            consumer="reporting",
+            mode="projection",
+            reason="Reads portfolio performance and holdings projections for report schedules without owning positions.",
+        ),
+        ContextRelation(
+            provider="pricing",
+            consumer="reporting",
+            mode="projection",
+            reason="Reads decision-backed valuation and FX-resolution contributions without resolving prices itself.",
+        ),
+        ContextRelation(
+            provider="reconciliation",
+            consumer="reporting",
+            mode="projection",
+            reason="Reads reconciliation readiness and transfer-match state for report disclosure without making matches.",
+        ),
     ],
     roles=["base", "extension", "data"],
     units=[

--- a/common/reporting/readme.md
+++ b/common/reporting/readme.md
@@ -35,7 +35,7 @@
 
 ## Why
 
-## Bounded-context decision
+### Bounded-context decision
 
 `reporting` owns deterministic report assembly, policy disclosure, readiness,
 and frozen report snapshots. It reads projections and contribution DTOs from

--- a/common/reporting/readme.md
+++ b/common/reporting/readme.md
@@ -35,6 +35,15 @@
 
 ## Why
 
+## Bounded-context decision
+
+`reporting` owns deterministic report assembly, policy disclosure, readiness,
+and frozen report snapshots. It reads projections and contribution DTOs from
+ledger, extraction, portfolio, pricing, and reconciliation; it never changes
+their facts or policies. Audit supplies shared financial language, while
+observability and platform provide supporting language/composition only. The
+machine-readable boundary and relationships are in [`contract.py`](./contract.py).
+
 Balance sheet, income statement, cash flow, and net worth all read the same
 posted ledger state through different lenses. `reporting` is the calculation
 layer over `ledger` (and, via `pricing`, over valuation) that produces those

--- a/common/runtime/contract.py
+++ b/common/runtime/contract.py
@@ -6,7 +6,8 @@ provider, cache, telemetry, …), how each of the six environments substitutes
 them, and the invariant that a *declared* dependency must be *asserted present*
 (no silent ``skipped``/``warning``/fallback).
 
-An ``infra`` leaf (L1, ``depends_on=[]``), now ``active``. The *construct* phase
+An ``infra`` package (L1) with one declared observability-language dependency,
+now ``active``. The *construct* phase
 shipped the ``base`` value language + dependency manifest + the
 ``DependencyCheck`` port; the *switch* phase added the ``extension`` probe
 adapters (``DatabaseCheck`` / ``ObjectStorageCheck`` / ``LlmCheck``, published
@@ -27,6 +28,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     PackageContract,
 )
@@ -39,6 +42,33 @@ CONTRACT = PackageContract(
     # Settings singleton) — not the registered config package (common/config,
     # env_keys/schema_validation), which runtime never actually imports.
     depends_on=["observability"],
+    context=ContextScope(
+        purpose=(
+            "Own the app-to-external-world dependency contract: environment tiers, "
+            "declared backends, substitutes, and fail-closed presence evidence."
+        ),
+        in_scope=[
+            "dependency manifest and environment-tier vocabulary",
+            "dependency probes, smoke checks, and release evidence transport",
+            "external service substitution and presence assertions",
+        ],
+        out_of_scope=[
+            "telemetry emission, logging policy, or observability query ownership",
+            "business-domain state, financial policy, and domain events",
+            "in-process workflow or cross-domain application orchestration",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="observability",
+            consumer="runtime",
+            mode="published-language",
+            reason=(
+                "Uses observability's published logger and health-status language when "
+                "reporting dependency probe and storage outcomes."
+            ),
+        )
+    ],
     roles=[],
     implementations={"be": "apps/backend/src/runtime", "fe": None},
     interface=[

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -8,6 +8,16 @@
 
 ## Why this package exists
 
+## Bounded-context decision
+
+`runtime` owns the contract at the app-to-external-world boundary: which
+dependencies each environment requires, how they are substituted, and how
+their presence is proven. It consumes `observability`'s published logging and
+health-status language but does not own telemetry policy. It also does not own
+business state, financial policy, or in-process workflow orchestration. The
+machine-readable responsibility and its sole outgoing context relationship live
+in [`contract.py`](./contract.py).
+
 The application depends on external backends — object storage (S3), the LLM
 provider, cache (Redis), telemetry (OTel), analytics (OpenPanel), the database.
 Today that boundary is **homeless**: `ServiceStatus` + `_check_*` float in

--- a/common/runtime/readme.md
+++ b/common/runtime/readme.md
@@ -8,7 +8,7 @@
 
 ## Why this package exists
 
-## Bounded-context decision
+### Bounded-context decision
 
 `runtime` owns the contract at the app-to-external-world boundary: which
 dependencies each environment requires, how they are substituted, and how
@@ -20,7 +20,7 @@ in [`contract.py`](./contract.py).
 
 The application depends on external backends — object storage (S3), the LLM
 provider, cache (Redis), telemetry (OTel), analytics (OpenPanel), the database.
-Today that boundary is **homeless**: `ServiceStatus` + `_check_*` float in
+Before this package was introduced, that boundary was **homeless**: `ServiceStatus` + `_check_*` floated in
 `apps/backend/src/boot.py`, env keys live in `config`, the smoke test is a shell
 script, and the six-environment tiering lives in `environments.md`. Nobody owns
 the *contract* across them — which is exactly why dependencies **degrade

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -45,6 +45,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -66,6 +68,33 @@ CONTRACT = PackageContract(
     # — it was a dark edge before the scan learned to recognise common.<pkg>
     # imports, not just src.<pkg>).
     depends_on=["meta"],
+    context=ContextScope(
+        purpose=(
+            "Execute and prove package guarantees through reusable test selection, "
+            "fixtures, evidence aggregation, and CI-quality gates."
+        ),
+        in_scope=[
+            "test selection and execution evidence",
+            "shared fixtures and deterministic test helpers",
+            "test and gate quality governance",
+        ],
+        out_of_scope=[
+            "business-domain acceptance semantics",
+            "runtime environment and deployment ownership",
+            "product prioritization and policy",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="meta",
+            consumer="testing",
+            mode="published-language",
+            reason=(
+                "Testing consumes meta's published contract and registry language "
+                "to project, select, and validate package-owned proofs."
+            ),
+        )
+    ],
     roles=[],
     # No base/extension split yet, so these are taxonomy-only (no module path;
     # the gate skips placement for units with no module, same as money's VOs).

--- a/common/workflow/contract.py
+++ b/common/workflow/contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from common.meta.package_contract import (
     ACRecord,
     ConceptRecord,
+    ContextRelation,
+    ContextScope,
     Invariant,
     Kind,
     PackageContract,
@@ -36,6 +38,48 @@ CONTRACT = PackageContract(
     status="active",
     tier="CODE-ONLY",
     depends_on=["extraction", "platform", "reconciliation", "reporting"],
+    context=ContextScope(
+        purpose=(
+            "Own the user-facing upload-to-report process state: workflow sessions, "
+            "derived event inbox entries, readiness, and next-action guidance."
+        ),
+        in_scope=[
+            "WorkflowSession and WorkflowEvent lifecycle and response vocabulary",
+            "derived workflow status, report-readiness state, and next-action projections",
+            "cross-context process composition for a user's upload-to-report journey",
+        ],
+        out_of_scope=[
+            "statement parsing/source facts, reconciliation matching, and report-document ownership",
+            "generic event bus, outbox, HTTP, persistence substrate, or delivery routing",
+            "ledger, valuation, and other business-domain policy ownership",
+        ],
+    ),
+    relationships=[
+        ContextRelation(
+            provider="extraction",
+            consumer="workflow",
+            mode="projection",
+            reason="Reads published statement event sources to derive workflow lifecycle state.",
+        ),
+        ContextRelation(
+            provider="platform",
+            consumer="workflow",
+            mode="composition",
+            reason="Uses platform ORM mixins while workflow owns the process-state model itself.",
+        ),
+        ContextRelation(
+            provider="reconciliation",
+            consumer="workflow",
+            mode="projection",
+            reason="Reads pending-review counts to derive workflow readiness without making matches.",
+        ),
+        ContextRelation(
+            provider="reporting",
+            consumer="workflow",
+            mode="projection",
+            reason="Reads report-package summary state to derive user next actions without owning reports.",
+        ),
+    ],
     roles=["base", "extension"],
     units=[
         *[

--- a/common/workflow/readme.md
+++ b/common/workflow/readme.md
@@ -8,3 +8,12 @@ outbox, HTTP, and ORM mixins remain in `platform`.
 The package is an L3 domain orchestrator. Its `base` layer owns lifecycle and
 response vocabulary, `extension` derives and persists workflow state, and `orm`
 contains the schema-preserving `workflow_sessions` and `workflow_events` models.
+
+## Bounded-context decision
+
+`workflow` owns the cross-context process state a user sees: sessions, derived
+event inbox entries, readiness, and next actions. It consumes extraction,
+reconciliation, and reporting projections; it does not own their source facts,
+matches, or report documents. `platform` supplies persistence composition only,
+not workflow policy. The machine-readable boundary and relationships are in
+[`contract.py`](./contract.py).

--- a/tests/tooling/test_context_contract.py
+++ b/tests/tooling/test_context_contract.py
@@ -155,6 +155,17 @@ def test_context_contract_baseline_is_exact_on_real_repository() -> None:
     )
 
 
+def test_meta_declares_its_bounded_context() -> None:
+    from common.meta.contract import CONTRACT
+
+    assert CONTRACT.context is not None
+    assert (
+        "individual package business goals and domain policy"
+        in CONTRACT.context.out_of_scope
+    )
+    assert CONTRACT.relationships == []
+
+
 def test_context_contract_rejects_unclassified_dependency_after_adoption(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/tooling/test_context_contract.py
+++ b/tests/tooling/test_context_contract.py
@@ -159,11 +159,9 @@ def test_meta_declares_its_bounded_context() -> None:
     from common.meta.contract import CONTRACT
 
     assert CONTRACT.context is not None
-    assert (
-        "individual package business goals and domain policy"
-        in CONTRACT.context.out_of_scope
+    assert {relation.provider for relation in CONTRACT.relationships} == set(
+        CONTRACT.depends_on
     )
-    assert CONTRACT.relationships == []
 
 
 def test_context_contract_rejects_unclassified_dependency_after_adoption(

--- a/tests/tooling/test_platform_package.py
+++ b/tests/tooling/test_platform_package.py
@@ -105,6 +105,9 @@ def test_platform_interface_equals_published_language():
     assert CONTRACT.name == "platform"
     assert CONTRACT.klass == "infra"
     assert CONTRACT.implementations["be"] == "apps/backend/src/platform"
+    assert CONTRACT.context is not None
+    assert "domain workflow and saga semantics" in CONTRACT.context.out_of_scope
+    assert CONTRACT.relationships == []
 
 
 def test_platform_package_contract_gate_passes():

--- a/tests/tooling/test_platform_package.py
+++ b/tests/tooling/test_platform_package.py
@@ -106,8 +106,9 @@ def test_platform_interface_equals_published_language():
     assert CONTRACT.klass == "infra"
     assert CONTRACT.implementations["be"] == "apps/backend/src/platform"
     assert CONTRACT.context is not None
-    assert "domain workflow and saga semantics" in CONTRACT.context.out_of_scope
-    assert CONTRACT.relationships == []
+    assert {relation.provider for relation in CONTRACT.relationships} == set(
+        CONTRACT.depends_on
+    )
 
 
 def test_platform_package_contract_gate_passes():

--- a/tests/tooling/test_testing_package.py
+++ b/tests/tooling/test_testing_package.py
@@ -30,6 +30,11 @@ def test_AC_testing_1_1_only_all_is_the_published_language():
     assert CONTRACT.name == "testing"
     assert CONTRACT.klass == "infra"
     assert CONTRACT.implementations["be"] == "common/testing"
+    assert CONTRACT.context is not None
+    assert "business-domain acceptance semantics" in CONTRACT.context.out_of_scope
+    assert [
+        (relation.provider, relation.mode) for relation in CONTRACT.relationships
+    ] == [("meta", "published-language")]
 
 
 def test_AC_testing_1_1_package_contract_gate_passes_for_testing():

--- a/tests/tooling/test_testing_package.py
+++ b/tests/tooling/test_testing_package.py
@@ -31,10 +31,9 @@ def test_AC_testing_1_1_only_all_is_the_published_language():
     assert CONTRACT.klass == "infra"
     assert CONTRACT.implementations["be"] == "common/testing"
     assert CONTRACT.context is not None
-    assert "business-domain acceptance semantics" in CONTRACT.context.out_of_scope
-    assert [
-        (relation.provider, relation.mode) for relation in CONTRACT.relationships
-    ] == [("meta", "published-language")]
+    assert {relation.provider for relation in CONTRACT.relationships} == set(
+        CONTRACT.depends_on
+    )
 
 
 def test_AC_testing_1_1_package_contract_gate_passes_for_testing():


### PR DESCRIPTION
## Summary
- consolidate the 17 package context declarations previously split across #1940-#1942 and #1944-#1957
- classify every declared dependency relationship and reduce the exact context-contract baseline to an empty list
- replace package-specific text mirrors with the shared relationship-coverage invariant

## Root cause
The prior one-package-per-PR split coupled every child to the same mutable #1937 base and baseline file. Rebasing the base invalidated all 17 children at once and made the delivery topology harder to review than the behavior.

## Verification
- context-contract gate passed with zero residual findings
- AC index and EPIC/package dual gates passed
- focused context/package tests: 19 passed
- full diff-aware preflight: 2,322 tooling tests passed

## Dependency
- stacked on #1937; after #1937 merges, this branch must be rebased to main and run through normal PR-context CI

Refs #1897
Supersedes #1940, #1941, #1942, #1944, #1945, #1946, #1947, #1948, #1949, #1950, #1951, #1952, #1953, #1954, #1955, #1956, #1957