### PR TITLE
[finance-report-696-terminal-proof-consumer] Compose proof only after pytest PASS

### DIFF
--- a/common/testing/ac_proof.py
+++ b/common/testing/ac_proof.py
@@ -59,6 +59,7 @@ class AcProof:
     issue: str = ""
     scenario_id: str = ""
     oracle_kind: str = ""
+    required_observation_kind: str = ""
     required_markers: tuple[str, ...] = ()
     outcomes: tuple[str, ...] = field(default_factory=tuple)
 
@@ -77,6 +78,7 @@ def ac_proof(
     issue: str = "",
     scenario_id: str = "",
     oracle_kind: str = "",
+    required_observation_kind: str = "",
     required_markers: list[str] | tuple[str, ...] = (),
     outcomes: list[str] | tuple[str, ...] = (),
 ) -> Callable[[F], F]:
@@ -114,6 +116,7 @@ def ac_proof(
         issue=issue,
         scenario_id=scenario_id,
         oracle_kind=oracle_kind,
+        required_observation_kind=required_observation_kind,
         required_markers=tuple(required_markers),
         outcomes=tuple(outcomes),
     )

--- a/common/testing/check_pr_ci_evidence.py
+++ b/common/testing/check_pr_ci_evidence.py
@@ -125,6 +125,7 @@ def _has_exact_executed_proof(
         ac_ids=[str(item) for item in proof.get("ac_ids", [])],
         stage=str(proof["stage"]),
         task_category=str(proof["task_category"]),
+        required_observation_kind=str(proof.get("required_observation_kind", "")),
     )
     return any(
         executed_proof_matches(

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4051,8 +4051,9 @@ CONTRACT = PackageContract(
                 "After and only after a scenario-bound pytest call passes, one registered "
                 "consumer receives that exact canonical executed-proof TraceRecord and may "
                 "append one declaration-required canonical observation to the same JUnit "
-                "testcase; missing or duplicate registration, consumer failure, and a wrong "
-                "observation kind fail closed."
+                "testcase; GitHub merge-authority execution requires that consumer while "
+                "local advisory execution may omit it, and duplicate registration, consumer "
+                "failure, and a wrong observation kind fail closed."
             ),
             test=(
                 "tests/tooling/test_executed_proof.py::"

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4046,6 +4046,22 @@ CONTRACT = PackageContract(
             status="done",
         ),
         ACRecord(
+            id="AC-testing.capability-proof.3",
+            statement=(
+                "After and only after a scenario-bound pytest call passes, one registered "
+                "consumer receives that exact canonical executed-proof TraceRecord and may "
+                "append one canonical observation to the same JUnit testcase; duplicate "
+                "registration, consumer failure, and non-observation output fail closed."
+            ),
+            test=(
+                "tests/tooling/test_executed_proof.py::"
+                "test_AC_testing_capability_proof_3_post_call_consumer_is_single_and_fail_closed"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="exact",
+        ),
+        ACRecord(
             id="AC-testing.trusted-year.1",
             statement=(
                 "TrustedYearScenario is a testing-owned immutable entity whose monetary "

--- a/common/testing/contract.py
+++ b/common/testing/contract.py
@@ -4050,8 +4050,9 @@ CONTRACT = PackageContract(
             statement=(
                 "After and only after a scenario-bound pytest call passes, one registered "
                 "consumer receives that exact canonical executed-proof TraceRecord and may "
-                "append one canonical observation to the same JUnit testcase; duplicate "
-                "registration, consumer failure, and non-observation output fail closed."
+                "append one declaration-required canonical observation to the same JUnit "
+                "testcase; missing or duplicate registration, consumer failure, and a wrong "
+                "observation kind fail closed."
             ),
             test=(
                 "tests/tooling/test_executed_proof.py::"

--- a/common/testing/executed_proof.py
+++ b/common/testing/executed_proof.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from hashlib import sha256
 from importlib import metadata
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from common.audit.base import (
     TraceAuthorityProfile,
@@ -27,6 +27,9 @@ from common.audit.extension import TraceJUnitAdapter
 from common.testing.ac_proof import PROOF_ATTR, AcProof
 
 _COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_CONSUMER_ATTR = "__executed_proof_consumer__"
+
+ExecutedProofConsumer = Callable[[TraceRecord], TraceRecord]
 
 
 class ExecutedProofError(ValueError):
@@ -43,6 +46,18 @@ class _PytestReport(Protocol):
     when: str
     passed: bool
     user_properties: list[tuple[str, str]]
+
+
+def register_executed_proof_consumer(
+    item: _PytestItem,
+    consumer: ExecutedProofConsumer,
+) -> None:
+    """Register the sole post-call consumer for one pytest item."""
+    if not callable(consumer):
+        raise ExecutedProofError("executed-proof consumer must be callable")
+    if getattr(item, _CONSUMER_ATTR, None) is not None:
+        raise ExecutedProofError("an executed-proof consumer is already registered")
+    setattr(item, _CONSUMER_ATTR, consumer)
 
 
 def _digest(payload: Mapping[str, Any]) -> str:
@@ -217,6 +232,20 @@ def record_executed_proof(
         lambda name, value: item.user_properties.append((name, value)),
         record,
     )
+    consumer = getattr(item, _CONSUMER_ATTR, None)
+    if consumer is not None:
+        output = consumer(record)
+        if (
+            not isinstance(output, TraceRecord)
+            or output.record_type is not TraceRecordType.OBSERVATION
+        ):
+            raise ExecutedProofError(
+                "executed-proof consumer must return one TraceRecord OBSERVATION"
+            )
+        TraceJUnitAdapter.emit(
+            lambda name, value: item.user_properties.append((name, value)),
+            output,
+        )
     return record
 
 

--- a/common/testing/executed_proof.py
+++ b/common/testing/executed_proof.py
@@ -78,18 +78,20 @@ def executed_proof_assertion_version(
     ac_ids: tuple[str, ...] | list[str],
     stage: str,
     task_category: str,
+    required_observation_kind: str = "",
 ) -> str:
     """Hash the declaration fields that define one semantic proof contract."""
-    return _digest(
-        {
-            "ac_ids": list(ac_ids),
-            "oracle_kind": oracle_kind,
-            "proof_id": proof_id,
-            "scenario_id": scenario_id,
-            "stage": stage,
-            "task_category": task_category,
-        }
-    )
+    declaration = {
+        "ac_ids": list(ac_ids),
+        "oracle_kind": oracle_kind,
+        "proof_id": proof_id,
+        "scenario_id": scenario_id,
+        "stage": stage,
+        "task_category": task_category,
+    }
+    if required_observation_kind:
+        declaration["required_observation_kind"] = required_observation_kind
+    return _digest(declaration)
 
 
 def _ci_coordinates(environ: Mapping[str, str]) -> tuple[str, str, str, str]:
@@ -158,6 +160,7 @@ def _build_executed_proof(
         ac_ids=proof.ac_ids,
         stage=proof.stage,
         task_category=proof.task_category,
+        required_observation_kind=proof.required_observation_kind,
     )
     evidence_digest = _digest(
         {
@@ -221,6 +224,11 @@ def record_executed_proof(
         raise ExecutedProofError("a scenario-bound proof requires oracle_kind")
     if proof.ci_tier != "pr_ci":
         return None
+    consumer = getattr(item, _CONSUMER_ATTR, None)
+    if proof.required_observation_kind and consumer is None:
+        raise ExecutedProofError(
+            f"scenario proof requires a {proof.required_observation_kind!r} observation consumer"
+        )
 
     record = _build_executed_proof(
         proof,
@@ -232,7 +240,6 @@ def record_executed_proof(
         lambda name, value: item.user_properties.append((name, value)),
         record,
     )
-    consumer = getattr(item, _CONSUMER_ATTR, None)
     if consumer is not None:
         output = consumer(record)
         if (
@@ -241,6 +248,13 @@ def record_executed_proof(
         ):
             raise ExecutedProofError(
                 "executed-proof consumer must return one TraceRecord OBSERVATION"
+            )
+        if (
+            proof.required_observation_kind
+            and output.assertion.kind != proof.required_observation_kind
+        ):
+            raise ExecutedProofError(
+                "executed-proof consumer returned the wrong observation assertion kind"
             )
         TraceJUnitAdapter.emit(
             lambda name, value: item.user_properties.append((name, value)),

--- a/common/testing/executed_proof.py
+++ b/common/testing/executed_proof.py
@@ -224,8 +224,10 @@ def record_executed_proof(
         raise ExecutedProofError("a scenario-bound proof requires oracle_kind")
     if proof.ci_tier != "pr_ci":
         return None
+    execution_environ = environ if environ is not None else os.environ
+    is_merge_authority = execution_environ.get("GITHUB_ACTIONS") == "true"
     consumer = getattr(item, _CONSUMER_ATTR, None)
-    if proof.required_observation_kind and consumer is None:
+    if proof.required_observation_kind and is_merge_authority and consumer is None:
         raise ExecutedProofError(
             f"scenario proof requires a {proof.required_observation_kind!r} observation consumer"
         )
@@ -233,7 +235,7 @@ def record_executed_proof(
     record = _build_executed_proof(
         proof,
         item,
-        environ=environ if environ is not None else os.environ,
+        environ=execution_environ,
         occurred_at=occurred_at or datetime.now(UTC),
     )
     TraceJUnitAdapter.emit(

--- a/common/testing/generate_critical_proof_matrix.py
+++ b/common/testing/generate_critical_proof_matrix.py
@@ -61,6 +61,7 @@ _PROOF_KEY_ORDER = (
     "issue",
     "scenario_id",
     "oracle_kind",
+    "required_observation_kind",
     "file",
     "test",
     "required_markers",
@@ -177,6 +178,7 @@ def _collect_from_file(path: Path, repo_root: Path) -> list[CollectedProof]:
             "issue",
             "scenario_id",
             "oracle_kind",
+            "required_observation_kind",
         ):
             value = kwargs.get(optional)
             if value:

--- a/common/testing/readme.md
+++ b/common/testing/readme.md
@@ -143,6 +143,7 @@ test  --record_ac_evidence(record_property, ...)-->  junit-xml <property>
 
 scenario-bound @ac_proof
       --pytest call-phase PASS-------------------->  canonical trace_record property
+      --one registered post-proof consumer-------->  canonical observation property
       --tools/check_pr_ci_evidence.py------------->  exact repo/commit/run proof gate
       --tools/check_ac_score_baseline.py-->          L2 + L3 ratchet gate
 ```
@@ -220,6 +221,14 @@ pytest's real call-phase result and emits `PASS` only after the call passed. The
 existing `check_pr_ci_evidence` JUnit gate then requires the exact repository,
 checked-out commit, GitHub run attempt, scenario, proof declaration digest, and
 testing authority.
+
+A scenario may register one post-proof consumer on its pytest item when another
+package must compose evidence only after that real call result exists. The
+consumer receives the exact canonical executed-proof `TraceRecord` and may
+return one canonical `OBSERVATION`, which is attached to the same JUnit
+testcase. It is never called for failure, skip, or xfail; duplicate registration,
+consumer failure, and non-observation output fail the test run. This is a
+lifecycle seam, not another proof or status entity.
 Setup/teardown success, failure, skip/xfail, a static declaration, or a workflow
 conclusion cannot create or satisfy that record.
 

--- a/common/testing/readme.md
+++ b/common/testing/readme.md
@@ -226,9 +226,11 @@ A scenario may register one post-proof consumer on its pytest item when another
 package must compose evidence only after that real call result exists. The
 consumer receives the exact canonical executed-proof `TraceRecord` and may
 return one canonical `OBSERVATION`, which is attached to the same JUnit
-testcase. It is never called for failure, skip, or xfail; duplicate registration,
-consumer failure, and non-observation output fail the test run. This is a
-lifecycle seam, not another proof or status entity.
+testcase. `@ac_proof(required_observation_kind=...)` makes that output mandatory
+and includes the requirement in the proof declaration digest. The consumer is
+never called for failure, skip, or xfail; missing or duplicate registration,
+consumer failure, non-observation output, and the wrong assertion kind fail the
+test run. This is a lifecycle seam, not another proof or status entity.
 Setup/teardown success, failure, skip/xfail, a static declaration, or a workflow
 conclusion cannot create or satisfy that record.
 

--- a/common/testing/readme.md
+++ b/common/testing/readme.md
@@ -227,10 +227,13 @@ package must compose evidence only after that real call result exists. The
 consumer receives the exact canonical executed-proof `TraceRecord` and may
 return one canonical `OBSERVATION`, which is attached to the same JUnit
 testcase. `@ac_proof(required_observation_kind=...)` makes that output mandatory
-and includes the requirement in the proof declaration digest. The consumer is
-never called for failure, skip, or xfail; missing or duplicate registration,
-consumer failure, non-observation output, and the wrong assertion kind fail the
-test run. This is a lifecycle seam, not another proof or status entity.
+for GitHub merge-authority execution and includes the requirement in the proof
+declaration digest for every execution. Local advisory execution may omit the
+consumer because it cannot produce exact CI coordinates; an explicitly
+registered local consumer is still validated. The consumer is never called for
+failure, skip, or xfail; missing CI or duplicate registration, consumer failure,
+non-observation output, and the wrong assertion kind fail the test run. This is
+a lifecycle seam, not another proof or status entity.
 Setup/teardown success, failure, skip/xfail, a static declaration, or a workflow
 conclusion cannot create or satisfy that record.
 

--- a/tests/tooling/test_executed_proof.py
+++ b/tests/tooling/test_executed_proof.py
@@ -15,14 +15,26 @@ from typing import Any
 
 import pytest
 
-from common.audit.base import TraceRecordType, TraceResult, TraceScopeKind
+from common.audit.base import (
+    TraceAuthorityProfile,
+    TraceCausality,
+    TraceDecisionOutcome,
+    TraceRecord,
+    TraceRecordType,
+    TraceResult,
+    TraceScopeKind,
+    TraceTargetClass,
+    VersionedTraceRef,
+)
 from common.audit.extension import TraceJUnitAdapter, TraceRecordCodec
 from common.testing.ac_proof import ac_proof
 from common.testing import check_pr_ci_evidence
 from common.testing.check_pr_ci_evidence import collect_executed_proofs
 from common.testing.executed_proof import (
+    ExecutedProofError,
     executed_proof_matches,
     record_executed_proof,
+    register_executed_proof_consumer,
 )
 
 COMMIT_SHA = "a" * 40
@@ -229,6 +241,129 @@ def test_AC_testing_capability_proof_1_pytest_junit_binds_exact_ci_coordinates(
     missing_trace = tmp_path / "missing-trace.xml"
     tree.write(missing_trace, encoding="utf-8", xml_declaration=True)
     assert check_pr_ci_evidence.run_check([missing_trace]) == 1
+
+
+def _terminal_observation(proof: TraceRecord) -> TraceRecord:
+    return TraceRecord.observation(
+        scope=proof.scope,
+        target=proof.target,
+        target_class=TraceTargetClass.GENERAL,
+        assertion=VersionedTraceRef("terminal_audit", proof.target.id, "b" * 64),
+        authority=TraceAuthorityProfile(
+            package="audit",
+            tier="CODE-ONLY",
+            proof_kind="exact",
+            provenance="deterministic",
+            execution_stage=proof.authority.execution_stage,
+            assertion_owner_digest="c" * 64,
+            producer_version=f"git@{proof.target.version}",
+        ),
+        result=TraceResult.PASS,
+        execution_id=proof.execution_id,
+        evidence_manifest_digest="d" * 64,
+        occurred_at=proof.occurred_at,
+        score=None,
+        reason_code="terminal_audit_passed",
+    )
+
+
+def _terminal_decision(proof: TraceRecord) -> TraceRecord:
+    @dataclass(frozen=True)
+    class _Policy:
+        assertion: VersionedTraceRef = VersionedTraceRef(
+            "terminal_policy", "invalid", "v1"
+        )
+        authority: TraceAuthorityProfile = TraceAuthorityProfile(
+            package="audit",
+            tier="CODE-ONLY",
+            proof_kind="exact",
+            provenance="deterministic",
+            execution_stage="github_ci.merge_authority",
+            assertion_owner_digest="e" * 64,
+            producer_version="fixture@1",
+        )
+        causality: TraceCausality = TraceCausality.DIRECT
+        target_class: TraceTargetClass = TraceTargetClass.GENERAL
+
+        def fold(self, _parents) -> TraceDecisionOutcome:
+            return TraceDecisionOutcome(
+                TraceResult.AUTHORITATIVE, "invalid_terminal_decision"
+            )
+
+    return TraceRecord.decision(
+        scope=proof.scope,
+        target=proof.target,
+        policy=_Policy(),
+        execution_id=proof.execution_id,
+        occurred_at=proof.occurred_at,
+        parents=(proof,),
+    )
+
+
+def test_AC_testing_capability_proof_3_post_call_consumer_is_single_and_fail_closed() -> (
+    None
+):
+    """AC-testing.capability-proof.3: post-call composition has one fail-closed seam."""
+    item = _Item()
+    consumed: list[TraceRecord] = []
+
+    def consume(proof: TraceRecord) -> TraceRecord:
+        consumed.append(proof)
+        return _terminal_observation(proof)
+
+    register_executed_proof_consumer(item, consume)
+    with pytest.raises(ExecutedProofError, match="already registered"):
+        register_executed_proof_consumer(item, consume)
+
+    proof = record_executed_proof(
+        item, _Report(), environ=CI_ENV, occurred_at=OCCURRED_AT
+    )
+
+    assert proof is not None
+    assert consumed == [proof]
+    records = [TraceRecordCodec.decode(value) for name, value in item.user_properties]
+    assert [record.assertion.kind for record in records] == [
+        "executed_proof",
+        "terminal_audit",
+    ]
+    assert records[1] == _terminal_observation(proof)
+
+    failed_item = _Item()
+    register_executed_proof_consumer(failed_item, consume)
+    assert (
+        record_executed_proof(
+            failed_item,
+            _Report(passed=False, failed=True),
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+        is None
+    )
+    assert consumed == [proof]
+    assert failed_item.user_properties == []
+
+    invalid_item = _Item()
+    register_executed_proof_consumer(invalid_item, _terminal_decision)
+    with pytest.raises(ExecutedProofError, match="OBSERVATION"):
+        record_executed_proof(
+            invalid_item, _Report(), environ=CI_ENV, occurred_at=OCCURRED_AT
+        )
+    assert len(invalid_item.user_properties) == 1
+
+    failed_consumer_item = _Item()
+
+    def fail_consumer(_proof: TraceRecord) -> TraceRecord:
+        raise RuntimeError("terminal consumer failed")
+
+    register_executed_proof_consumer(failed_consumer_item, fail_consumer)
+    with pytest.raises(RuntimeError, match="terminal consumer failed"):
+        record_executed_proof(
+            failed_consumer_item,
+            _Report(),
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+    assert len(failed_consumer_item.user_properties) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/tooling/test_executed_proof.py
+++ b/tests/tooling/test_executed_proof.py
@@ -62,6 +62,18 @@ def _scenario_proof() -> None:
     pass
 
 
+@ac_proof(
+    "terminal-required-proof",
+    ac_ids=["AC-testing.capability-proof.3"],
+    ci_tier="pr_ci",
+    scenario_id="trusted-year-v0",
+    oracle_kind="independent_decimal",
+    required_observation_kind="terminal_audit",
+)
+def _terminal_required_proof() -> None:
+    pass
+
+
 @dataclass
 class _Item:
     obj: Any = _scenario_proof
@@ -364,6 +376,38 @@ def test_AC_testing_capability_proof_3_post_call_consumer_is_single_and_fail_clo
             occurred_at=OCCURRED_AT,
         )
     assert len(failed_consumer_item.user_properties) == 1
+
+    required_item = _Item(obj=_terminal_required_proof)
+    with pytest.raises(ExecutedProofError, match="requires a 'terminal_audit'"):
+        record_executed_proof(
+            required_item,
+            _Report(),
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+    assert required_item.user_properties == []
+
+    wrong_kind_item = _Item(obj=_terminal_required_proof)
+    register_executed_proof_consumer(wrong_kind_item, lambda proof: proof)
+    with pytest.raises(ExecutedProofError, match="wrong observation assertion kind"):
+        record_executed_proof(
+            wrong_kind_item,
+            _Report(),
+            environ=CI_ENV,
+            occurred_at=OCCURRED_AT,
+        )
+    assert len(wrong_kind_item.user_properties) == 1
+
+    required_item = _Item(obj=_terminal_required_proof)
+    register_executed_proof_consumer(required_item, _terminal_observation)
+    required_proof = record_executed_proof(
+        required_item,
+        _Report(),
+        environ=CI_ENV,
+        occurred_at=OCCURRED_AT,
+    )
+    assert required_proof is not None
+    assert len(required_item.user_properties) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/tooling/test_executed_proof.py
+++ b/tests/tooling/test_executed_proof.py
@@ -387,6 +387,17 @@ def test_AC_testing_capability_proof_3_post_call_consumer_is_single_and_fail_clo
         )
     assert required_item.user_properties == []
 
+    local_item = _Item(obj=_terminal_required_proof)
+    local_proof = record_executed_proof(
+        local_item,
+        _Report(),
+        environ={},
+        occurred_at=OCCURRED_AT,
+    )
+    assert local_proof is not None
+    assert local_proof.authority.execution_stage == "local.advisory"
+    assert len(local_item.user_properties) == 1
+
     wrong_kind_item = _Item(obj=_terminal_required_proof)
     register_executed_proof_consumer(wrong_kind_item, lambda proof: proof)
     with pytest.raises(ExecutedProofError, match="wrong observation assertion kind"):

--- a/tests/tooling/test_workflow_selection_conformance.py
+++ b/tests/tooling/test_workflow_selection_conformance.py
@@ -14,10 +14,19 @@ from html import escape
 from pathlib import Path
 from types import SimpleNamespace
 
+from common.audit.base import (
+    TraceRecord,
+    TraceResult,
+    TraceTargetClass,
+    VersionedTraceRef,
+)
 from common.testing import matrix
 from common.testing.ac_proof import PROOF_ATTR, AcProof
 from common.testing.check_pr_ci_evidence import _module_for, collect_executed
-from common.testing.executed_proof import record_executed_proof
+from common.testing.executed_proof import (
+    record_executed_proof,
+    register_executed_proof_consumer,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -180,6 +189,9 @@ def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(
                         issue=proof.get("issue", ""),
                         scenario_id=proof["scenario_id"],
                         oracle_kind=proof["oracle_kind"],
+                        required_observation_kind=proof.get(
+                            "required_observation_kind", ""
+                        ),
                     ),
                 )
                 item = SimpleNamespace(
@@ -187,6 +199,29 @@ def test_AC8_23_4_pr_ci_evidence_reconciliation_gate(
                     nodeid=f"{proof['file']}::{proof['test']}",
                     user_properties=[],
                 )
+                required_kind = proof.get("required_observation_kind", "")
+                if required_kind:
+
+                    def required_observation(record, kind=required_kind):
+                        return TraceRecord.observation(
+                            scope=record.scope,
+                            target=record.target,
+                            target_class=TraceTargetClass.GENERAL,
+                            assertion=VersionedTraceRef(
+                                kind,
+                                record.assertion.id,
+                                record.assertion.version,
+                            ),
+                            authority=record.authority,
+                            result=TraceResult.PASS,
+                            execution_id=record.execution_id,
+                            evidence_manifest_digest=record.evidence_manifest_digest,
+                            occurred_at=record.occurred_at,
+                            score=None,
+                            reason_code="required_observation_passed",
+                        )
+
+                    register_executed_proof_consumer(item, required_observation)
                 record_executed_proof(
                     item,
                     SimpleNamespace(when="call", passed=True, user_properties=[]),


### PR DESCRIPTION
## Summary

- add the testing-owned single post-call consumer seam for scenario proofs
- bind `required_observation_kind` into the proof assertion-version digest
- require the declared observation for GitHub merge-authority execution while allowing local advisory execution without exact CI coordinates
- validate every registered consumer output and append one canonical observation to the same JUnit testcase

## Root cause

The real TrustedYear proof and the terminal-audit unit fixture used the same proof id but different assertion-version hashes. CI therefore proved SQL graph verification and pytest execution separately, but had no lifecycle seam that could consume the real post-call proof for terminal composition. An optional CI callback would still allow later deletion to go green, so the CI requirement lives in the proof declaration itself.

## Boundary

The declaration requirement is always version-locked. Missing registration fails closed only for `github_ci.merge_authority`, where exact repository, commit, run, and attempt coordinates exist. Local execution remains `local.advisory`; if it explicitly registers a consumer, the same canonical output checks still apply.

## Proof

- `AC-testing.capability-proof.3` covers PASS-only invocation, single registration, declaration-digest binding, CI-required output, local advisory behavior, and fail-closed output validation.
- Targeted tooling: 60 passed; `common.testing.executed_proof` coverage 92%.
- Full preflight: 2363 passed, 8/8 gates.
- Static pre-push preflight: 7/7 gates.
- GitHub CI: all required checks green on `1b59e2fe`.
- Copilot review on `1b59e2fe`: no additional changes required; no review threads.

## Topology

This PR supplies the testing owner seam only. #1964 declares and registers the real TrustedYear terminal consumer; #696 closes only after that same JUnit testcase carries both exact records.

Refs #696