### PR TITLE
[finance-report-696-executed-proof] Bind scenario proof to pytest outcome

### DIFF
--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -76,6 +76,8 @@ _REPO_ROOT = str(Path(__file__).resolve().parents[3])
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+pytest_plugins = ("common.testing.executed_proof_plugin",)
+
 logger = get_logger(__name__)
 
 

--- a/common/testing/check_pr_ci_evidence.py
+++ b/common/testing/check_pr_ci_evidence.py
@@ -14,12 +14,20 @@ make it run or declare post_merge_environment.
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 from xml.etree import ElementTree
 
+from common.audit.base import TraceRecord, TraceRecordValidationError
+from common.audit.extension import TraceJUnitAdapter, TraceRecordCodec
 from common.meta.base.gate_cli import run_gate
+from common.testing.executed_proof import (
+    executed_proof_assertion_version,
+    executed_proof_matches,
+    github_execution_id,
+)
 from common.testing.matrix import PR_EVIDENCE_STAGES, classify_stage
 
 
@@ -51,6 +59,86 @@ def collect_executed(junit_paths: list[Path]) -> dict[tuple[str, str], bool]:
             key = (classname, name)
             executed[key] = executed.get(key, False) or not skipped
     return executed
+
+
+def collect_executed_proofs(
+    junit_paths: list[Path],
+) -> tuple[dict[tuple[str, str], tuple[TraceRecord, ...]], set[tuple[str, str]]]:
+    """Collect canonical trace properties and retain malformed testcase keys."""
+    records: dict[tuple[str, str], list[TraceRecord]] = {}
+    malformed: set[tuple[str, str]] = set()
+    for path in junit_paths:
+        if not path.exists():
+            continue
+        try:
+            tree = ElementTree.parse(path)
+        except ElementTree.ParseError:
+            continue
+        for case in tree.iter("testcase"):
+            key = (
+                case.get("classname") or "",
+                (case.get("name") or "").split("[", 1)[0],
+            )
+            for prop in case.findall("./properties/property"):
+                if prop.get("name") != TraceJUnitAdapter.PROPERTY_KEY:
+                    continue
+                raw = prop.get("value")
+                if raw is None:
+                    malformed.add(key)
+                    continue
+                try:
+                    records.setdefault(key, []).append(TraceRecordCodec.decode(raw))
+                except TraceRecordValidationError:
+                    malformed.add(key)
+    return ({key: tuple(value) for key, value in records.items()}, malformed)
+
+
+def _matching_testcase_keys(
+    proof: dict[str, object],
+    keys: set[tuple[str, str]],
+) -> tuple[tuple[str, str], ...]:
+    module = _module_for(str(proof["file"]))
+    test = str(proof["test"])
+    return tuple(
+        key
+        for key in keys
+        if (key[0] == module or key[0].startswith(module + ".")) and key[1] == test
+    )
+
+
+def _has_exact_executed_proof(
+    proof: dict[str, object],
+    *,
+    records: dict[tuple[str, str], tuple[TraceRecord, ...]],
+    malformed: set[tuple[str, str]],
+    repository_id: str,
+    commit_sha: str,
+    execution_id: str,
+) -> bool:
+    keys = _matching_testcase_keys(proof, set(records) | malformed)
+    if not keys or any(key in malformed for key in keys):
+        return False
+    assertion_version = executed_proof_assertion_version(
+        proof_id=str(proof["id"]),
+        scenario_id=str(proof["scenario_id"]),
+        oracle_kind=str(proof["oracle_kind"]),
+        ac_ids=[str(item) for item in proof.get("ac_ids", [])],
+        stage=str(proof["stage"]),
+        task_category=str(proof["task_category"]),
+    )
+    return any(
+        executed_proof_matches(
+            record,
+            proof_id=str(proof["id"]),
+            scenario_id=str(proof["scenario_id"]),
+            repository_id=repository_id,
+            commit_sha=commit_sha,
+            execution_id=execution_id,
+            assertion_version=assertion_version,
+        )
+        for key in keys
+        for record in records.get(key, ())
+    )
 
 
 def run_check(junit_paths: list[Path]) -> int:
@@ -89,10 +177,31 @@ def run_check(junit_paths: list[Path]) -> int:
         elif hit is False:
             skipped_only.append(label)
 
-    if missing or skipped_only:
+    invalid_executed_proof: list[str] = []
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        repository_id = os.environ.get("GITHUB_REPOSITORY", "")
+        commit_sha = os.environ.get("GITHUB_SHA", "")
+        execution_id = github_execution_id(os.environ)
+        records, malformed = collect_executed_proofs(junit_paths)
+        for proof in scoped:
+            if not proof.get("scenario_id"):
+                continue
+            label = f"{proof['id']}: {proof['file']}::{proof['test']}"
+            if not _has_exact_executed_proof(
+                proof,
+                records=records,
+                malformed=malformed,
+                repository_id=repository_id,
+                commit_sha=commit_sha,
+                execution_id=execution_id,
+            ):
+                invalid_executed_proof.append(label)
+
+    if missing or skipped_only or invalid_executed_proof:
         print(
             f"ERROR: {len(missing)} behavioral pr_ci proof(s) never executed and "
-            f"{len(skipped_only)} only ever skipped in PR junit evidence. Either "
+            f"{len(skipped_only)} only ever skipped; {len(invalid_executed_proof)} "
+            "scenario proof(s) lack one exact canonical executed TraceRecord. Either "
             "the test does not run pre-merge (fix the marker/stage/skip condition "
             "so it does) or the proof's ci_tier is wrong (declare "
             "post_merge_environment).",
@@ -102,6 +211,8 @@ def run_check(junit_paths: list[Path]) -> int:
             print(f"  - missing: {label}", file=sys.stderr)
         for label in skipped_only:
             print(f"  - skipped-only: {label}", file=sys.stderr)
+        for label in invalid_executed_proof:
+            print(f"  - invalid-executed-proof: {label}", file=sys.stderr)
         return 1
     print(f"pr_ci evidence reconciliation: {len(scoped)} proofs executed.")
     return 0

--- a/common/testing/check_pr_ci_evidence.py
+++ b/common/testing/check_pr_ci_evidence.py
@@ -183,10 +183,13 @@ def run_check(junit_paths: list[Path]) -> int:
         commit_sha = os.environ.get("GITHUB_SHA", "")
         execution_id = github_execution_id(os.environ)
         records, malformed = collect_executed_proofs(junit_paths)
+        not_executed = set(missing) | set(skipped_only)
         for proof in scoped:
             if not proof.get("scenario_id"):
                 continue
             label = f"{proof['id']}: {proof['file']}::{proof['test']}"
+            if label in not_executed:
+                continue
             if not _has_exact_executed_proof(
                 proof,
                 records=records,
@@ -201,10 +204,10 @@ def run_check(junit_paths: list[Path]) -> int:
         print(
             f"ERROR: {len(missing)} behavioral pr_ci proof(s) never executed and "
             f"{len(skipped_only)} only ever skipped; {len(invalid_executed_proof)} "
-            "scenario proof(s) lack one exact canonical executed TraceRecord. Either "
-            "the test does not run pre-merge (fix the marker/stage/skip condition "
-            "so it does) or the proof's ci_tier is wrong (declare "
-            "post_merge_environment).",
+            "executed scenario proof(s) lack one exact canonical TraceRecord. Fix "
+            "the marker/stage/skip condition for absent executions, correct an "
+            "overstated ci_tier, or ensure the executed-proof pytest plugin emits "
+            "a well-formed trace property with the exact CI coordinates.",
             file=sys.stderr,
         )
         for label in missing:

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4021,12 +4021,13 @@ CONTRACT = PackageContract(
         ACRecord(
             id="AC-testing.capability-proof.1",
             statement=(
-                "A PR-CI behavioral proof is collected with an explicit scenario id "
-                "and independent oracle kind, and its execution is reconciled from JUnit."
+                "A scenario-bound PR-CI behavioral proof emits one canonical TraceRecord "
+                "only after its pytest call phase passes; the JUnit gate requires exact "
+                "repository, commit, run, scenario, and proof coordinates."
             ),
             test=(
-                "tests/tooling/test_trusted_year_scenario.py::"
-                "test_AC_testing_capability_proof_1_collector_preserves_scenario_binding"
+                "tests/tooling/test_executed_proof.py::"
+                "test_AC_testing_capability_proof_1_pytest_junit_binds_exact_ci_coordinates"
             ),
             priority="P0",
             status="done",

--- a/common/testing/executed_proof.py
+++ b/common/testing/executed_proof.py
@@ -98,9 +98,7 @@ def github_execution_id(environ: Mapping[str, str]) -> str:
     run_id = environ.get("GITHUB_RUN_ID", "")
     run_attempt = environ.get("GITHUB_RUN_ATTEMPT", "")
     if not run_id.isdigit() or not run_attempt.isdigit():
-        raise ExecutedProofError(
-            "GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must be numeric"
-        )
+        raise ExecutedProofError("GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must be numeric")
     execution_id = f"{run_id}.{run_attempt}"
     if len(execution_id) > 200:
         raise ExecutedProofError("GitHub execution id must not exceed 200 characters")

--- a/common/testing/executed_proof.py
+++ b/common/testing/executed_proof.py
@@ -1,0 +1,253 @@
+"""Bind a scenario proof to the pytest outcome and exact CI coordinates."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import asdict
+from datetime import UTC, datetime
+from hashlib import sha256
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Protocol
+
+from common.audit.base import (
+    TraceAuthorityProfile,
+    TraceRecord,
+    TraceRecordType,
+    TraceResult,
+    TraceScope,
+    TraceScopeKind,
+    TraceTargetClass,
+    VersionedTraceRef,
+)
+from common.audit.extension import TraceJUnitAdapter
+from common.testing.ac_proof import PROOF_ATTR, AcProof
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ExecutedProofError(ValueError):
+    """A CI proof cannot be bound to exact execution coordinates."""
+
+
+class _PytestItem(Protocol):
+    obj: Any
+    nodeid: str
+    user_properties: list[tuple[str, str]]
+
+
+class _PytestReport(Protocol):
+    when: str
+    passed: bool
+    user_properties: list[tuple[str, str]]
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def executed_proof_assertion_version(
+    *,
+    proof_id: str,
+    scenario_id: str,
+    oracle_kind: str,
+    ac_ids: tuple[str, ...] | list[str],
+    stage: str,
+    task_category: str,
+) -> str:
+    """Hash the declaration fields that define one semantic proof contract."""
+    return _digest(
+        {
+            "ac_ids": list(ac_ids),
+            "oracle_kind": oracle_kind,
+            "proof_id": proof_id,
+            "scenario_id": scenario_id,
+            "stage": stage,
+            "task_category": task_category,
+        }
+    )
+
+
+def _ci_coordinates(environ: Mapping[str, str]) -> tuple[str, str, str, str]:
+    repository_id = environ.get("GITHUB_REPOSITORY", "")
+    commit_sha = environ.get("GITHUB_SHA", "")
+    execution_id = github_execution_id(environ)
+    if not repository_id or "/" not in repository_id:
+        raise ExecutedProofError("GITHUB_REPOSITORY must identify owner/repository")
+    if not _COMMIT_RE.fullmatch(commit_sha):
+        raise ExecutedProofError("GITHUB_SHA must be one exact lowercase commit SHA")
+    return (
+        repository_id,
+        commit_sha,
+        execution_id,
+        "github_ci.merge_authority",
+    )
+
+
+def github_execution_id(environ: Mapping[str, str]) -> str:
+    """Return an attempt-specific GitHub execution id or fail closed."""
+    run_id = environ.get("GITHUB_RUN_ID", "")
+    run_attempt = environ.get("GITHUB_RUN_ATTEMPT", "")
+    if not run_id.isdigit() or not run_attempt.isdigit():
+        raise ExecutedProofError(
+            "GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must be numeric"
+        )
+    execution_id = f"{run_id}.{run_attempt}"
+    if len(execution_id) > 200:
+        raise ExecutedProofError("GitHub execution id must not exceed 200 characters")
+    return execution_id
+
+
+def _local_coordinates(
+    item: _PytestItem,
+    environ: Mapping[str, str],
+) -> tuple[str, str, str, str]:
+    execution_id = environ.get("PYTEST_CURRENT_TEST", item.nodeid)
+    if len(execution_id) > 200:
+        execution_id = f"pytest@{sha256(execution_id.encode('utf-8')).hexdigest()}"
+    return (
+        environ.get("GITHUB_REPOSITORY", "finance_report"),
+        environ.get("GITHUB_SHA", "local-unpinned"),
+        execution_id,
+        "local.advisory",
+    )
+
+
+def _build_executed_proof(
+    proof: AcProof,
+    item: _PytestItem,
+    *,
+    environ: Mapping[str, str],
+    occurred_at: datetime,
+) -> TraceRecord:
+    if environ.get("GITHUB_ACTIONS") == "true":
+        repository_id, commit_sha, execution_id, stage = _ci_coordinates(environ)
+    else:
+        repository_id, commit_sha, execution_id, stage = _local_coordinates(
+            item, environ
+        )
+
+    contract_path = Path(__file__).with_name("contract.py")
+    owner_digest = sha256(contract_path.read_bytes()).hexdigest()
+    assertion_version = executed_proof_assertion_version(
+        proof_id=proof.proof_id,
+        scenario_id=proof.scenario_id,
+        oracle_kind=proof.oracle_kind,
+        ac_ids=proof.ac_ids,
+        stage=proof.stage,
+        task_category=proof.task_category,
+    )
+    evidence_digest = _digest(
+        {
+            "commit_sha": commit_sha,
+            "execution_id": execution_id,
+            "node_id_digest": sha256(item.nodeid.encode("utf-8")).hexdigest(),
+            "proof": asdict(proof),
+            "repository_id": repository_id,
+            "result": "pass",
+        }
+    )
+    return TraceRecord.observation(
+        scope=TraceScope(TraceScopeKind.REPOSITORY, repository_id),
+        target=VersionedTraceRef(
+            "terminal_scenario",
+            proof.scenario_id,
+            commit_sha,
+        ),
+        target_class=TraceTargetClass.GENERAL,
+        assertion=VersionedTraceRef(
+            "executed_proof",
+            proof.proof_id,
+            assertion_version,
+        ),
+        authority=TraceAuthorityProfile(
+            package="testing",
+            tier="CODE-ONLY",
+            proof_kind="exact",
+            provenance="deterministic",
+            execution_stage=stage,
+            assertion_owner_digest=owner_digest,
+            producer_version=f"pytest@{metadata.version('pytest')}",
+        ),
+        result=TraceResult.PASS,
+        execution_id=execution_id,
+        evidence_manifest_digest=evidence_digest,
+        occurred_at=occurred_at,
+        score=None,
+        reason_code="executed_proof_passed",
+    )
+
+
+def record_executed_proof(
+    item: _PytestItem,
+    report: _PytestReport,
+    *,
+    environ: Mapping[str, str] | None = None,
+    occurred_at: datetime | None = None,
+) -> TraceRecord | None:
+    """Attach PASS only after a scenario-bound test's call phase passed."""
+    if (
+        report.when != "call"
+        or not report.passed
+        or getattr(report, "wasxfail", None) is not None
+    ):
+        return None
+    proof = getattr(item.obj, PROOF_ATTR, None)
+    if not isinstance(proof, AcProof) or not proof.scenario_id:
+        return None
+    if not proof.oracle_kind:
+        raise ExecutedProofError("a scenario-bound proof requires oracle_kind")
+    if proof.ci_tier != "pr_ci":
+        return None
+
+    record = _build_executed_proof(
+        proof,
+        item,
+        environ=environ if environ is not None else os.environ,
+        occurred_at=occurred_at or datetime.now(UTC),
+    )
+    TraceJUnitAdapter.emit(
+        lambda name, value: item.user_properties.append((name, value)),
+        record,
+    )
+    return record
+
+
+def executed_proof_matches(
+    record: TraceRecord,
+    *,
+    proof_id: str,
+    scenario_id: str,
+    repository_id: str,
+    commit_sha: str,
+    execution_id: str,
+    assertion_version: str | None = None,
+) -> bool:
+    """Validate one emitted record without inferring success from JUnit shape."""
+    return (
+        record.record_type is TraceRecordType.OBSERVATION
+        and record.result is TraceResult.PASS
+        and record.scope.kind is TraceScopeKind.REPOSITORY
+        and record.scope.id == repository_id
+        and record.target
+        == VersionedTraceRef("terminal_scenario", scenario_id, commit_sha)
+        and record.assertion.kind == "executed_proof"
+        and record.assertion.id == proof_id
+        and (assertion_version is None or record.assertion.version == assertion_version)
+        and record.execution_id == execution_id
+        and record.authority.package == "testing"
+        and record.authority.tier == "CODE-ONLY"
+        and record.authority.proof_kind == "exact"
+        and record.authority.provenance == "deterministic"
+        and record.authority.execution_stage == "github_ci.merge_authority"
+        and record.reason_code == "executed_proof_passed"
+    )

--- a/common/testing/executed_proof_plugin.py
+++ b/common/testing/executed_proof_plugin.py
@@ -1,0 +1,16 @@
+"""Thin pytest lifecycle adapter for scenario-bound executed proofs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from common.testing.executed_proof import record_executed_proof
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_makereport(item: Any, call: Any):
+    """Record proof metadata only after pytest has resolved the call result."""
+    outcome = yield
+    record_executed_proof(item, outcome.get_result())

--- a/common/testing/readme.md
+++ b/common/testing/readme.md
@@ -140,6 +140,10 @@ just `assert True` moved up one level.
 test  --record_ac_evidence(record_property, ...)-->  junit-xml <property>
       --package-contract resolver----------------->  canonical trace_record property
       --tools/aggregate_ac_evidence.py-->            per-AC aggregate JSON
+
+scenario-bound @ac_proof
+      --pytest call-phase PASS-------------------->  canonical trace_record property
+      --tools/check_pr_ci_evidence.py------------->  exact repo/commit/run proof gate
       --tools/check_ac_score_baseline.py-->          L2 + L3 ratchet gate
 ```
 
@@ -209,13 +213,21 @@ with `merge=union` so independent ACs auto-merge — one AC per line — instead
 all ACs colliding in one central JSON object). Hermetic proof of the whole chain:
 `tests/tooling/test_ac_evidence_pipeline.py`.
 
+`record_ac_evidence()` still emits its in-body `pass` as `UNPROVEN`: a measured
+score is not automatically a terminal execution proof. A scenario-bound
+`@ac_proof` is different. `common.testing.executed_proof_plugin` observes
+pytest's real call-phase result and emits `PASS` only after the call passed. The
+existing `check_pr_ci_evidence` JUnit gate then requires the exact repository,
+checked-out commit, GitHub run attempt, scenario, proof declaration digest, and
+testing authority.
+Setup/teardown success, failure, skip/xfail, a static declaration, or a workflow
+conclusion cannot create or satisfy that record.
+
 ## Deliberately **out of scope** (follow-ups)
 
-1. Deriving `code` from the actual test report via a `pytest_runtest_makereport`
-   hook instead of trusting the in-body default.
-2. A periodic mutation / golden-swap audit that verifies scores actually drop
+1. A periodic mutation / golden-swap audit that verifies scores actually drop
    when behavior breaks (the real L3 proof).
-3. Migrating additional ACs and front-end (vitest) emission.
+2. Migrating additional ACs and front-end (vitest) emission.
 
 ## <a id="trusted-year-scenario"></a>TrustedYearScenario
 
@@ -226,13 +238,16 @@ brokerage position and selected market price; and one reviewed manual
 valuation. It is test truth, not a second product capability registry or a new
 transaction taxonomy.
 
-One `pr_ci` behavioral proof must bind the scenario to one independent oracle
-through explicit `scenario_id` and `oracle_kind` metadata. The integration path
-uses existing authority boundaries: LLM-led classification for supported P&L
-categories, a reviewed deterministic rule with explicit intent for the asset
-movement, immutable extraction results, ledger decisions, valuation decisions,
-and the frozen report-package lifecycle. Source-matrix expansion, deployed
-replay, operator evidence, and broader proof-format deletion remain outside v0.
+One `pr_ci` behavioral proof binds the scenario to one independent oracle
+through explicit `scenario_id` and `oracle_kind` metadata. After its real pytest
+call passes, the testing plugin emits one canonical `TraceRecord` observation;
+the JUnit reconciliation gate rejects missing or stale execution coordinates.
+The integration path uses existing authority boundaries: LLM-led classification
+for supported P&L categories, a reviewed deterministic rule with explicit intent
+for the asset movement, immutable extraction results, ledger decisions,
+valuation decisions, and the frozen report-package lifecycle. Source-matrix
+expansion, deployed replay, operator evidence, and broader proof-format deletion
+remain outside v0.
 
 ---
 

--- a/tests/tooling/test_executed_proof.py
+++ b/tests/tooling/test_executed_proof.py
@@ -1,0 +1,293 @@
+"""Executed semantic proof contract for scenario-bound PR-CI tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from xml.etree import ElementTree
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from common.audit.base import TraceRecordType, TraceResult, TraceScopeKind
+from common.audit.extension import TraceJUnitAdapter, TraceRecordCodec
+from common.testing.ac_proof import ac_proof
+from common.testing import check_pr_ci_evidence
+from common.testing.check_pr_ci_evidence import collect_executed_proofs
+from common.testing.executed_proof import (
+    executed_proof_matches,
+    record_executed_proof,
+)
+
+COMMIT_SHA = "a" * 40
+OCCURRED_AT = datetime(2026, 7, 20, tzinfo=UTC)
+CI_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_REPOSITORY": "wangzitian0/finance_report",
+    "GITHUB_SHA": COMMIT_SHA,
+    "GITHUB_RUN_ID": "123456789",
+    "GITHUB_RUN_ATTEMPT": "2",
+}
+EXECUTION_ID = "123456789.2"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@ac_proof(
+    "scenario-proof",
+    ac_ids=["AC-testing.capability-proof.1"],
+    ci_tier="pr_ci",
+    trust_mode="deterministic_pr",
+    scenario_id="trusted-year-v0",
+    oracle_kind="independent_decimal",
+)
+def _scenario_proof() -> None:
+    pass
+
+
+@dataclass
+class _Item:
+    obj: Any = _scenario_proof
+    nodeid: str = "tests/integration/test_scenario.py::test_terminal"
+    user_properties: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class _Report:
+    when: str = "call"
+    passed: bool = True
+    skipped: bool = False
+    failed: bool = False
+    wasxfail: str | None = None
+    user_properties: list[tuple[str, str]] = field(default_factory=list)
+
+
+def test_pass_is_bound_to_exact_ci_coordinates() -> None:
+    item = _Item()
+    report = _Report()
+
+    record = record_executed_proof(
+        item,
+        report,
+        environ=CI_ENV,
+        occurred_at=OCCURRED_AT,
+    )
+
+    assert record is not None
+    assert item.user_properties[0][0] == TraceJUnitAdapter.PROPERTY_KEY
+    decoded = TraceRecordCodec.decode(item.user_properties[0][1])
+    assert decoded == record
+    assert decoded.record_type is TraceRecordType.OBSERVATION
+    assert decoded.result is TraceResult.PASS
+    assert decoded.scope.kind is TraceScopeKind.REPOSITORY
+    assert decoded.scope.id == CI_ENV["GITHUB_REPOSITORY"]
+    assert decoded.target.kind == "terminal_scenario"
+    assert decoded.target.id == "trusted-year-v0"
+    assert decoded.target.version == COMMIT_SHA
+    assert decoded.assertion.kind == "executed_proof"
+    assert decoded.assertion.id == "scenario-proof"
+    assert decoded.execution_id == EXECUTION_ID
+    assert decoded.authority.package == "testing"
+    assert decoded.authority.execution_stage == "github_ci.merge_authority"
+    assert executed_proof_matches(
+        decoded,
+        proof_id="scenario-proof",
+        scenario_id="trusted-year-v0",
+        repository_id=CI_ENV["GITHUB_REPOSITORY"],
+        commit_sha=COMMIT_SHA,
+        execution_id=EXECUTION_ID,
+    )
+
+
+def test_AC_testing_capability_proof_1_pytest_junit_binds_exact_ci_coordinates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-testing.capability-proof.1: real pytest outcome survives JUnit exactly."""
+    test_file = tmp_path / "test_scenario.py"
+    test_file.write_text(
+        textwrap.dedent(
+            """
+            from common.testing.ac_proof import ac_proof
+
+            @ac_proof(
+                "scenario-proof",
+                ac_ids=["AC-testing.capability-proof.1"],
+                ci_tier="pr_ci",
+                trust_mode="deterministic_pr",
+                scenario_id="trusted-year-v0",
+                oracle_kind="independent_decimal",
+            )
+            def test_terminal():
+                assert 2 + 2 == 4
+            """
+        ),
+        encoding="utf-8",
+    )
+    junit = tmp_path / "junit.xml"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(test_file),
+            "-p",
+            "common.testing.executed_proof_plugin",
+            "-p",
+            "no:xdist",
+            "-o",
+            "addopts=",
+            "-q",
+            f"--junit-xml={junit}",
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            **CI_ENV,
+            "PYTHONPATH": os.pathsep.join(
+                filter(None, (str(REPO_ROOT), os.environ.get("PYTHONPATH", "")))
+            ),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+    records, malformed = collect_executed_proofs([junit])
+    assert malformed == set()
+    record = next(record for group in records.values() for record in group)
+    assert executed_proof_matches(
+        record,
+        proof_id="scenario-proof",
+        scenario_id="trusted-year-v0",
+        repository_id=CI_ENV["GITHUB_REPOSITORY"],
+        commit_sha=COMMIT_SHA,
+        execution_id=EXECUTION_ID,
+    )
+
+    proof = {
+        "id": "scenario-proof",
+        "scope": "behavioral",
+        "ci_tier": "pr_ci",
+        "file": "test_scenario.py",
+        "test": "test_terminal",
+        "ac_ids": ["AC-testing.capability-proof.1"],
+        "scenario_id": "trusted-year-v0",
+        "oracle_kind": "independent_decimal",
+        "stage": "github_ci.merge_authority",
+        "task_category": "critical_behavioral",
+    }
+    import common.testing.ac_graph as ac_graph
+    import common.testing.generate_critical_proof_matrix as proof_matrix
+
+    monkeypatch.setattr(ac_graph, "build_proofs_only", lambda: object())
+    monkeypatch.setattr(
+        proof_matrix,
+        "build_matrix_from_graph",
+        lambda _graph: {"proofs": [proof]},
+    )
+    monkeypatch.setattr(
+        check_pr_ci_evidence,
+        "classify_stage",
+        lambda _path: next(iter(check_pr_ci_evidence.PR_EVIDENCE_STAGES)),
+    )
+    for name, value in CI_ENV.items():
+        monkeypatch.setenv(name, value)
+    assert check_pr_ci_evidence.run_check([junit]) == 0
+
+    tree = ElementTree.parse(junit)
+    for properties in tree.iter("properties"):
+        properties.clear()
+    missing_trace = tmp_path / "missing-trace.xml"
+    tree.write(missing_trace, encoding="utf-8", xml_declaration=True)
+    assert check_pr_ci_evidence.run_check([missing_trace]) == 1
+
+
+@pytest.mark.parametrize(
+    ("when", "passed", "skipped", "failed", "wasxfail"),
+    (
+        ("setup", True, False, False, None),
+        ("teardown", True, False, False, None),
+        ("call", False, True, False, None),
+        ("call", False, False, True, None),
+        ("call", True, False, False, "reason"),
+    ),
+)
+def test_executed_proof_rejects_non_pass_call_outcomes(
+    when: str,
+    passed: bool,
+    skipped: bool,
+    failed: bool,
+    wasxfail: str | None,
+) -> None:
+    report = _Report(
+        when=when,
+        passed=passed,
+        skipped=skipped,
+        failed=failed,
+        wasxfail=wasxfail,
+    )
+    item = _Item()
+
+    assert (
+        record_executed_proof(
+            item,
+            report,
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+        is None
+    )
+    assert item.user_properties == []
+    assert report.user_properties == []
+
+
+def test_executed_proof_requires_scenario_metadata() -> None:
+    @ac_proof("ordinary-proof", ac_ids=["AC-testing.capability-proof.1"])
+    def ordinary_proof() -> None:
+        pass
+
+    item = _Item(obj=ordinary_proof)
+    report = _Report()
+
+    assert (
+        record_executed_proof(
+            item,
+            report,
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+        is None
+    )
+    assert item.user_properties == []
+    assert report.user_properties == []
+
+
+@pytest.mark.parametrize(
+    "changed",
+    ("proof_id", "scenario_id", "repository_id", "commit_sha", "execution_id"),
+)
+def test_executed_proof_matcher_fails_closed_on_coordinate_mismatch(
+    changed: str,
+) -> None:
+    record = record_executed_proof(
+        _Item(),
+        _Report(),
+        environ=CI_ENV,
+        occurred_at=OCCURRED_AT,
+    )
+    assert record is not None
+    expected = {
+        "proof_id": "scenario-proof",
+        "scenario_id": "trusted-year-v0",
+        "repository_id": CI_ENV["GITHUB_REPOSITORY"],
+        "commit_sha": COMMIT_SHA,
+        "execution_id": EXECUTION_ID,
+    }
+    expected[changed] = "wrong"
+
+    assert not executed_proof_matches(record, **expected)

--- a/tests/tooling/test_executed_proof.py
+++ b/tests/tooling/test_executed_proof.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -101,6 +102,29 @@ def test_pass_is_bound_to_exact_ci_coordinates() -> None:
         commit_sha=COMMIT_SHA,
         execution_id=EXECUTION_ID,
     )
+
+
+def test_pytest_hook_records_the_resolved_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from common.testing import executed_proof_plugin
+
+    captured: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        executed_proof_plugin,
+        "record_executed_proof",
+        lambda item, report: captured.append((item, report)),
+    )
+    item = _Item()
+    report = _Report()
+    outcome = SimpleNamespace(get_result=lambda: report)
+
+    hook = executed_proof_plugin.pytest_runtest_makereport(item, object())
+    next(hook)
+    with pytest.raises(StopIteration):
+        hook.send(outcome)
+
+    assert captured == [(item, report)]
 
 
 def test_AC_testing_capability_proof_1_pytest_junit_binds_exact_ci_coordinates(

--- a/tests/tooling/test_workflow_selection_conformance.py
+++ b/tests/tooling/test_workflow_selection_conformance.py
@@ -8,11 +8,16 @@ in common/testing/matrix.py; workflows keep literal text proven equal here.
 
 from __future__ import annotations
 
+import os
 import re
+from html import escape
 from pathlib import Path
+from types import SimpleNamespace
 
 from common.testing import matrix
+from common.testing.ac_proof import PROOF_ATTR, AcProof
 from common.testing.check_pr_ci_evidence import _module_for, collect_executed
+from common.testing.executed_proof import record_executed_proof
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -127,7 +132,10 @@ def test_AC8_23_3_staging_ai_ocr_corpus_aligns_with_matrix_llm_rows() -> None:
     )
 
 
-def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(tmp_path: Path) -> None:
+def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     """AC-testing.conformance.4: AC8.23.4: a behavioral pr_ci proof absent from PR junit evidence fails
     the reconciliation gate; present proofs pass; skipped-only warns."""
     from common.testing.check_pr_ci_evidence import run_check
@@ -145,15 +153,60 @@ def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(tmp_path: Path) -> None:
         and matrix.classify_stage(p.get("file", "")) in matrix.PR_EVIDENCE_STAGES
     ]
     assert proofs, "expected at least one scoped pr_ci proof in the repo"
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "wangzitian0/finance_report")
+    monkeypatch.setenv("GITHUB_SHA", "a" * 40)
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "2")
 
     def junit_for(subset: list[dict]) -> Path:
-        cases = "".join(
-            f'<testcase classname="{_module_for(p["file"])}" name="{p["test"]}" time="0.1"/>'
-            for p in subset
-        )
+        cases = []
+        for proof in subset:
+            properties = ""
+            if proof.get("scenario_id"):
+                test = lambda: None  # noqa: E731
+                setattr(
+                    test,
+                    PROOF_ATTR,
+                    AcProof(
+                        proof_id=proof["id"],
+                        ac_ids=tuple(proof["ac_ids"]),
+                        stage=proof["stage"],
+                        task_category=proof["task_category"],
+                        scope=proof["scope"],
+                        ci_tier=proof["ci_tier"],
+                        trust_mode=proof.get("trust_mode", ""),
+                        source_classes=tuple(proof.get("source_classes", ())),
+                        issue=proof.get("issue", ""),
+                        scenario_id=proof["scenario_id"],
+                        oracle_kind=proof["oracle_kind"],
+                    ),
+                )
+                item = SimpleNamespace(
+                    obj=test,
+                    nodeid=f"{proof['file']}::{proof['test']}",
+                    user_properties=[],
+                )
+                record_executed_proof(
+                    item,
+                    SimpleNamespace(when="call", passed=True, user_properties=[]),
+                    environ=os.environ,
+                )
+                properties = (
+                    "<properties>"
+                    + "".join(
+                        f'<property name="{escape(name)}" value="{escape(value)}"/>'
+                        for name, value in item.user_properties
+                    )
+                    + "</properties>"
+                )
+            cases.append(
+                f'<testcase classname="{_module_for(proof["file"])}" '
+                f'name="{proof["test"]}" time="0.1">{properties}</testcase>'
+            )
         path = tmp_path / f"junit-{len(subset)}.xml"
         path.write_text(
-            f'<testsuite name="s" tests="{len(subset)}">{cases}</testsuite>',
+            f'<testsuite name="s" tests="{len(subset)}">{"".join(cases)}</testsuite>',
             encoding="utf-8",
         )
         return path
@@ -164,13 +217,25 @@ def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(tmp_path: Path) -> None:
     # Skipped-only is a hard fail (#1558): a pr_ci proof that only ever skips
     # pre-merge is not executing its promise.
     skipped = tmp_path / "skipped.xml"
-    first = proofs[0]
+    scenario = next(proof for proof in proofs if proof.get("scenario_id"))
+    without_scenario = [proof for proof in proofs if proof is not scenario]
     skipped.write_text(
-        f'<testsuite name="s" tests="1"><testcase classname="{_module_for(first["file"])}"'
-        f' name="{first["test"]}"><skipped/></testcase></testsuite>',
+        f'<testsuite name="s" tests="1"><testcase classname="{_module_for(scenario["file"])}"'
+        f' name="{scenario["test"]}"><skipped/></testcase></testsuite>',
         encoding="utf-8",
     )
-    assert run_check([junit_for(proofs[1:]), skipped]) == 1
+    import common.testing.check_pr_ci_evidence as evidence_gate
+
+    def reject_match_for_nonexecuted_proof(*args, **kwargs):
+        raise AssertionError("a skipped proof must not enter TraceRecord validation")
+
+    with monkeypatch.context() as skipped_gate:
+        skipped_gate.setattr(
+            evidence_gate,
+            "_has_exact_executed_proof",
+            reject_match_for_nonexecuted_proof,
+        )
+        assert run_check([junit_for(without_scenario), skipped]) == 1
     # ...but a skip in one shard with a real run in another still passes.
     assert run_check([junit_for(proofs), skipped]) == 0
 


### PR DESCRIPTION
## Summary
- bind scenario-scoped `@ac_proof` declarations to the real pytest call outcome
- emit one canonical `TraceRecord` through the existing JUnit adapter with exact repository, checked-out commit, run attempt, scenario, and declaration coordinates
- extend the existing PR-CI evidence reconciliation gate to reject missing, malformed, stale, skipped, failed, xfailed, or coordinate-mismatched terminal proofs

## Root cause
#696 was closed after collecting scenario metadata and confirming a testcase appeared in JUnit. That proved declaration and execution presence, but no component converted the real pytest outcome into a canonical PASS observation. The earlier in-body AC evidence intentionally remained `UNPROVEN`, so terminal audit could not consume a valid executed proof.

This correction stays in `common/testing`: pytest owns outcome observation, while audit remains a consumer of the shared TraceRecord language. No new evidence entity, storage path, or workflow gate is introduced.

Closes #696

## Verification
- `tools/preflight.py --tier=full --base origin/main` (2342 passed; all relevant gates green)
- `tools/preflight.py --tier=static --base origin/main`
- targeted tooling suite (104 passed)
- `apps/backend/tests/integration/test_trusted_year_scenario.py` (1 passed, real JUnit emission)
