### PR TITLE
[finance_report_audit_950_extraction] Complete extraction source capabilities

### DIFF
--- a/apps/backend/src/extraction/base/result.py
+++ b/apps/backend/src/extraction/base/result.py
@@ -207,6 +207,42 @@ SOURCE_CAPABILITIES: tuple[SourceCapability, ...] = (
         review_semantics="unsupported until structured settlement facts reach extraction",
         traceability_target="settlement-note-to-investment-schedule",
     ),
+    SourceCapability(
+        capability_id="esop_rsu_plan",
+        status=SourceCapabilityStatus.MANUAL_TRUSTED,
+        intake_modes=("manual_evidence", "structured_payload"),
+        evidence_kinds=("grant_document", "vesting_schedule"),
+        produced_facts=("grant", "vesting_event", "unlock_basis"),
+        review_semantics="explicit manual evidence must identify vesting and unlock basis",
+        traceability_target="manual-restricted-compensation-to-annualized-schedule",
+    ),
+    SourceCapability(
+        capability_id="property_statement",
+        status=SourceCapabilityStatus.MANUAL_TRUSTED,
+        intake_modes=("manual_evidence", "structured_payload"),
+        evidence_kinds=("appraisal", "property_statement"),
+        produced_facts=("property_valuation",),
+        review_semantics="explicit manual evidence must identify valuation basis and as-of date",
+        traceability_target="manual-property-valuation-to-balance-sheet-line",
+    ),
+    SourceCapability(
+        capability_id="liability_statement",
+        status=SourceCapabilityStatus.MANUAL_TRUSTED,
+        intake_modes=("manual_evidence", "structured_payload"),
+        evidence_kinds=("loan_statement", "credit_card_statement", "mortgage_statement"),
+        produced_facts=("liability_balance",),
+        review_semantics="explicit manual input or reviewed statement evidence is required",
+        traceability_target="liability-source-to-balance-sheet-liability-line",
+    ),
+    SourceCapability(
+        capability_id="manual_record",
+        status=SourceCapabilityStatus.MANUAL_TRUSTED,
+        intake_modes=("api_entry", "manual_evidence"),
+        evidence_kinds=("user_supplied_record",),
+        produced_facts=("balanced_journal_command",),
+        review_semantics="explicit user input and a balanced Decimal command are required",
+        traceability_target="manual-entry-to-ledger-to-report-line",
+    ),
 )
 
 

--- a/apps/backend/tests/extraction/test_statement_result_contract.py
+++ b/apps/backend/tests/extraction/test_statement_result_contract.py
@@ -287,8 +287,17 @@ def test_AC_extraction_source_capability_1_declares_semantics_not_test_paths():
     """AC-extraction.source-capability.1: capability truth is semantic product data."""
     by_id = {capability.capability_id: capability for capability in SOURCE_CAPABILITIES}
 
-    assert by_id["settlement_note"].status is SourceCapabilityStatus.GAP
-    assert by_id["csv_export"].status is SourceCapabilityStatus.MANUAL_TRUSTED
+    assert len(by_id) == len(SOURCE_CAPABILITIES)
+    assert {capability_id: capability.status for capability_id, capability in by_id.items()} == {
+        "bank_statement": SourceCapabilityStatus.SUPPORTED,
+        "brokerage_statement": SourceCapabilityStatus.SUPPORTED,
+        "csv_export": SourceCapabilityStatus.MANUAL_TRUSTED,
+        "esop_rsu_plan": SourceCapabilityStatus.MANUAL_TRUSTED,
+        "liability_statement": SourceCapabilityStatus.MANUAL_TRUSTED,
+        "manual_record": SourceCapabilityStatus.MANUAL_TRUSTED,
+        "property_statement": SourceCapabilityStatus.MANUAL_TRUSTED,
+        "settlement_note": SourceCapabilityStatus.GAP,
+    }
     assert "pytest" not in repr(SOURCE_CAPABILITIES).lower()
 
 

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -3764,7 +3764,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_4_api_and_prefect_use_same_composed_use_case"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3779,7 +3779,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_5_incomplete_composition_fails_before_job"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3794,7 +3794,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_6_application_error_does_not_reject_source"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3808,7 +3808,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_7_fresh_worker_composes_without_main"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3822,7 +3822,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_8_retry_does_not_duplicate_financial_effects"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(
@@ -3838,7 +3838,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_9_upload_registers_source_before_dispatch"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(
@@ -3855,7 +3855,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_1913_10_staging_statement_canary_is_sha_pinned_and_blocking"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3870,7 +3870,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_ingestion_trace_1_is_atomic_with_statement_facts"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(
@@ -3885,7 +3885,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_ingestion_trace_2_retries_are_idempotent_and_changes_supersede"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(
@@ -3906,7 +3906,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_result_envelope_1_rejects_unknown_versions_and_defaults"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(
@@ -3921,7 +3921,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_result_envelope_2_round_trips_complete_facts"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         # ── group reviewed-envelope: human confirmation is a separate,
@@ -4094,7 +4094,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_statement_contribution_4_publishes_confirmed_custody_account"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="invariant",
         ),
         ACRecord(
@@ -4109,7 +4109,7 @@ CONTRACT = PackageContract(
                 "::test_AC_extraction_source_capability_1_declares_semantics_not_test_paths"
             ),
             priority="P0",
-            status="open",
+            status="done",
             proof_kind="property",
         ),
         ACRecord(

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -80,12 +80,13 @@ package disclosure instead of rebuilding policy facts from configuration.
 
 ## Upload-First Product Contract
 
-The user-facing input model is upload-first: users provide supported source
-documents and exports, and the system converts them into reviewed records before
-ledger/report use. Supported upload classes include bank statements, brokerage
-statements or settlement notes, CSV exports, ESOP/RSU grant or vesting
-documents, property appraisals, insurance or liability statements, and other
-future document types registered through the schema and AC workflow.
+The user-facing input model is upload-first: users provide source documents and
+exports, and the system converts them into reviewed records before ledger/report
+use. `SourceCapability` is the semantic registry for every source class named by
+the product vision. Bank and brokerage statements are `supported`; CSV, ESOP/RSU,
+property, liability, and explicit manual records are `manual_trusted` inputs;
+settlement notes remain a `gap`. A recognized format is not automatically a
+supported parsing capability.
 
 Extraction owns parsing, source metadata, validation results, and lineage back
 to the original file. Downstream automation such as market-data refresh,
@@ -95,11 +96,12 @@ weaken extraction confidence or balance-validation rules.
 
 ## Source Coverage Matrix
 
-Supported source classes, proof levels, review requirements, and traceability
-targets are owned by
-[`source_coverage_matrix`](../../common/testing/data/source-coverage-matrix.yaml). This document
-explains extraction behavior; source-class changes must land through the matrix
-and its EPIC -> AC -> test anchors.
+Semantic source status, review requirements, produced facts, and traceability
+targets are owned by extraction's `SourceCapability` registry. Testing's
+[`source_coverage_matrix`](../../common/testing/data/source-coverage-matrix.yaml)
+may map those stable capability ids to executable proof requirements, but it
+cannot redefine product support. Source-class changes start in extraction's
+contract and then update their testing proof mapping.
 
 ## Data Flow
 


### PR DESCRIPTION
## Summary

- mark 13 implemented extraction ACs complete in the owning roadmap
- complete the single `SourceCapability` registry for all eight vision source classes
- keep product capability semantics in extraction; testing may reference stable capability IDs but may not redefine support

## Root cause

The original closeout only reconciled stale roadmap statuses. A counterfactual audit then showed that `AC-extraction.source-capability.1` was not actually proven: the registry contained only four of the eight source classes named by the vision, while its test sampled only CSV and settlement-note statuses.

## Why gates missed it

The existing unit test asserted two examples instead of exact registry completeness and uniqueness. The separate testing matrix only checks that test files exist, so its duplicated source rows could not prove extraction's semantic registry or detect drift.

## Proof added

- the AC test now requires one unique capability for every vision source class and locks the exact semantic status mapping
- the test was observed red with the four missing capabilities, then green after the registry was completed
- focused local AC proof: 1 passed; the broader local backend run hit an intermittent native `asyncpg` setup segfault
- final-head GitHub CI re-proved the complete backend surface: five backend shards, integration, Tier-1 API E2E, tooling/common coverage, unified coverage, and behavioral ratchet all passed
- full local preflight: 2362 passed; 11/11 relevant gates
- static pre-push preflight: 10/10 relevant gates
- current-head Copilot review: 4/4 files reviewed, no comments

## Scope

Extraction owns capability status, intake modes, evidence kinds, produced facts, review semantics, and traceability targets. This PR does not create a second proof/certificate entity and does not rewrite testing's proof matrix; #696 owns the separate G6 slice that replaces stale test-path anchors with a derived capability-to-proof join.

Refs #950
Refs #696
Refs #1834
Refs #1681