### PR TITLE
[finance-report-567-package-decision-ref] Publish package decision coordinates

### DIFF
--- a/apps/backend/src/reporting/__init__.py
+++ b/apps/backend/src/reporting/__init__.py
@@ -32,6 +32,8 @@ _EXPORTS = {
     "PERSONAL_REPORT_PACKAGE_NOTES": "src.reporting.base.report_package_contract",
     "PackageAssembler": "src.reporting.extension.package_document",
     "PackageSectionContribution": "src.reporting.base.package_contribution",
+    "personal_report_package_target": "src.reporting.base.package_decision",
+    "personal_report_package_decision_ref": "src.reporting.extension.package_document",
     "current_package_document_summary": "src.reporting.extension.package_document",
     "PackageDocumentVersionError": "src.reporting.extension.report_package",
     "AnnualizedIncomeTotals": "src.reporting.extension.reporting_calc",
@@ -87,6 +89,8 @@ __all__ = [
     "PERSONAL_REPORT_PACKAGE_NOTES",
     "PackageAssembler",
     "PackageSectionContribution",
+    "personal_report_package_target",
+    "personal_report_package_decision_ref",
     "current_package_document_summary",
     "PackageDocumentVersionError",
     "AnnualizedIncomeTotals",
@@ -150,6 +154,7 @@ def __getattr__(name: str) -> object:
 if TYPE_CHECKING:
     from src.reporting.base.l1_registry import is_valid_line_for_framework
     from src.reporting.base.package_contribution import PackageSectionContribution
+    from src.reporting.base.package_decision import personal_report_package_target
     from src.reporting.base.report_package_contract import (
         PERSONAL_REPORT_PACKAGE_CONTRACT,
         PERSONAL_REPORT_PACKAGE_NOTES,
@@ -178,6 +183,7 @@ if TYPE_CHECKING:
     from src.reporting.extension.package_document import (
         PackageAssembler,
         current_package_document_summary,
+        personal_report_package_decision_ref,
     )
     from src.reporting.extension.report_package import (
         PackageDocumentVersionError,

--- a/apps/backend/src/reporting/base/package_decision.py
+++ b/apps/backend/src/reporting/base/package_decision.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Sequence
+import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
 
 from src.audit import (
     TraceAuthorityProfile,
@@ -22,6 +25,31 @@ PACKAGE_DECISION_POLICY_VERSION = "2026-07-18"
 
 def _digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def personal_report_package_target(
+    *,
+    snapshot_id: UUID,
+    context: Mapping[str, Any],
+    framework_policy: Mapping[str, Any],
+    statement_disposition_policy: Mapping[str, Any],
+    input_manifest: Sequence[Mapping[str, Any]],
+    sections: Mapping[str, Any],
+) -> VersionedTraceRef:
+    """Bind one frozen package's complete semantic payload to an exact target."""
+    semantic_payload = {
+        "schema_version": "2",
+        "snapshot_id": str(snapshot_id),
+        "context": dict(context),
+        "framework_policy": dict(framework_policy),
+        "statement_disposition_policy": dict(statement_disposition_policy),
+        "input_manifest": [dict(item) for item in input_manifest],
+        "sections": dict(sections),
+    }
+    version = hashlib.sha256(
+        json.dumps(semantic_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return VersionedTraceRef("personal_report_package", str(snapshot_id), version)
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/backend/src/reporting/extension/package_document.py
+++ b/apps/backend/src/reporting/extension/package_document.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections import defaultdict
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
@@ -46,6 +44,7 @@ from src.reporting.base.package_contribution import PackageCashInputs, PackageSe
 from src.reporting.base.package_decision import (
     PACKAGE_DECISION_POLICY_VERSION,
     PackageReadinessDecisionPolicy,
+    personal_report_package_target,
 )
 from src.reporting.base.report_package_contract import (
     PERSONAL_REPORT_PACKAGE_CONTRACT,
@@ -97,6 +96,28 @@ def _package_document_summary(document: PersonalReportPackageDocument) -> Person
         readiness=document.readiness,
         generated_at=document.generated_at,
         frozen_at=document.frozen_at,
+    )
+
+
+def personal_report_package_decision_ref(document: PersonalReportPackageDocument) -> TraceDecisionRef:
+    """Reconstruct exact audit coordinates from one selected frozen document."""
+    if document.schema_version != "2":
+        raise ValueError("unsupported package document schema version")
+    if document.lifecycle is not PersonalReportPackageDocumentLifecycle.FROZEN:
+        raise ValueError("package decision coordinates require a frozen document")
+    if document.snapshot_id is None or document.package_decision_id is None:
+        raise ValueError("frozen package decision coordinates require snapshot and decision ids")
+    return TraceDecisionRef(
+        decision_id=document.package_decision_id,
+        target=personal_report_package_target(
+            snapshot_id=document.snapshot_id,
+            context=document.context.model_dump(mode="json"),
+            framework_policy=document.framework_policy.model_dump(mode="json"),
+            statement_disposition_policy=document.statement_disposition_policy.model_dump(mode="json"),
+            input_manifest=[item.model_dump(mode="json") for item in document.input_manifest],
+            sections=document.sections.model_dump(mode="json"),
+        ),
+        assertion=PackageReadinessDecisionPolicy().assertion,
     )
 
 
@@ -580,19 +601,15 @@ class PackageAssembler:
         if not parents:
             raise ValueError("trusted package requires at least one authoritative input decision")
 
-        semantic_payload = {
-            "schema_version": "2",
-            "snapshot_id": str(snapshot_id),
-            "context": context,
-            "framework_policy": framework_policy,
-            "statement_disposition_policy": statement_disposition_policy,
-            "input_manifest": [item.model_dump(mode="json") for item in input_manifest],
-            "sections": sections.model_dump(mode="json"),
-        }
-        target_version = hashlib.sha256(
-            json.dumps(semantic_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        ).hexdigest()
-        target = VersionedTraceRef("personal_report_package", str(snapshot_id), target_version)
+        target = personal_report_package_target(
+            snapshot_id=snapshot_id,
+            context=context,
+            framework_policy=framework_policy,
+            statement_disposition_policy=statement_disposition_policy,
+            input_manifest=[item.model_dump(mode="json") for item in input_manifest],
+            sections=sections.model_dump(mode="json"),
+        )
+        target_version = target.version
         execution_id = f"report-package:{snapshot_id}"
         section_observation = TraceRecord.observation(
             scope=scope,

--- a/apps/backend/tests/reporting/test_package_document.py
+++ b/apps/backend/tests/reporting/test_package_document.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import ast
+import copy
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -23,11 +24,13 @@ from src.audit import (
     TraceTargetClass,
     VersionedTraceRef,
 )
+from src.reporting import personal_report_package_decision_ref, personal_report_package_target
 from src.reporting.base.package_contribution import PackageCashInputs, PackageSectionContribution
 from src.reporting.base.package_decision import PackageReadinessDecisionPolicy
 from src.reporting.extension.package_document import PackageAssembler, _section_invariant_blockers
 from src.schemas.reporting import (
     PersonalReportPackageDocument,
+    PersonalReportPackageDocumentLifecycle,
     PersonalReportPackageInputCoverage,
     PersonalReportPackageReadinessState,
 )
@@ -448,3 +451,80 @@ def test_AC_reporting_package_document_7_manifest_folds_only_typed_contributions
         "StatementSummary",
     ):
         assert forbidden_raw_input not in traceability_source
+
+
+class _JsonValue:
+    def __init__(self, value):
+        self.value = value
+
+    def model_dump(self, *, mode):
+        assert mode == "json"
+        return copy.deepcopy(self.value)
+
+
+def test_AC_reporting_package_document_10_reconstructs_exact_decision_coordinates() -> None:
+    """AC-reporting.package-document.10: one owner function binds frozen semantics."""
+    snapshot_id = UUID("10000000-0000-0000-0000-000000000001")
+    decision_id = UUID("20000000-0000-0000-0000-000000000002")
+    semantics = {
+        "context": {
+            "framework_id": "personal_financial_reporting",
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "as_of_date": "2026-12-31",
+            "currency": "SGD",
+        },
+        "framework_policy": {"result_id": "policy-1", "gaps": []},
+        "statement_disposition_policy": {"policy_version": "2026-07-19"},
+        "input_manifest": [{"decision_id": str(decision_id), "input_refs": ["statement:1"]}],
+        "sections": {"balance_sheet": {"total_assets": "125.00"}},
+    }
+
+    target = personal_report_package_target(snapshot_id=snapshot_id, **semantics)
+    assert target == VersionedTraceRef(
+        kind="personal_report_package",
+        id=str(snapshot_id),
+        version="9d136a722c6fee121996a72b47f70e46633ea8828c57d96899a96f56f56ec5ae",
+    )
+
+    document = SimpleNamespace(
+        schema_version="2",
+        lifecycle=PersonalReportPackageDocumentLifecycle.FROZEN,
+        snapshot_id=snapshot_id,
+        package_decision_id=decision_id,
+        context=_JsonValue(semantics["context"]),
+        framework_policy=_JsonValue(semantics["framework_policy"]),
+        statement_disposition_policy=_JsonValue(semantics["statement_disposition_policy"]),
+        input_manifest=[_JsonValue(item) for item in semantics["input_manifest"]],
+        sections=_JsonValue(semantics["sections"]),
+    )
+    decision_ref = personal_report_package_decision_ref(document)
+    assert decision_ref == TraceDecisionRef(
+        decision_id=decision_id,
+        target=target,
+        assertion=PackageReadinessDecisionPolicy().assertion,
+    )
+
+    def changed_document(**updates):
+        return SimpleNamespace(**(vars(document) | updates))
+
+    with pytest.raises(ValueError, match="schema version"):
+        personal_report_package_decision_ref(changed_document(schema_version="1"))
+    with pytest.raises(ValueError, match="frozen document"):
+        personal_report_package_decision_ref(changed_document(lifecycle=PersonalReportPackageDocumentLifecycle.PREVIEW))
+    with pytest.raises(ValueError, match="snapshot and decision ids"):
+        personal_report_package_decision_ref(changed_document(package_decision_id=None))
+
+    for field in semantics:
+        changed = copy.deepcopy(semantics)
+        value = changed[field]
+        if isinstance(value, list):
+            value.append({"decision_id": str(uuid4()), "input_refs": ["statement:changed"]})
+        else:
+            value["counterfactual"] = field
+        assert personal_report_package_target(snapshot_id=snapshot_id, **changed) != target, field
+    assert personal_report_package_target(snapshot_id=uuid4(), **semantics) != target
+
+    assembler_source = (REPOSITORY_ROOT / "apps/backend/src/reporting/extension/package_document.py").read_text()
+    assert "personal_report_package_target(" in assembler_source
+    assert "semantic_payload =" not in assembler_source

--- a/common/advisor/readme.md
+++ b/common/advisor/readme.md
@@ -79,7 +79,7 @@ The advisor aggregates context from:
 
 | Source | What it reads | How the advisor reads it |
 |--------|--------------|---------------------------|
-| `report_readiness` | Readiness state + blockers | `src.reporting` published root (`get_personal_report_package_readiness`, #1666) |
+| `report_readiness` | Readiness state + blockers | `src.reporting` published root (`current_package_document_summary`) |
 | `reporting` | Balance sheet, income statement, category breakdown | `src.reporting` published root (`generate_balance_sheet`/`generate_income_statement`/`get_category_breakdown`, #1666) |
 | `reconciliation` | Pending review count, reconciliation stats | `src.reconciliation` published root (`get_reconciliation_stats`) |
 | `portfolio` | Positions, unrealised P&L, active symbols | `src.portfolio` published root (`PortfolioService`, `active_stock_symbols`) |

--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -150,6 +150,16 @@ CONTRACT = PackageContract(
             module="base/package_contribution.py",
         ),
         Unit(
+            name="personal_report_package_target",
+            kind=Kind.FACTORY,
+            module="base/package_decision.py",
+        ),
+        Unit(
+            name="personal_report_package_decision_ref",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/package_document.py",
+        ),
+        Unit(
             name="ReportingReadRepository",
             kind=Kind.REPOSITORY,
         ),
@@ -166,6 +176,8 @@ CONTRACT = PackageContract(
         "PERSONAL_REPORT_PACKAGE_NOTES",
         "PackageAssembler",
         "PackageSectionContribution",
+        "personal_report_package_target",
+        "personal_report_package_decision_ref",
         "PackageDocumentVersionError",
         "current_package_document_summary",
         "AnnualizedIncomeTotals",
@@ -1520,6 +1532,23 @@ CONTRACT = PackageContract(
             test=(
                 "apps/backend/tests/reporting/test_package_document.py"
                 "::test_AC_reporting_package_document_9_requires_exact_decision_coordinates"
+            ),
+            priority="P0",
+            status="open",
+            proof_kind="exact",
+        ),
+        ACRecord(
+            id="AC-reporting.package-document.10",
+            statement=(
+                "Reporting publishes one pure package-decision coordinate builder over the exact "
+                "frozen document semantics, and PackageAssembler consumes that same builder. A "
+                "consumer can reconstruct the persisted decision target and assertion from the "
+                "selected frozen document; changing any bound document field changes the target "
+                "version, so an opaque decision id alone cannot authorize the package."
+            ),
+            test=(
+                "apps/backend/tests/reporting/test_package_document.py"
+                "::test_AC_reporting_package_document_10_reconstructs_exact_decision_coordinates"
             ),
             priority="P0",
             status="open",

--- a/common/reporting/readme.md
+++ b/common/reporting/readme.md
@@ -404,6 +404,13 @@ it only when the tenant-scoped current projection matches all coordinates;
 missing, stale, cross-scope, target-mismatched, and assertion-mismatched inputs
 remain visible as unproven and cannot enter the trusted manifest.
 
+The frozen package decision is bound to the document by reporting's published
+`personal_report_package_target` canonicalizer. `PackageAssembler` uses that
+function when it emits the decision; terminal consumers use
+`personal_report_package_decision_ref` to reconstruct the exact decision id,
+target, and assertion from the selected frozen document. Consumers must not
+copy the semantic hash or treat an opaque decision id as package authority.
+
 Reporting never follows a foreign ORM relation or guesses a source class from
 `JournalEntry.source_id`. Extraction publishes current immutable statement
 results, ledger publishes decision-anchored journal lines, and pricing


### PR DESCRIPTION
## Summary
- publish one reporting-owned canonical target builder for frozen package semantics
- reconstruct an exact `TraceDecisionRef` from the selected frozen document
- make `PackageAssembler` consume the same builder and remove its private hash implementation
- remove stale advisor documentation for the retired readiness endpoint

## Root cause
The frozen document exposed only an opaque package decision id while `PackageAssembler` privately derived the decision target version. A terminal audit could load that id, but could not independently prove that it authorized the selected document without copying reporting's hash rule.

## Why gates missed it
Existing package tests verified contribution decision coordinates and persisted trust, but did not require a public inverse from frozen document semantics to the package decision target/assertion.

## Proof added
`AC-reporting.package-document.10` fixes one canonical digest vector, reconstructs the full decision reference, mutates every bound semantic field and snapshot identity, and structurally rejects a second assembler hash. Red phase failed at the missing public imports; green phase passes 11 package-document tests, 4 reporting contract tests, and full preflight with 2,329 tooling/common tests.

## Stack
Temporarily based on #1960 because current `main` fails its own app-boundary/mirror ratchets. After #1960 merges this PR will be retargeted to `main` with reporting-only diff.

Closes #567