### PR TITLE
[finance-report-567-owner-closeout] Close package document roadmap

### DIFF
--- a/common/reporting/contract.py
+++ b/common/reporting/contract.py
@@ -1410,7 +1410,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_1_requires_typed_delivery_sections"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1425,7 +1425,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_2_has_one_assembler_and_no_live_package_export"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1441,7 +1441,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_3_trust_is_one_trace_decision_fold"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1456,7 +1456,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_4_exports_the_selected_frozen_document"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -1470,7 +1470,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_5_trace_and_snapshot_rollback_together"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1486,7 +1486,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_6_producer_and_consumer_closure"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1502,7 +1502,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_7_manifest_folds_only_typed_contributions"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1517,7 +1517,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_8_uses_exact_cash_inputs_not_account_names"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1534,7 +1534,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_9_requires_exact_decision_coordinates"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         ACRecord(
@@ -1551,7 +1551,7 @@ CONTRACT = PackageContract(
                 "::test_AC_reporting_package_document_10_reconstructs_exact_decision_coordinates"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="exact",
         ),
         # ── group year-scale: year-scale reporting validation (was EPIC-005


### PR DESCRIPTION
## Summary

Mark the ten implemented and independently re-verified PackageDocument ACs complete in the reporting package roadmap.

Closes #567

---

## Linked EPIC and ACs

| Field | Value |
|-------|-------|
| **EPIC** | #950 — trustworthy personal report package |
| **AC IDs** | AC-reporting.package-document.1 through .10 |
| **AC source updated** | `common/reporting/contract.py` |

---

## SSOT Changes

- [x] `common/reporting/contract.py` — status-only owner acceptance closeout; statements and test anchors are unchanged

---

## TDD Evidence

This is a status-only closeout after the implementation PR sequence (#1926, #1927, #1928, #1930, #1961). No new behavior or test was introduced.

| Phase | Commit SHA | Description |
|-------|-----------|-------------|
| Existing green implementation | `e93da99c` | Exact package implementation and decision-coordinate corrections are present on main |
| Closeout | `1776f99b` | Mark only the ten proven reporting ACs done |

---

## Engineering Audit

- [x] No schema, environment, migration, runtime, or infrastructure changes
- [x] No financial or user data
- [x] Generated AC registry checked; no generated diff was required

---

## Testing

```bash
PYTHONPATH=apps/backend:. apps/backend/.venv/bin/python -m pytest \
  apps/backend/tests/reporting/test_package_document.py \
  apps/backend/tests/reporting/test_financial_logic_audit.py \
  apps/backend/tests/api/test_personal_report_package_contract.py \
  -q --rootdir=apps/backend --override-ini addopts=''
# 38 passed

PYTHONPATH=apps/backend:. apps/backend/.venv/bin/python -m pytest \
  apps/backend/tests/integration/test_trusted_year_scenario.py \
  -q --rootdir=apps/backend --override-ini addopts=''
# 1 passed

npm test -- --run src/__tests__/personalReportPackagePage.test.tsx
# 41 passed

apps/backend/.venv/bin/python tools/preflight.py --tier=full
# 2338 passed; 6/6 relevant gates passed
```

---

## Screenshots / Evidence

N/A — package-contract status only.
