### PR TITLE
[finance_report_pic] Converge extraction source lifecycle state

### DIFF
--- a/apps/backend/migrations/versions/0059_source_lifecycle.py
+++ b/apps/backend/migrations/versions/0059_source_lifecycle.py
@@ -1,0 +1,19 @@
+"""Add retired states for extraction-owned source lifecycle."""
+
+from alembic import op
+
+revision = "0059_source_lifecycle"
+down_revision = "0058_economic_disposition"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE statement_summary_status_enum ADD VALUE IF NOT EXISTS 'retired'")
+    op.execute("ALTER TYPE document_status_enum ADD VALUE IF NOT EXISTS 'retired'")
+
+
+def downgrade() -> None:
+    # PostgreSQL enum values cannot be removed without rebuilding the type.
+    # Keeping an unused additive value is safer than rewriting source rows.
+    pass

--- a/apps/backend/src/extraction/__init__.py
+++ b/apps/backend/src/extraction/__init__.py
@@ -75,6 +75,7 @@ from src.extraction.base.types import (
     DocumentSource,
     ExtractedTransactionRow,
     ParseJob,
+    RetireStatementCommand,
     RetryableStatementIngestionError,
     StatementIngestionConfigurationError,
     StatementIngestionError,
@@ -148,6 +149,7 @@ from src.extraction.extension.reviewed_statement_envelope import (
     persist_statement_extraction_result,
 )
 from src.extraction.extension.service import ExtractionError, ExtractionService
+from src.extraction.extension.source_lifecycle import retire_statement
 from src.extraction.extension.statement_contribution import (
     list_statement_contributions,
     resolve_statement_contribution,
@@ -266,6 +268,7 @@ __all__ = [
     "PositionStatus",
     "ParseJob",
     "RetryableStatementIngestionError",
+    "RetireStatementCommand",
     "ReviewedStatementEnvelopeCommand",
     "ReviewedStatementEnvelopeConflict",
     "ResolvedStatementContribution",
@@ -337,6 +340,7 @@ __all__ = [
     "register_fx_rate_provider",
     "register_position_reconciler",
     "reject_statement_workflow",
+    "retire_statement",
     "resolve_custody_account_id",
     "register_statement_source",
     "resolve_ingest_currency",

--- a/apps/backend/src/extraction/base/types.py
+++ b/apps/backend/src/extraction/base/types.py
@@ -49,6 +49,20 @@ class RetryableStatementIngestionError(StatementIngestionError):
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class RetireStatementCommand:
+    """Idempotently retire one user-owned statement without purging facts."""
+
+    statement_id: UUID
+    user_id: UUID
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.statement_id, UUID):
+            raise TypeError("statement_id must be a UUID")
+        if not isinstance(self.user_id, UUID):
+            raise TypeError("user_id must be a UUID")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class StatementIngestionOutcome:
     """Typed result returned by every statement-ingestion transport."""
 

--- a/apps/backend/src/extraction/extension/deduplication.py
+++ b/apps/backend/src/extraction/extension/deduplication.py
@@ -9,6 +9,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.extraction.base.types import ExtractedTransactionRow
+from src.extraction.extension.source_lifecycle import SourceIdentityCommand, resolve_source_identity
 from src.extraction.orm.layer1 import DocumentStatus, DocumentType, UploadedDocument
 from src.extraction.orm.layer2 import (
     AtomicPosition,
@@ -543,11 +544,9 @@ async def dual_write_layer2(
     Precondition: each immutable row carries its precomputed ``dedup_hash`` and
     every value needed by persistence; no transient ORM attributes are accepted.
 
-    Raises RuntimeError on non-IntegrityError failures. IntegrityError (duplicate
-    upload) is silently ignored.
+    Expected source-identity conflicts select the canonical winner under a
+    savepoint. Every other persistence failure raises ``RuntimeError``.
     """
-    from sqlalchemy.exc import IntegrityError
-
     if any(not isinstance(txn, ExtractedTransactionRow) for txn in transactions):
         raise TypeError(
             "dual_write_layer2 requires ExtractedTransactionRow values; "
@@ -579,15 +578,18 @@ async def dual_write_layer2(
         # raising on the unique key (which previously aborted the whole dual-write and
         # made reparse a silent no-op). On reparse, drop this document's prior parse
         # output first so the fresh extraction replaces it rather than accumulating.
-        existing_doc = (
-            await db.execute(
-                select(UploadedDocument)
-                .where(UploadedDocument.user_id == user_id)
-                .where(UploadedDocument.file_hash == file_hash)
-            )
-        ).scalar_one_or_none()
-        if existing_doc is not None:
-            uploaded_doc = existing_doc
+        uploaded_doc, document_created = await resolve_source_identity(
+            db,
+            SourceIdentityCommand(
+                user_id=user_id,
+                file_path=str(file_path) if file_path else file_hash,
+                file_hash=file_hash,
+                original_filename=original_filename or file_hash,
+                document_type=doc_type,
+                extraction_metadata=effective_metadata,
+            ),
+        )
+        if not document_created:
             uploaded_doc.original_filename = original_filename or uploaded_doc.original_filename
             # The upload registers an artifact before parsing can determine
             # whether it is a bank or brokerage statement.  Resolve that
@@ -601,17 +603,6 @@ async def dual_write_layer2(
             # ends in quarantine would delete a prior good parse's transactions.
             if not envelope_only:
                 await _detach_document_from_atomic_transactions(db, user_id, uploaded_doc.id)
-        else:
-            uploaded_doc = await dedup_service.create_uploaded_document(
-                db=db,
-                user_id=user_id,
-                file_path=str(file_path) if file_path else file_hash,
-                file_hash=file_hash,
-                original_filename=original_filename or file_hash,
-                document_type=doc_type,
-                extraction_metadata=effective_metadata,
-            )
-
         # Lazily import to avoid an import cycle (evidence_graph_integration imports
         # models that transitively reach back here).
         from src.extraction.extension.evidence_graph_integration import EvidenceGraphIntegrationService
@@ -719,13 +710,6 @@ async def dual_write_layer2(
             layer2_transactions=layer2_count,
         )
 
-    except IntegrityError:
-        # Duplicate upload - acceptable silent failure
-        logger.warning(
-            "Dual write skipped - document already exists",
-            file_hash=file_hash,
-            user_id=str(user_id),
-        )
     except Exception as e:
         # All other errors are CRITICAL - must be visible to user
         logger.error(

--- a/apps/backend/src/extraction/extension/reviewed_statement_envelope.py
+++ b/apps/backend/src/extraction/extension/reviewed_statement_envelope.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from sqlalchemy import desc, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit import (
@@ -148,32 +149,35 @@ async def persist_statement_extraction_result(
     if StatementExtractionResult.from_payload(payload) != result:
         raise ValueError("statement extraction result failed typed persistence validation")
 
-    existing = (
-        await db.execute(
-            select(StatementExtractionResultRecord)
-            .where(StatementExtractionResultRecord.user_id == statement.user_id)
-            .where(StatementExtractionResultRecord.statement_id == statement.id)
-            .where(StatementExtractionResultRecord.content_digest == result.content_digest)
-        )
-    ).scalar_one_or_none()
-    if existing is not None:
-        if existing.payload != payload:
-            raise ValueError("statement extraction result digest collision")
-        source_record = existing
-    else:
-        source_record = StatementExtractionResultRecord(
-            user_id=statement.user_id,
-            statement_id=statement.id,
-            content_digest=result.content_digest,
-            source_content_digest=result.source_content_digest,
-            schema_version=result.schema_version,
-            producer_version=result.producer_version,
-            payload=payload,
-            source_trace_record_id=source_trace_record_id,
-            created_at=datetime.now(UTC),
-        )
-        db.add(source_record)
-        await db.flush()
+    candidate = StatementExtractionResultRecord(
+        user_id=statement.user_id,
+        statement_id=statement.id,
+        content_digest=result.content_digest,
+        source_content_digest=result.source_content_digest,
+        schema_version=result.schema_version,
+        producer_version=result.producer_version,
+        payload=payload,
+        source_trace_record_id=source_trace_record_id,
+        created_at=datetime.now(UTC),
+    )
+    try:
+        async with db.begin_nested():
+            db.add(candidate)
+            await db.flush()
+        source_record = candidate
+    except IntegrityError:
+        source_record = (
+            await db.execute(
+                select(StatementExtractionResultRecord)
+                .where(StatementExtractionResultRecord.user_id == statement.user_id)
+                .where(StatementExtractionResultRecord.statement_id == statement.id)
+                .where(StatementExtractionResultRecord.content_digest == result.content_digest)
+            )
+        ).scalar_one_or_none()
+        if source_record is None:
+            raise RuntimeError("source-result conflict did not expose a canonical winner") from None
+    if source_record.payload != payload:
+        raise ValueError("statement extraction result digest collision")
 
     previous_source_result_id = statement.current_extraction_result_id
     if previous_source_result_id != source_record.id:

--- a/apps/backend/src/extraction/extension/source_lifecycle.py
+++ b/apps/backend/src/extraction/extension/source_lifecycle.py
@@ -1,0 +1,105 @@
+"""Extraction-owned source identity and ordinary lifecycle commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.extraction.base.types import RetireStatementCommand
+from src.extraction.orm.layer1 import DocumentStatus, DocumentType, UploadedDocument
+from src.extraction.orm.statement_enums import BankStatementStatus
+from src.extraction.orm.statement_summary import StatementSummary
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SourceIdentityCommand:
+    """Typed values needed to resolve one immutable uploaded source."""
+
+    user_id: UUID
+    file_path: str
+    file_hash: str
+    original_filename: str
+    document_type: DocumentType
+    extraction_metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.user_id, UUID):
+            raise TypeError("user_id must be a UUID")
+        if not isinstance(self.document_type, DocumentType):
+            raise TypeError("document_type must be a DocumentType")
+        for name in ("file_path", "file_hash", "original_filename"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} is required")
+
+
+async def resolve_source_identity(
+    db: AsyncSession,
+    command: SourceIdentityCommand,
+) -> tuple[UploadedDocument, bool]:
+    """Insert a source under a savepoint or return the concurrent winner."""
+    candidate = UploadedDocument(
+        user_id=command.user_id,
+        file_path=command.file_path,
+        file_hash=command.file_hash,
+        original_filename=command.original_filename,
+        document_type=command.document_type,
+        extraction_metadata=command.extraction_metadata,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(candidate)
+            await db.flush()
+        return candidate, True
+    except IntegrityError:
+        winner = (
+            await db.execute(
+                select(UploadedDocument).where(
+                    UploadedDocument.user_id == command.user_id,
+                    UploadedDocument.file_hash == command.file_hash,
+                )
+            )
+        ).scalar_one_or_none()
+        if winner is None:
+            raise RuntimeError("source identity conflict did not expose a canonical winner") from None
+        return winner, False
+
+
+async def retire_statement(
+    db: AsyncSession,
+    command: RetireStatementCommand,
+) -> StatementSummary:
+    """Retire product visibility while retaining source content and lineage."""
+    statement = (
+        await db.execute(
+            select(StatementSummary)
+            .where(
+                StatementSummary.id == command.statement_id,
+                StatementSummary.user_id == command.user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if statement is None:
+        raise ValueError("Statement not found or access denied")
+
+    statement.status = BankStatementStatus.RETIRED
+    if statement.uploaded_document_id is not None:
+        document = await db.get(UploadedDocument, statement.uploaded_document_id)
+        if document is not None and document.user_id == command.user_id:
+            document.status = DocumentStatus.RETIRED
+    await db.flush()
+    return statement
+
+
+__all__ = [
+    "RetireStatementCommand",
+    "SourceIdentityCommand",
+    "resolve_source_identity",
+    "retire_statement",
+]

--- a/apps/backend/src/extraction/extension/statement_validation.py
+++ b/apps/backend/src/extraction/extension/statement_validation.py
@@ -113,8 +113,26 @@ async def validate_balance_chain(
                 }
             )
 
+        primary_currency = (statement.currency or "").strip().upper()
+        if (
+            primary_currency
+            and primary_currency not in declared
+            and not any(row["currency"] == primary_currency for row in per_currency)
+        ):
+            per_currency.append(
+                {
+                    "currency": primary_currency,
+                    "opening_balance": None,
+                    "closing_balance": None,
+                    "calculated_closing": "0",
+                    "closing_delta": "0",
+                    "closing_match": False,
+                    "declared_balance": False,
+                }
+            )
+
         primary = next(
-            (row for row in per_currency if row["currency"] == (statement.currency or "").upper()),
+            (row for row in per_currency if row["currency"] == primary_currency),
             per_currency[0],
         )
         return {
@@ -127,6 +145,45 @@ async def validate_balance_chain(
             "closing_known": True,
             "closing_match": primary["closing_match"],
             "balance_valid": all(row["closing_match"] for row in per_currency),
+            "per_currency": per_currency,
+            "validated_at": datetime.now(UTC).isoformat(),
+        }
+
+    transaction_currencies = {txn.currency.strip().upper() for txn in transactions}
+    scalar_currency = (statement.currency or "").strip().upper()
+    if len(transaction_currencies) > 1 or (transaction_currencies and scalar_currency not in transaction_currencies):
+        nets = {currency: Decimal("0") for currency in transaction_currencies}
+        for txn in transactions:
+            currency = txn.currency.strip().upper()
+            nets[currency] += txn.amount if _direction_is_in(txn.direction) else -txn.amount
+        per_currency = []
+        for currency in sorted(nets):
+            expected, delta = balance_check(Decimal("0"), Decimal("0"), nets[currency], currency)
+            per_currency.append(
+                {
+                    "currency": currency,
+                    "opening_balance": None,
+                    "closing_balance": None,
+                    "calculated_closing": str(expected),
+                    "closing_delta": str(delta),
+                    "closing_match": False,
+                    "declared_balance": False,
+                }
+            )
+        primary = next(
+            (row for row in per_currency if row["currency"] == scalar_currency),
+            per_currency[0],
+        )
+        return {
+            "opening_balance": primary["opening_balance"],
+            "closing_balance": primary["closing_balance"],
+            "calculated_closing": primary["calculated_closing"],
+            "opening_delta": "0",
+            "closing_delta": primary["closing_delta"],
+            "opening_match": False,
+            "closing_known": False,
+            "closing_match": False,
+            "balance_valid": False,
             "per_currency": per_currency,
             "validated_at": datetime.now(UTC).isoformat(),
         }

--- a/apps/backend/src/extraction/extension/statement_validation.py
+++ b/apps/backend/src/extraction/extension/statement_validation.py
@@ -14,6 +14,7 @@ from sqlalchemy import and_, desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.audit import STATEMENT_BALANCE_TOLERANCE, InvariantResult, evaluate_promotion
+from src.audit.money.adopt import balance_check
 from src.extraction.extension.reviewed_statement_envelope import require_current_statement_envelope_trust
 from src.extraction.orm.layer2 import AtomicTransaction, TransactionDirection
 from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
@@ -69,6 +70,67 @@ async def validate_balance_chain(
 
     transactions = await resolve_statement_transactions(db, statement)
 
+    typed_balances = statement.typed_currency_balances()
+    if len(typed_balances):
+        nets = {currency: Decimal("0") for currency in typed_balances.currencies()}
+        for txn in transactions:
+            currency = txn.currency.strip().upper()
+            nets.setdefault(currency, Decimal("0"))
+            nets[currency] += txn.amount if _direction_is_in(txn.direction) else -txn.amount
+
+        per_currency = []
+        for balance in typed_balances:
+            currency = balance.currency.code
+            expected, delta = balance_check(
+                balance.opening.amount,
+                balance.closing.amount,
+                nets.get(currency, Decimal("0")),
+                currency,
+            )
+            per_currency.append(
+                {
+                    "currency": currency,
+                    "opening_balance": str(balance.opening.amount),
+                    "closing_balance": str(balance.closing.amount),
+                    "calculated_closing": str(expected),
+                    "closing_delta": str(delta),
+                    "closing_match": delta <= BALANCE_TOLERANCE,
+                    "declared_balance": True,
+                }
+            )
+        declared = set(typed_balances.currencies())
+        for currency in sorted(set(nets) - declared):
+            expected, delta = balance_check(Decimal("0"), Decimal("0"), nets[currency], currency)
+            per_currency.append(
+                {
+                    "currency": currency,
+                    "opening_balance": None,
+                    "closing_balance": None,
+                    "calculated_closing": str(expected),
+                    "closing_delta": str(delta),
+                    "closing_match": False,
+                    "declared_balance": False,
+                }
+            )
+
+        primary = next(
+            (row for row in per_currency if row["currency"] == (statement.currency or "").upper()),
+            per_currency[0],
+        )
+        return {
+            "opening_balance": primary["opening_balance"],
+            "closing_balance": primary["closing_balance"],
+            "calculated_closing": primary["calculated_closing"],
+            "opening_delta": "0",
+            "closing_delta": primary["closing_delta"],
+            "opening_match": True,
+            "closing_known": True,
+            "closing_match": primary["closing_match"],
+            "balance_valid": all(row["closing_match"] for row in per_currency),
+            "per_currency": per_currency,
+            "validated_at": datetime.now(UTC).isoformat(),
+        }
+
     opening_balance = await _get_opening_balance(db, statement)
     opening_delta = abs((statement.opening_balance or Decimal("0")) - opening_balance)
 
@@ -98,6 +160,9 @@ async def validate_balance_chain(
         "opening_match": opening_delta <= BALANCE_TOLERANCE,
         "closing_known": closing_known,
         "closing_match": closing_known and closing_delta <= BALANCE_TOLERANCE,
+        "balance_valid": (opening_delta <= BALANCE_TOLERANCE)
+        and (not closing_known or closing_delta <= BALANCE_TOLERANCE),
+        "per_currency": [],
         "validated_at": datetime.now(UTC).isoformat(),
     }
 
@@ -147,6 +212,11 @@ async def _get_statement_for_update(
 
 
 def _raise_if_balance_chain_invalid(validation_result: dict, *, after_edits: bool = False) -> None:
+    per_currency = validation_result.get("per_currency", [])
+    failed_currencies = [row["currency"] for row in per_currency if not row["closing_match"]]
+    if failed_currencies:
+        raise ValueError(f"Balance mismatch for currency: {', '.join(failed_currencies)}")
+
     # Route the Stage-1 approval decision through the promotion gate: the
     # balance-chain checks are the deterministic invariants, with no confidence
     # term (min_confidence=0). The gate disposes; a failed invariant blocks

--- a/apps/backend/src/extraction/orm/layer1.py
+++ b/apps/backend/src/extraction/orm/layer1.py
@@ -26,6 +26,7 @@ class DocumentStatus(str, Enum):
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
+    RETIRED = "retired"
 
 
 class UploadedDocument(Base, UUIDMixin, UserOwnedMixin, TimestampMixin):

--- a/apps/backend/src/extraction/orm/statement_enums.py
+++ b/apps/backend/src/extraction/orm/statement_enums.py
@@ -16,6 +16,7 @@ class BankStatementStatus(str, Enum):
     PARSED = "parsed"
     APPROVED = "approved"
     REJECTED = "rejected"
+    RETIRED = "retired"
 
 
 class Stage1Status(str, Enum):

--- a/apps/backend/src/routers/reconciliation.py
+++ b/apps/backend/src/routers/reconciliation.py
@@ -13,6 +13,7 @@ from src.audit import STATEMENT_SOURCE_TYPES
 from src.composition import compose_reviewed_disposition_dependencies
 from src.config_app import get_effective_base_currency
 from src.deps import CurrentUserId, DbSession, Pagination
+from src.extraction import BankStatementStatus
 from src.extraction.orm.layer2 import AtomicTransaction
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import (
@@ -204,6 +205,7 @@ async def run_reconciliation(
             select(StatementSummary)
             .where(StatementSummary.id == payload.statement_id)
             .where(StatementSummary.user_id == user_id)
+            .where(StatementSummary.status != BankStatementStatus.RETIRED)
         )
         statement = stmt_result.scalar_one_or_none()
         if statement is None:

--- a/apps/backend/src/routers/review.py
+++ b/apps/backend/src/routers/review.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from src.audit.money import InvalidCurrencyError
 from src.deps import CurrentUserId, DbSession
 from src.extraction import (
+    BankStatementStatus,
     resolve_statement_conflicts,
     resolve_statement_transactions,
     resolve_transaction_currency,
@@ -17,7 +18,7 @@ from src.extraction.orm.layer2 import AtomicTransaction
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import JournalEntry, JournalEntryStatus
 from src.observability import get_logger
-from src.platform import get_owned_or_404, raise_conflict
+from src.platform import get_owned_or_404, raise_conflict, raise_not_found
 from src.reconciliation import (
     CheckResolutionAction,
     ReconciliationError,
@@ -64,6 +65,8 @@ async def get_review_conflicts(
 ) -> ReviewConflictsResponse:
     """Return duplicate and transfer-pair candidates for a statement."""
     statement = await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
+    if statement.status is BankStatementStatus.RETIRED:
+        raise_not_found("Statement")
 
     transactions = await resolve_statement_transactions(db, statement)
 
@@ -230,7 +233,9 @@ async def run_stage2_checks(
 ) -> ConsistencyCheckListResponse:
     """Run consistency checks for a statement."""
     # Existence/ownership guard (404); the checks below key off statement_id.
-    await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
+    statement = await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
+    if statement.status is BankStatementStatus.RETIRED:
+        raise_not_found("Statement")
 
     checks = await run_all_consistency_checks(db, user_id, statement_id)
     await db.commit()

--- a/apps/backend/src/routers/statements.py
+++ b/apps/backend/src/routers/statements.py
@@ -17,8 +17,10 @@ from src.composition import compose_statement_posting_dependencies
 from src.config import settings
 from src.deps import CurrentUserId, DbSession
 from src.extraction import (
+    BankStatementStatus,
     BrokeragePositionImportService,
     ParseJob,
+    RetireStatementCommand,
     ReviewedStatementEnvelopeCommand,
     ReviewedStatementEnvelopeConflict,
     StatementPostingOutcome,
@@ -38,18 +40,17 @@ from src.extraction import (
     reject_statement_workflow,
     resolve_statement_posting_account,
     resolve_statement_transactions,
+    retire_statement,
     set_opening_balance,
     submit_parse_pipeline,
     supports_reviewed_statement_envelope,
     validate_balance_chain,
 )
-from src.extraction.orm.statement_enums import BankStatementStatus
 from src.extraction.orm.statement_summary import StatementSummary
 from src.ledger import Account, AccountType
 from src.llm import LitellmCatalog, Modality
 from src.observability import ErrorIds, ensure_request_id, get_logger, safe_error_message
 from src.platform import (
-    get_owned_or_404,
     raise_bad_request,
     raise_conflict,
     raise_internal_error,
@@ -140,7 +141,17 @@ async def _get_statement_or_404(
     statement_id: UUID,
     user_id: UUID,
 ) -> StatementSummary:
-    return await get_owned_or_404(db, StatementSummary, statement_id, user_id, name="Statement")
+    result = await db.execute(
+        select(StatementSummary).where(
+            StatementSummary.id == statement_id,
+            StatementSummary.user_id == user_id,
+            StatementSummary.status != BankStatementStatus.RETIRED,
+        )
+    )
+    statement = result.scalar_one_or_none()
+    if statement is None:
+        raise_not_found("Statement")
+    return statement
 
 
 async def _queue_statement_reparse(
@@ -496,12 +507,22 @@ async def list_statements(
 ) -> BankStatementListResponse:
     """List all statements for the current user."""
     result = await db.execute(
-        select(StatementSummary).where(StatementSummary.user_id == user_id).order_by(StatementSummary.created_at.desc())
+        select(StatementSummary)
+        .where(
+            StatementSummary.user_id == user_id,
+            StatementSummary.status != BankStatementStatus.RETIRED,
+        )
+        .order_by(StatementSummary.created_at.desc())
     )
     statements = result.scalars().all()
 
     total_result = await db.execute(
-        select(func.count()).select_from(StatementSummary).where(StatementSummary.user_id == user_id)
+        select(func.count())
+        .select_from(StatementSummary)
+        .where(
+            StatementSummary.user_id == user_id,
+            StatementSummary.status != BankStatementStatus.RETIRED,
+        )
     )
     total = total_result.scalar() or 0
 
@@ -702,27 +723,16 @@ async def delete_statement(
     db: DbSession,
     user_id: CurrentUserId,
 ) -> None:
-    """Delete a statement."""
-    statement = await _get_statement_or_404(db, statement_id, user_id)
-
-    # Resolve the MinIO object key via the ODS document and delete from storage.
-    uploaded_document = await _resolve_uploaded_document(db, statement, user_id)
-    storage_key = uploaded_document.file_path if uploaded_document else None
-    if storage_key:
-        storage = StorageService()
-        try:
-            await run_in_threadpool(storage.delete_object, storage_key)
-        except StorageError as exc:
-            logger.error(
-                "Failed to delete file from storage",
-                error=str(exc),
-                error_id=ErrorIds.STORAGE_DELETE_FAILED,
-                file_path=storage_key,
-            )
-            # Proceed to delete from DB to avoid zombie record
-
-    await db.delete(statement)
-    await db.commit()
+    """Retire a statement from product views while retaining source history."""
+    try:
+        await retire_statement(
+            db,
+            RetireStatementCommand(statement_id=statement_id, user_id=user_id),
+        )
+        await db.commit()
+    except ValueError as exc:
+        await db.rollback()
+        raise_not_found("Statement", cause=exc)
 
 
 # --- Two-Stage Review Endpoints ---

--- a/apps/backend/tests/api/test_statements_router.py
+++ b/apps/backend/tests/api/test_statements_router.py
@@ -1645,7 +1645,7 @@ async def test_handle_parse_failure_rollback_fails(db, test_user):
 async def test_delete_statement_success(db, test_user, monkeypatch):
     """Given an existing statement with a file_path,
     When delete_statement is called,
-    Then it deletes from storage and DB (lines 685-698).
+    Then it retires the DB/reference state without deleting storage.
     """
     statement = build_statement(test_user.id, "hash_del", 90)
     db.add(statement)
@@ -1658,8 +1658,9 @@ async def test_delete_statement_success(db, test_user, monkeypatch):
 
     await statements_router.delete_statement(statement_id=statement_id, db=db, user_id=test_user.id)
 
-    deleted = await db.get(StatementSummary, statement_id)
-    assert deleted is None
+    retired = await db.get(StatementSummary, statement_id)
+    assert retired is not None
+    assert retired.status is BankStatementStatus.RETIRED
 
 
 async def test_delete_statement_not_found(db, test_user):
@@ -1679,7 +1680,7 @@ async def test_delete_statement_not_found(db, test_user):
 async def test_delete_statement_storage_error_still_deletes(db, test_user, monkeypatch):
     """Given a statement whose storage delete fails,
     When delete_statement is called,
-    Then the DB record is still deleted to avoid zombie records (lines 690-696).
+    Then retirement does not call storage and preserves the DB record.
     """
     statement = build_statement(test_user.id, "hash_del_err", 90)
     db.add(statement)
@@ -1694,8 +1695,10 @@ async def test_delete_statement_storage_error_still_deletes(db, test_user, monke
 
     await statements_router.delete_statement(statement_id=statement_id, db=db, user_id=test_user.id)
 
-    deleted = await db.get(StatementSummary, statement_id)
-    assert deleted is None
+    mock_storage.delete_object.assert_not_called()
+    retired = await db.get(StatementSummary, statement_id)
+    assert retired is not None
+    assert retired.status is BankStatementStatus.RETIRED
 
 
 async def test_get_statement_for_review(db, test_user, monkeypatch):

--- a/apps/backend/tests/extraction/test_dual_write_layer2.py
+++ b/apps/backend/tests/extraction/test_dual_write_layer2.py
@@ -343,7 +343,7 @@ class TestDualWriteLayer2:
 
         with patch.object(service, "extract_financial_data", return_value=mock_ai_response):
             with patch(
-                "src.extraction.extension.service.DeduplicationService.create_uploaded_document",
+                "src.extraction.extension.deduplication.resolve_source_identity",
                 side_effect=Exception("DB error"),
             ):
                 with pytest.raises(ExtractionError) as exc_info:

--- a/apps/backend/tests/extraction/test_extraction_error_paths.py
+++ b/apps/backend/tests/extraction/test_extraction_error_paths.py
@@ -2,12 +2,11 @@ from datetime import date
 from decimal import Decimal  # noqa: F401
 from pathlib import Path
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 
 from src.extraction import (
     DocumentSource,
@@ -1378,57 +1377,76 @@ async def test_parse_document_csv_no_institution():
         )
 
 
-async def test_dual_write_layer2_integrity_error_is_non_fatal():
-    """AC-extraction.111.1: Dual-write handles duplicate document hash / IntegrityError without failing."""
-    db = AsyncMock()
-    # No pre-existing UploadedDocument for (user_id, file_hash), so dual_write takes the
-    # create branch; a concurrent race then makes create_uploaded_document raise
-    # IntegrityError, which must be swallowed without failing ingestion.
-    no_existing = MagicMock()
-    no_existing.scalar_one_or_none.return_value = None
-    db.execute.return_value = no_existing
-    with patch("src.extraction.extension.deduplication.DeduplicationService") as mock_dedup_cls:
-        mock_dedup = mock_dedup_cls.return_value
-        mock_dedup.create_uploaded_document.side_effect = IntegrityError("x", {}, Exception("dup"))
+async def test_dual_write_layer2_integrity_error_is_non_fatal(db, test_user):
+    """AC-extraction.111.1: duplicate source identity reuses the winner."""
+    txn_date = date(2025, 1, 1)
+    amount = Decimal("1.00")
+    direction = TransactionDirection.IN
+    description = "txn"
+    txn = ExtractedTransactionRow(
+        user_id=test_user.id,
+        txn_date=txn_date,
+        amount=amount,
+        direction=direction.value,
+        description=description,
+        reference=None,
+        currency="SGD",
+        currency_unresolved=False,
+        balance_after=None,
+        occurrence_index=0,
+        dedup_hash=DeduplicationService.calculate_transaction_hash(
+            test_user.id,
+            txn_date,
+            amount,
+            direction,
+            description,
+        ),
+    )
+    first = StatementSummaryFactory.build(
+        user_id=test_user.id,
+        file_hash="abc123",
+        institution="DBS",
+        currency="SGD",
+    )
+    await dual_write_layer2(
+        db=db,
+        user_id=test_user.id,
+        statement=first,
+        transactions=[txn],
+        file_path=Path("statement.pdf"),
+        original_filename="statement.pdf",
+    )
+    await db.commit()
 
-        user_id = uuid4()
-        txn_date = date(2025, 1, 1)
-        amount = Decimal("1.00")
-        direction = TransactionDirection.IN
-        description = "txn"
-        txn = ExtractedTransactionRow(
-            user_id=user_id,
-            txn_date=txn_date,
-            amount=amount,
-            direction=direction.value,
-            description=description,
-            reference=None,
-            currency="SGD",
-            currency_unresolved=False,
-            balance_after=None,
-            occurrence_index=0,
-            dedup_hash=DeduplicationService.calculate_transaction_hash(
-                user_id,
-                txn_date,
-                amount,
-                direction,
-                description,
-            ),
+    repeated = StatementSummaryFactory.build(
+        user_id=test_user.id,
+        file_hash="abc123",
+        institution="DBS",
+        currency="SGD",
+    )
+    await dual_write_layer2(
+        db=db,
+        user_id=test_user.id,
+        statement=repeated,
+        transactions=[txn],
+        file_path=Path("statement.pdf"),
+        original_filename="statement.pdf",
+    )
+    await db.commit()
+
+    rows = (
+        (
+            await db.execute(
+                select(UploadedDocument).where(
+                    UploadedDocument.user_id == test_user.id,
+                    UploadedDocument.file_hash == "abc123",
+                )
+            )
         )
-        statement = StatementSummaryFactory.build(
-            user_id=user_id,
-            file_hash="abc123",
-            institution="DBS",
-            currency="SGD",
-        )
-        await dual_write_layer2(
-            db=db,
-            user_id=user_id,
-            statement=statement,
-            transactions=[txn],
-            file_path=Path("statement.pdf"),
-            original_filename="statement.pdf",
-        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/extraction/test_source_lifecycle.py
+++ b/apps/backend/tests/extraction/test_source_lifecycle.py
@@ -1,0 +1,530 @@
+"""Acceptance proofs for #1970's extraction-owned source lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import get_type_hints
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.extraction import DocumentStatus, DocumentType, UploadedDocument
+from src.extraction.base.result import (
+    ExtractedTransactionFact,
+    ExtractionMethod,
+    SourceProvenance,
+    StatementEvidenceType,
+    StatementExtractionResult,
+    StatementSourceType,
+)
+from src.extraction.extension.deduplication import dual_write_layer2
+from src.extraction.extension.reviewed_statement_envelope import persist_statement_extraction_result
+from src.extraction.extension.source_lifecycle import (
+    RetireStatementCommand,
+    SourceIdentityCommand,
+    resolve_source_identity,
+    retire_statement,
+)
+from src.extraction.extension.statement_validation import (
+    _raise_if_balance_chain_invalid,
+    validate_balance_chain,
+)
+from src.extraction.orm.layer2 import AtomicTransaction, TransactionDirection
+from src.extraction.orm.reviewed_statement_envelope import (
+    ReviewedStatementEnvelope,
+    StatementExtractionResultRecord,
+)
+from src.extraction.orm.statement_enums import BankStatementStatus, Stage1Status
+from src.extraction.orm.statement_summary import StatementSummary
+from src.ledger import Account, AccountType
+from src.routers import statements as statements_router
+from src.routers.reconciliation import run_reconciliation
+from src.routers.review import get_review_conflicts, run_stage2_checks
+from src.schemas.reconciliation import ReconciliationRunRequest
+
+
+def _summary(
+    user_id: UUID,
+    *,
+    file_hash: str,
+    uploaded_document_id: UUID | None = None,
+) -> StatementSummary:
+    return StatementSummary(
+        user_id=user_id,
+        uploaded_document_id=uploaded_document_id,
+        file_hash=file_hash,
+        institution="Example Bank",
+        currency="SGD",
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 30),
+        opening_balance=Decimal("0.00"),
+        closing_balance=Decimal("0.00"),
+        status=BankStatementStatus.PARSED,
+        stage1_status=Stage1Status.PENDING_REVIEW,
+    )
+
+
+def _document(user_id: UUID, *, file_hash: str) -> UploadedDocument:
+    return UploadedDocument(
+        user_id=user_id,
+        file_path=f"statements/{file_hash}.pdf",
+        file_hash=file_hash,
+        original_filename="statement.pdf",
+        document_type=DocumentType.BANK_STATEMENT,
+        status=DocumentStatus.COMPLETED,
+    )
+
+
+def _atomic(
+    user_id: UUID,
+    document_id: UUID,
+    *,
+    currency: str,
+    direction: TransactionDirection,
+    amount: str,
+) -> AtomicTransaction:
+    return AtomicTransaction(
+        user_id=user_id,
+        txn_date=date(2026, 6, 15),
+        description=f"{currency} movement {uuid4().hex}",
+        amount=Decimal(amount),
+        direction=direction,
+        currency=currency,
+        dedup_hash=uuid4().hex + uuid4().hex,
+        source_documents=[{"doc_id": str(document_id), "doc_type": "bank_statement"}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_1_approval_is_per_currency(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.1: cross-currency cancellation cannot approve."""
+    document = _document(test_user.id, file_hash="per-currency-approval")
+    db.add(document)
+    await db.flush()
+    statement = _summary(
+        test_user.id,
+        file_hash=document.file_hash,
+        uploaded_document_id=document.id,
+    )
+    statement.currency_balances = [
+        {"currency": "SGD", "opening": "0.00", "closing": "0.00"},
+        {"currency": "USD", "opening": "0.00", "closing": "0.00"},
+    ]
+    db.add(statement)
+    db.add_all(
+        [
+            _atomic(
+                test_user.id,
+                document.id,
+                currency="SGD",
+                direction=TransactionDirection.IN,
+                amount="10.00",
+            ),
+            _atomic(
+                test_user.id,
+                document.id,
+                currency="USD",
+                direction=TransactionDirection.OUT,
+                amount="10.00",
+            ),
+        ]
+    )
+    await db.flush()
+
+    result = await validate_balance_chain(db, statement.id)
+
+    assert result["balance_valid"] is False
+    assert {row["currency"] for row in result["per_currency"]} == {"SGD", "USD"}
+    assert all(row["closing_match"] is False for row in result["per_currency"])
+    with pytest.raises(ValueError, match="currency"):
+        _raise_if_balance_chain_invalid(result)
+
+
+def _identity(user_id: UUID, *, file_hash: str) -> SourceIdentityCommand:
+    return SourceIdentityCommand(
+        user_id=user_id,
+        file_path=f"statements/{file_hash}.pdf",
+        file_hash=file_hash,
+        original_filename="statement.pdf",
+        document_type=DocumentType.BANK_STATEMENT,
+        extraction_metadata={"producer": "acceptance"},
+    )
+
+
+def _source_result(source_digest: str) -> StatementExtractionResult:
+    return StatementExtractionResult.create(
+        producer_version="acceptance@1",
+        source_content_digest=source_digest,
+        source_type=StatementSourceType.BANK,
+        evidence_type=StatementEvidenceType.TRANSACTION_LEDGER,
+        institution="Example Bank",
+        account_last4="1234",
+        period_start=date(2026, 6, 1),
+        period_end=date(2026, 6, 30),
+        balances=(),
+        transactions=(
+            ExtractedTransactionFact(
+                fact_id="row-1",
+                transaction_date=date(2026, 6, 15),
+                description="typed source fact",
+                amount=Decimal("1.00"),
+                direction="IN",
+                currency="SGD",
+                balance_after=None,
+                confidence=Decimal("0.90"),
+            ),
+        ),
+        positions=(),
+        confidence=Decimal("0.90"),
+        balance_validated=None,
+        warnings=(),
+        review_reasons=("source facts require confirmation",),
+        provenance=SourceProvenance(
+            intake_mode="csv",
+            method=ExtractionMethod.DETERMINISTIC,
+            provider="acceptance",
+            model="acceptance@1",
+        ),
+        statement_currency=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_2_two_sessions_share_source_identity(
+    db: AsyncSession,
+    db_engine,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.2: workers select one source and result."""
+    maker = async_sessionmaker(db_engine, expire_on_commit=False)
+    command = _identity(test_user.id, file_hash="concurrent-source-identity")
+    start = asyncio.Event()
+    ready = 0
+    ready_lock = asyncio.Lock()
+
+    async def worker() -> tuple[UUID, bool]:
+        nonlocal ready
+        async with maker() as session:
+            async with ready_lock:
+                ready += 1
+                if ready == 2:
+                    start.set()
+            await start.wait()
+            document, created = await resolve_source_identity(session, command)
+            await session.commit()
+            return document.id, created
+
+    first, second = await asyncio.wait_for(asyncio.gather(worker(), worker()), timeout=10)
+    assert first[0] == second[0]
+    assert sorted((first[1], second[1])) == [False, True]
+
+    async with maker() as verification:
+        count = await verification.scalar(
+            select(func.count())
+            .select_from(UploadedDocument)
+            .where(
+                UploadedDocument.user_id == test_user.id,
+                UploadedDocument.file_hash == command.file_hash,
+            )
+        )
+        assert count == 1
+
+    statement = _summary(test_user.id, file_hash="concurrent-result-identity")
+    db.add(statement)
+    await db.commit()
+    result = _source_result("4" * 64)
+    result_start = asyncio.Event()
+    result_ready = 0
+    result_ready_lock = asyncio.Lock()
+
+    async def result_worker() -> UUID:
+        nonlocal result_ready
+        async with maker() as session:
+            owned_statement = await session.get(StatementSummary, statement.id)
+            assert owned_statement is not None
+            async with result_ready_lock:
+                result_ready += 1
+                if result_ready == 2:
+                    result_start.set()
+            await result_start.wait()
+            record = await persist_statement_extraction_result(
+                session,
+                statement=owned_statement,
+                result=result,
+                source_trace_record_id=uuid4(),
+            )
+            await session.commit()
+            return record.id
+
+    result_ids = await asyncio.wait_for(asyncio.gather(result_worker(), result_worker()), timeout=10)
+    assert result_ids[0] == result_ids[1]
+    async with maker() as verification:
+        result_count = await verification.scalar(
+            select(func.count())
+            .select_from(StatementExtractionResultRecord)
+            .where(
+                StatementExtractionResultRecord.statement_id == statement.id,
+                StatementExtractionResultRecord.content_digest == result.content_digest,
+            )
+        )
+        assert result_count == 1
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_3_conflict_preserves_outer_session(
+    db_engine,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.3: duplicate recovery does not poison commit."""
+    maker = async_sessionmaker(db_engine, expire_on_commit=False)
+    command = _identity(test_user.id, file_hash="recoverable-source-conflict")
+    async with maker() as winner_session:
+        winner, created = await resolve_source_identity(winner_session, command)
+        assert created is True
+        await winner_session.commit()
+
+    async with maker() as loser_session:
+        observed, created = await resolve_source_identity(loser_session, command)
+        assert created is False
+        assert observed.id == winner.id
+        summary = _summary(test_user.id, file_hash="outer-session-still-usable")
+        loser_session.add(summary)
+        await loser_session.commit()
+        assert summary.id is not None
+
+
+async def _history_fixture(db: AsyncSession, user_id: UUID) -> tuple[StatementSummary, UploadedDocument]:
+    account = Account(
+        user_id=user_id,
+        name="Source history account",
+        type=AccountType.ASSET,
+        currency="SGD",
+    )
+    document = _document(user_id, file_hash=f"history-{uuid4().hex}")
+    db.add_all([account, document])
+    await db.flush()
+    statement = _summary(user_id, file_hash=document.file_hash, uploaded_document_id=document.id)
+    db.add(statement)
+    await db.flush()
+    source_result = StatementExtractionResultRecord(
+        user_id=user_id,
+        statement_id=statement.id,
+        content_digest="1" * 64,
+        source_content_digest="2" * 64,
+        schema_version="2",
+        producer_version="acceptance",
+        payload={"kind": "source-result"},
+        source_trace_record_id=uuid4(),
+        created_at=datetime.now(UTC),
+    )
+    db.add(source_result)
+    await db.flush()
+    statement.current_extraction_result_id = source_result.id
+    db.add(
+        ReviewedStatementEnvelope(
+            user_id=user_id,
+            statement_id=statement.id,
+            source_result_id=source_result.id,
+            account_id=account.id,
+            currency="SGD",
+            period_start=statement.period_start,
+            period_end=statement.period_end,
+            opening_balance=Decimal("0.00"),
+            closing_balance=Decimal("0.00"),
+            rationale="Confirmed from source",
+            command_digest="3" * 64,
+            review_trace_record_id=uuid4(),
+            supersedes_id=None,
+            created_at=datetime.now(UTC),
+        )
+    )
+    db.add(
+        _atomic(
+            user_id,
+            document.id,
+            currency="SGD",
+            direction=TransactionDirection.IN,
+            amount="1.00",
+        )
+    )
+    await db.flush()
+    return statement, document
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_4_retire_preserves_history(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.4: removal preserves every source fact."""
+    statement, document = await _history_fixture(db, test_user.id)
+    before = {
+        model: await db.scalar(select(func.count()).select_from(model))
+        for model in (
+            StatementExtractionResultRecord,
+            ReviewedStatementEnvelope,
+            AtomicTransaction,
+            UploadedDocument,
+        )
+    }
+
+    retired = await retire_statement(
+        db,
+        RetireStatementCommand(statement_id=statement.id, user_id=test_user.id),
+    )
+    repeated = await retire_statement(
+        db,
+        RetireStatementCommand(statement_id=statement.id, user_id=test_user.id),
+    )
+    await db.commit()
+
+    assert retired.id == repeated.id == statement.id
+    assert retired.status is BankStatementStatus.RETIRED
+    await db.refresh(document)
+    assert document.status is DocumentStatus.RETIRED
+    after = {model: await db.scalar(select(func.count()).select_from(model)) for model in before}
+    assert after == before
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_5_retire_does_not_delete_storage(
+    db: AsyncSession,
+    test_user,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-extraction.source-lifecycle.5: storage outage cannot split retirement."""
+    statement, _ = await _history_fixture(db, test_user.id)
+    await db.commit()
+
+    class UnavailableStorage:
+        def __init__(self) -> None:
+            raise RuntimeError("object storage unavailable")
+
+    monkeypatch.setattr(statements_router, "StorageService", UnavailableStorage)
+    await statements_router.delete_statement(statement.id, db, test_user.id)
+
+    persisted = await db.get(StatementSummary, statement.id)
+    assert persisted is not None
+    assert persisted.status is BankStatementStatus.RETIRED
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_6_failure_and_retry_converge(
+    db: AsyncSession,
+    db_engine,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.6: rollback and retry keep one state."""
+    statement, _ = await _history_fixture(db, test_user.id)
+    await db.commit()
+    maker = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async with maker() as failed:
+        await retire_statement(
+            failed,
+            RetireStatementCommand(statement_id=statement.id, user_id=test_user.id),
+        )
+        await failed.flush()
+        await failed.rollback()
+
+    async with maker() as verification:
+        current = await verification.get(StatementSummary, statement.id)
+        assert current is not None
+        assert current.status is BankStatementStatus.PARSED
+
+    async with maker() as retry:
+        await retire_statement(
+            retry,
+            RetireStatementCommand(statement_id=statement.id, user_id=test_user.id),
+        )
+        await retry.commit()
+
+    async with maker() as repeated:
+        await retire_statement(
+            repeated,
+            RetireStatementCommand(statement_id=statement.id, user_id=test_user.id),
+        )
+        await repeated.commit()
+        count = await repeated.scalar(
+            select(func.count()).select_from(StatementSummary).where(StatementSummary.id == statement.id)
+        )
+        assert count == 1
+
+
+def test_AC_extraction_source_lifecycle_7_boundary_is_typed() -> None:
+    """AC-extraction.source-lifecycle.7: lifecycle inputs are typed values."""
+    identity_hints = get_type_hints(SourceIdentityCommand)
+    retire_hints = get_type_hints(RetireStatementCommand)
+    assert identity_hints["user_id"] is UUID
+    assert identity_hints["document_type"] is DocumentType
+    assert retire_hints["statement_id"] is UUID
+    assert retire_hints["user_id"] is UUID
+    signature = inspect.signature(dual_write_layer2)
+    assert "ExtractedTransactionRow" in str(signature.parameters["transactions"].annotation)
+    assert "dict" not in str(signature.parameters["transactions"].annotation)
+
+
+def test_AC_extraction_source_lifecycle_8_ordinary_api_has_no_purge_path() -> None:
+    """AC-extraction.source-lifecycle.8: DELETE is retirement, never purge."""
+    source = inspect.getsource(statements_router.delete_statement)
+    assert "retire_statement(" in source
+    assert "delete_object" not in source
+    assert "db.delete" not in source
+    assert "purge" not in source.casefold()
+
+
+@pytest.mark.asyncio
+async def test_AC_extraction_source_lifecycle_10_counterfactual_matrix_is_locked(
+    db: AsyncSession,
+    test_user,
+) -> None:
+    """AC-extraction.source-lifecycle.10: undeclared currency and retired reads fail closed."""
+    document = _document(test_user.id, file_hash="orphan-currency-counterfactual")
+    db.add(document)
+    await db.flush()
+    statement = _summary(test_user.id, file_hash=document.file_hash, uploaded_document_id=document.id)
+    statement.currency_balances = [{"currency": "SGD", "opening": "0.00", "closing": "0.00"}]
+    db.add(statement)
+    db.add(
+        _atomic(
+            test_user.id,
+            document.id,
+            currency="USD",
+            direction=TransactionDirection.IN,
+            amount="1.00",
+        )
+    )
+    await db.flush()
+    validation = await validate_balance_chain(db, statement.id)
+    orphan = next(row for row in validation["per_currency"] if row["currency"] == "USD")
+    assert orphan["declared_balance"] is False
+    with pytest.raises(ValueError, match="currency"):
+        _raise_if_balance_chain_invalid(validation)
+
+    await retire_statement(db, RetireStatementCommand(statement_id=statement.id, user_id=test_user.id))
+    await db.commit()
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.get_statement(statement.id, db, test_user.id)
+    assert exc.value.status_code == 404
+    with pytest.raises(HTTPException) as exc:
+        await get_review_conflicts(statement.id, db, test_user.id)
+    assert exc.value.status_code == 404
+    with pytest.raises(HTTPException) as exc:
+        await run_stage2_checks(statement.id, db, test_user.id)
+    assert exc.value.status_code == 404
+    with pytest.raises(HTTPException) as exc:
+        await run_reconciliation(
+            ReconciliationRunRequest(statement_id=statement.id),
+            db=db,
+            user_id=test_user.id,
+        )
+    assert exc.value.status_code == 404

--- a/apps/backend/tests/extraction/test_source_lifecycle.py
+++ b/apps/backend/tests/extraction/test_source_lifecycle.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from io import BytesIO
 from typing import get_type_hints
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.extraction import DocumentStatus, DocumentType, UploadedDocument
+from src.extraction import DocumentStatus, DocumentType, UploadedDocument, get_known_storage_paths
 from src.extraction.base.result import (
     ExtractedTransactionFact,
     ExtractionMethod,
@@ -46,6 +47,8 @@ from src.ledger import Account, AccountType
 from src.routers import statements as statements_router
 from src.routers.reconciliation import run_reconciliation
 from src.routers.review import get_review_conflicts, run_stage2_checks
+from src.runtime import StorageError, register_known_storage_paths_provider
+from src.runtime.extension import storage_sweep
 from src.schemas.reconciliation import ReconciliationRunRequest
 
 
@@ -147,6 +150,63 @@ async def test_AC_extraction_source_lifecycle_1_approval_is_per_currency(
     assert all(row["closing_match"] is False for row in result["per_currency"])
     with pytest.raises(ValueError, match="currency"):
         _raise_if_balance_chain_invalid(result)
+
+    legacy_document = _document(test_user.id, file_hash="legacy-scalar-multi-currency")
+    db.add(legacy_document)
+    await db.flush()
+    legacy_statement = _summary(
+        test_user.id,
+        file_hash=legacy_document.file_hash,
+        uploaded_document_id=legacy_document.id,
+    )
+    db.add(legacy_statement)
+    db.add_all(
+        [
+            _atomic(
+                test_user.id,
+                legacy_document.id,
+                currency="SGD",
+                direction=TransactionDirection.IN,
+                amount="10.00",
+            ),
+            _atomic(
+                test_user.id,
+                legacy_document.id,
+                currency="USD",
+                direction=TransactionDirection.OUT,
+                amount="10.00",
+            ),
+        ]
+    )
+    await db.flush()
+
+    legacy_result = await validate_balance_chain(db, legacy_statement.id)
+
+    assert legacy_result["balance_valid"] is False
+    assert {row["currency"] for row in legacy_result["per_currency"]} == {"SGD", "USD"}
+    assert all(row["declared_balance"] is False for row in legacy_result["per_currency"])
+    with pytest.raises(ValueError, match="currency"):
+        _raise_if_balance_chain_invalid(legacy_result)
+
+    mismatched_document = _document(test_user.id, file_hash="mismatched-primary-currency")
+    db.add(mismatched_document)
+    await db.flush()
+    mismatched_statement = _summary(
+        test_user.id,
+        file_hash=mismatched_document.file_hash,
+        uploaded_document_id=mismatched_document.id,
+    )
+    mismatched_statement.currency_balances = [{"currency": "USD", "opening": "0.00", "closing": "0.00"}]
+    db.add(mismatched_statement)
+    await db.flush()
+
+    mismatched_result = await validate_balance_chain(db, mismatched_statement.id)
+
+    assert mismatched_result["balance_valid"] is False
+    primary_finding = next(row for row in mismatched_result["per_currency"] if row["currency"] == "SGD")
+    assert primary_finding["declared_balance"] is False
+    with pytest.raises(ValueError, match="currency"):
+        _raise_if_balance_chain_invalid(mismatched_result)
 
 
 def _identity(user_id: UUID, *, file_hash: str) -> SourceIdentityCommand:
@@ -422,6 +482,7 @@ async def test_AC_extraction_source_lifecycle_6_failure_and_retry_converge(
     db: AsyncSession,
     db_engine,
     test_user,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AC-extraction.source-lifecycle.6: rollback and retry keep one state."""
     statement, _ = await _history_fixture(db, test_user.id)
@@ -458,6 +519,72 @@ async def test_AC_extraction_source_lifecycle_6_failure_and_retry_converge(
             select(func.count()).select_from(StatementSummary).where(StatementSummary.id == statement.id)
         )
         assert count == 1
+
+    class FailingThenRecoveringStorage:
+        def __init__(self) -> None:
+            self.keys: set[str] = set()
+            self.delete_attempts = 0
+
+        def upload_bytes(self, *, key: str, **_kwargs) -> None:
+            self.keys.add(key)
+
+        def delete_object(self, key: str) -> None:
+            self.delete_attempts += 1
+            if self.delete_attempts == 1:
+                raise StorageError("immediate cleanup unavailable")
+            self.keys.remove(key)
+
+    storage = FailingThenRecoveringStorage()
+    monkeypatch.setattr(statements_router, "StorageService", lambda: storage)
+    original_commit = db.commit
+
+    async def fail_commit() -> None:
+        raise RuntimeError("database commit unavailable")
+
+    monkeypatch.setattr(db, "commit", fail_commit)
+    upload = UploadFile(filename="failure-convergence.pdf", file=BytesIO(b"source bytes"))
+    with pytest.raises(HTTPException) as exc:
+        await statements_router.upload_statement(
+            file=upload,
+            institution="Example Bank",
+            model=None,
+            db=db,
+            user_id=test_user.id,
+        )
+    await upload.close()
+    assert exc.value.status_code == 500
+    assert storage.delete_attempts == 1
+    assert len(storage.keys) == 1
+    orphan_key = next(iter(storage.keys))
+    monkeypatch.setattr(db, "commit", original_commit)
+    assert (
+        await db.scalar(
+            select(func.count()).select_from(UploadedDocument).where(UploadedDocument.file_path == orphan_key)
+        )
+        == 0
+    )
+
+    class SessionContext:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *_args):
+            return False
+
+    register_known_storage_paths_provider(get_known_storage_paths)
+    monkeypatch.setattr(storage_sweep, "StorageService", lambda: storage)
+    monkeypatch.setattr(
+        storage_sweep,
+        "_list_storage_keys",
+        lambda _storage: [(orphan_key, datetime.now(UTC) - timedelta(hours=2))],
+    )
+    monkeypatch.setattr(storage_sweep.settings, "s3_bucket", "acceptance")
+    monkeypatch.setattr(storage_sweep.settings, "storage_sweep_grace_period_hours", 1)
+
+    deleted = await storage_sweep.sweep_orphaned_storage_objects(sessionmaker=lambda: SessionContext())
+
+    assert deleted == 1
+    assert storage.keys == set()
 
 
 def test_AC_extraction_source_lifecycle_7_boundary_is_typed() -> None:

--- a/apps/backend/tests/extraction/test_source_lifecycle_governance.py
+++ b/apps/backend/tests/extraction/test_source_lifecycle_governance.py
@@ -1,0 +1,92 @@
+"""Control-plane projection proof for extraction issue #1970."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from common.extraction.contract import CONTRACT
+from common.meta.base.governance_control import (
+    DetectorObservation,
+    EnforcementObservation,
+    IssueObservation,
+    ProofObservation,
+)
+from common.meta.data.governance_control import governance_control_index
+from common.meta.extension.governance_control_report import render_governance_markdown
+
+
+def test_AC_extraction_source_lifecycle_9_governance_detail_is_exact() -> None:
+    """AC-extraction.source-lifecycle.9: joined proof is exact and enforced."""
+    target_sha = "2" * 40
+    observed_at = datetime(2026, 7, 20, tzinfo=UTC)
+    initiative = next(item for item in CONTRACT.governance if item.id == "source-lifecycle-convergence")
+    affected_ids = {ac_id for guarantee in initiative.guarantees for ac_id in guarantee.affected_acs}
+    completed_contract = CONTRACT.model_copy(
+        update={
+            "roadmap": [
+                ac.model_copy(update={"status": "done"}) if ac.id in affected_ids else ac for ac in CONTRACT.roadmap
+            ]
+        }
+    )
+    detectors = [
+        DetectorObservation(
+            guarantee_id=f"extraction/{guarantee.id}",
+            current=0,
+            target=0,
+            findings=[],
+        )
+        for guarantee in initiative.guarantees
+    ]
+    proofs = [
+        ProofObservation(
+            guarantee_id=f"extraction/{guarantee.id}",
+            proof_id=guarantee.proof,
+            result="passed",
+            strength=guarantee.required_proof_strength,
+            target_sha=target_sha,
+            occurred_at=observed_at,
+            evidence_url="https://github.com/wangzitian0/finance_report/actions/runs/1970",
+            gate_id=guarantee.enforcing_gate,
+        )
+        for guarantee in initiative.guarantees
+    ]
+    enforcement = [
+        EnforcementObservation(
+            gate_id=gate_id,
+            declared_blocking=True,
+            workflow_required=True,
+            live_required=True,
+            required_context="finish",
+            observed_at=observed_at,
+        )
+        for gate_id in sorted({item.enforcing_gate for item in initiative.guarantees})
+    ]
+    report = governance_control_index(
+        [completed_contract],
+        target_sha=target_sha,
+        detector_observations=detectors,
+        proof_observations=proofs,
+        enforcement_observations=enforcement,
+        issue_observations=[
+            IssueObservation(
+                issue=initiative.issue,
+                state="OPEN",
+                observed_at=observed_at,
+            )
+        ],
+        observed_at=observed_at,
+    )
+
+    row = report["initiatives"]["extraction/source-lifecycle-convergence"]
+    assert row["state"] == "enforced"
+    assert row["open_guarantees"] == 0
+    assert row["blocked_guarantees"] == 0
+    for guarantee in initiative.guarantees:
+        detail = report["guarantees"][f"extraction/{guarantee.id}"]
+        assert detail["state"] == "enforced"
+        assert detail["proof"]["target_sha"] == target_sha
+        assert detail["proof"]["strength"] == guarantee.required_proof_strength
+        assert detail["enforcement"]["live_required"] is True
+    markdown = render_governance_markdown(report)
+    assert "Source-fact lifecycle and failure convergence" in markdown
+    assert "per-currency-approval" in markdown

--- a/apps/backend/tests/extraction/test_source_lifecycle_migration.py
+++ b/apps/backend/tests/extraction/test_source_lifecycle_migration.py
@@ -1,0 +1,29 @@
+"""Migration contract for #1970's retired source lifecycle state."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_AC_extraction_source_lifecycle_4_migration_is_additive() -> None:
+    """AC-extraction.source-lifecycle.4: retirement adds states without data deletion."""
+    path = Path(__file__).resolve().parents[2] / "migrations/versions/0059_source_lifecycle.py"
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    assignments = {
+        node.targets[0].id: ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id in {"revision", "down_revision"}
+    }
+    assert assignments == {
+        "revision": "0059_source_lifecycle",
+        "down_revision": "0058_economic_disposition",
+    }
+    assert "ALTER TYPE statement_summary_status_enum ADD VALUE IF NOT EXISTS 'retired'" in source
+    assert "ALTER TYPE document_status_enum ADD VALUE IF NOT EXISTS 'retired'" in source
+    assert "DELETE FROM" not in source
+    assert "DROP TABLE" not in source

--- a/apps/backend/tests/extraction/test_statements_supervisor_errors.py
+++ b/apps/backend/tests/extraction/test_statements_supervisor_errors.py
@@ -191,15 +191,16 @@ async def test_statement_router_error_cases(db, test_user, monkeypatch):
         session_maker=session_maker,
     )
 
-    # Delete statement storage error (should continue to DB delete)
+    # Ordinary removal retires without touching storage.
     # Already created sid in DB above
     with patch("src.routers.statements.StorageService") as mock_storage_cls:
         mock_storage = mock_storage_cls.return_value
         mock_storage.delete_object.side_effect = StorageError("Failed")
         await delete_statement(sid, db, uid)
-        # Verify it was deleted from DB
+        mock_storage.delete_object.assert_not_called()
         result = await db.get(StatementSummary, sid)
-        assert result is None
+        assert result is not None
+        assert result.status is BankStatementStatus.RETIRED
 
 
 async def test_upload_statement_db_commit_failure(db, test_user, monkeypatch):

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -1772,7 +1772,8 @@
           "parsing",
           "parsed",
           "approved",
-          "rejected"
+          "rejected",
+          "retired"
         ],
         "title": "BankStatementStatus",
         "type": "string"
@@ -24567,7 +24568,7 @@
     },
     "/statements/{statement_id}": {
       "delete": {
-        "description": "Delete a statement.",
+        "description": "Retire a statement from product views while retaining source history.",
         "operationId": "delete_statement_statements__statement_id__delete",
         "parameters": [
           {

--- a/apps/frontend/src/lib/api-types.ts
+++ b/apps/frontend/src/lib/api-types.ts
@@ -1966,7 +1966,7 @@ export interface paths {
         post?: never;
         /**
          * Delete Statement
-         * @description Delete a statement.
+         * @description Retire a statement from product views while retaining source history.
          */
         delete: operations["delete_statement_statements__statement_id__delete"];
         options?: never;
@@ -3146,7 +3146,7 @@ export interface components {
          * @description Statement processing status.
          * @enum {string}
          */
-        BankStatementStatus: "uploaded" | "parsing" | "parsed" | "approved" | "rejected";
+        BankStatementStatus: "uploaded" | "parsing" | "parsed" | "approved" | "rejected" | "retired";
         /**
          * BankTransactionSummary
          * @description Summary of a transaction for reconciliation.

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -105,7 +105,7 @@ export interface BankStatement {
   period_end?: string | null;
   opening_balance?: MoneyValue | null;
   closing_balance?: MoneyValue | null;
-  status: "uploaded" | "parsing" | "parsed" | "approved" | "rejected";
+  status: Schemas["BankStatementStatus"];
   confidence_score?: number | null;
   balance_validated?: boolean | null;
   validation_error?: string | null;

--- a/common/extraction/contract.py
+++ b/common/extraction/contract.py
@@ -60,6 +60,8 @@ from common.meta.package_contract import (
     ACRecord,
     CommandBoundary,
     ConceptRecord,
+    GovernanceGuarantee,
+    GovernanceInitiative,
     Invariant,
     Kind,
     PackageContract,
@@ -177,6 +179,16 @@ CONTRACT = PackageContract(
             module="base/types.py",
         ),
         Unit(name="ParseJob", kind=Kind.VALUE_OBJECT, module="base/types.py"),
+        Unit(
+            name="RetireStatementCommand",
+            kind=Kind.VALUE_OBJECT,
+            module="base/types.py",
+        ),
+        Unit(
+            name="retire_statement",
+            kind=Kind.DOMAIN_SERVICE,
+            module="extension/source_lifecycle.py",
+        ),
         Unit(
             name="StatementExtractionResult",
             kind=Kind.VALUE_OBJECT,
@@ -310,6 +322,7 @@ CONTRACT = PackageContract(
         "PositionStatus",
         "ParseJob",
         "RetryableStatementIngestionError",
+        "RetireStatementCommand",
         "ReviewedStatementEnvelopeCommand",
         "ReviewedStatementEnvelopeConflict",
         "RuleType",
@@ -389,6 +402,7 @@ CONTRACT = PackageContract(
         "register_statement_source",
         "reject_json_floats",
         "reject_statement_workflow",
+        "retire_statement",
         "resolve_custody_account_id",
         "resolve_ingest_currency",
         "resolve_statement_conflicts",
@@ -1689,7 +1703,10 @@ CONTRACT = PackageContract(
         ),
         ACRecord(
             id="AC-extraction.111.1",
-            statement="Dual-write handles duplicate document hash / IntegrityError without failing.",  # was AC13.11.1
+            statement=(
+                "Dual-write handles a duplicate document identity by selecting and continuing with "
+                "the canonical database winner without failing or duplicating the source row."
+            ),  # was AC13.11.1
             test="apps/backend/tests/extraction/test_extraction_error_paths.py::test_dual_write_layer2_integrity_error_is_non_fatal",
             priority="P1",
             status="done",
@@ -4685,6 +4702,268 @@ CONTRACT = PackageContract(
             status="done",
             proof_kind="property",
         ),
+        # #1970: one extraction-owned source lifecycle, reusing the existing
+        # ingestion/result/envelope aggregates rather than adding a platform.
+        ACRecord(
+            id="AC-extraction.source-lifecycle.1",
+            statement=(
+                "Stage-1 approval validates every declared currency independently and "
+                "never permits opposite differences in distinct currencies to cancel."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_1_approval_is_per_currency"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.2",
+            statement=(
+                "Concurrent ingestion of one user-owned content digest converges on one "
+                "canonical UploadedDocument and immutable extraction-result identity."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_2_two_sessions_share_source_identity"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.3",
+            statement=(
+                "A source-identity uniqueness conflict is isolated by a savepoint; the outer "
+                "session selects the winner and remains usable for deterministic commit."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_3_conflict_preserves_outer_session"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.4",
+            statement=(
+                "Ordinary statement removal is an idempotent retire transition that preserves "
+                "source results, reviewed envelopes, transactions, and lineage."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_4_retire_preserves_history"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.5",
+            statement=(
+                "Retirement changes durable reference state without deleting object content, so "
+                "object-storage failure cannot split source truth from database truth."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_5_retire_does_not_delete_storage"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.6",
+            statement=(
+                "Rollback, commit failure, restart, and repeated lifecycle commands converge on "
+                "the same canonical source state without duplicate financial facts."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_6_failure_and_retry_converge"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.7",
+            statement=(
+                "The audited lifecycle boundary accepts typed UUID, currency, Decimal, date, and "
+                "immutable transaction/result values rather than list-of-dict financial payloads."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_7_boundary_is_typed"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.8",
+            statement=(
+                "Physical purge is absent from ordinary statement lifecycle commands and remains "
+                "a separately governed cross-package operation."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_8_ordinary_api_has_no_purge_path"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.9",
+            statement=(
+                "Governance detail derives detector, proof-strength, exact target SHA, issue, "
+                "progress, and live enforcement state for every source-lifecycle guarantee."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle_governance.py"
+                "::test_AC_extraction_source_lifecycle_9_governance_detail_is_exact"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+        ACRecord(
+            id="AC-extraction.source-lifecycle.10",
+            statement=(
+                "Counterfactual tests exercise cross-currency cancellation, independent-session "
+                "conflict, failed commit, storage outage, retry, and retained history."
+            ),
+            test=(
+                "apps/backend/tests/extraction/test_source_lifecycle.py"
+                "::test_AC_extraction_source_lifecycle_10_counterfactual_matrix_is_locked"
+            ),
+            priority="P0",
+            status="done",
+            proof_kind="property",
+        ),
+    ],
+    governance=[
+        GovernanceInitiative(
+            id="source-lifecycle-convergence",
+            title="Source-fact lifecycle and failure convergence",
+            issue="https://github.com/wangzitian0/finance_report/issues/1970",
+            depends_on=["meta/governance-control-plane"],
+            guarantees=[
+                GovernanceGuarantee(
+                    id="per-currency-approval",
+                    statement="Approval proves each declared currency without scalar cancellation.",
+                    affected_acs=["AC-extraction.source-lifecycle.1"],
+                    detector="cross-currency-stage1-validation-paths",
+                    target="0 cross-currency scalar approval paths",
+                    lock="ci.backend",
+                    proof="source-lifecycle-per-currency-oracle",
+                    required_proof_strength="value-oracle",
+                    enforcing_gate="ci.backend",
+                ),
+                GovernanceGuarantee(
+                    id="one-source-identity",
+                    statement="Concurrent ingestion converges on one canonical source identity.",
+                    affected_acs=["AC-extraction.source-lifecycle.2"],
+                    detector="duplicate-canonical-source-identities",
+                    target="0 duplicate source identities",
+                    lock="ci.backend_integration",
+                    proof="source-lifecycle-two-session-identity",
+                    required_proof_strength="concurrency",
+                    enforcing_gate="ci.backend_integration",
+                ),
+                GovernanceGuarantee(
+                    id="session-recovery",
+                    statement="Dedup conflicts preserve the outer database session.",
+                    affected_acs=["AC-extraction.source-lifecycle.3"],
+                    detector="unprotected-source-dedup-conflicts",
+                    target="0 unprotected conflict sites",
+                    lock="ci.backend_integration",
+                    proof="source-lifecycle-savepoint-recovery",
+                    required_proof_strength="concurrency",
+                    enforcing_gate="ci.backend_integration",
+                ),
+                GovernanceGuarantee(
+                    id="append-only-retirement",
+                    statement="Ordinary removal retires and preserves source history.",
+                    affected_acs=["AC-extraction.source-lifecycle.4"],
+                    detector="destructive-statement-lifecycle-paths",
+                    target="0 destructive ordinary lifecycle paths",
+                    lock="ci.backend_integration",
+                    proof="source-lifecycle-history-preservation",
+                    required_proof_strength="schema",
+                    enforcing_gate="ci.backend_integration",
+                ),
+                GovernanceGuarantee(
+                    id="storage-db-consistency",
+                    statement="Retirement cannot split object state from database source truth.",
+                    affected_acs=["AC-extraction.source-lifecycle.5"],
+                    detector="storage-database-split-lifecycle-paths",
+                    target="0 split lifecycle paths",
+                    lock="ci.backend",
+                    proof="source-lifecycle-storage-failure",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.backend",
+                ),
+                GovernanceGuarantee(
+                    id="failure-convergence",
+                    statement="Failure and retry preserve canonical lifecycle cardinality.",
+                    affected_acs=["AC-extraction.source-lifecycle.6"],
+                    detector="non-idempotent-source-lifecycle-retries",
+                    target="0 retry cardinality drift",
+                    lock="ci.backend_integration",
+                    proof="source-lifecycle-failure-retry",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.backend_integration",
+                ),
+                GovernanceGuarantee(
+                    id="typed-command-boundary",
+                    statement="Financial lifecycle inputs cross typed extraction boundaries.",
+                    affected_acs=["AC-extraction.source-lifecycle.7"],
+                    detector="untyped-source-lifecycle-boundaries",
+                    target="0 untyped audited boundaries",
+                    lock="ci.lint",
+                    proof="source-lifecycle-signature-contract",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.lint",
+                ),
+                GovernanceGuarantee(
+                    id="purge-boundary",
+                    statement="Ordinary extraction commands cannot physically purge source facts.",
+                    affected_acs=["AC-extraction.source-lifecycle.8"],
+                    detector="ordinary-api-physical-purge-paths",
+                    target="0 ordinary purge paths",
+                    lock="ci.lint",
+                    proof="source-lifecycle-purge-boundary",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.lint",
+                ),
+                GovernanceGuarantee(
+                    id="exact-governance-detail",
+                    statement="Control-plane detail exposes exact current proof and enforcement facts.",
+                    affected_acs=["AC-extraction.source-lifecycle.9"],
+                    detector="source-lifecycle-governance-join-gaps",
+                    target="0 missing detail facts",
+                    lock="ci.lint",
+                    proof="source-lifecycle-governance-detail",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.lint",
+                ),
+                GovernanceGuarantee(
+                    id="counterfactual-lock",
+                    statement="The adversarial lifecycle matrix remains executable and blocking.",
+                    affected_acs=["AC-extraction.source-lifecycle.10"],
+                    detector="missing-source-lifecycle-counterfactuals",
+                    target="0 missing counterfactuals",
+                    lock="ci.backend_integration",
+                    proof="source-lifecycle-counterfactual-matrix",
+                    required_proof_strength="exact",
+                    enforcing_gate="ci.backend_integration",
+                ),
+            ],
+        )
     ],
     concepts=[
         ConceptRecord(

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -43,6 +43,30 @@ exceptions raise typed ingestion errors so durable execution can retry without
 misrepresenting infrastructure failure as bad user data. Retrying finalization
 is idempotent by statement and atomic-transaction identity.
 
+### Source lifecycle convergence
+
+`StatementSummary` and its `UploadedDocument` share one extraction-owned source
+lifecycle. Canonical identity is `(user_id, file_hash)`: insertion is isolated
+under a database savepoint, and a concurrent loser selects and continues with
+the unique database winner without poisoning the outer ingestion transaction.
+The uniqueness constraint, not an application pre-read, is the final lock.
+
+Stage-1 approval consumes `StatementSummary.currency_balances` through the typed
+`CurrencyBalances` container. Each declared currency independently proves
+`opening + IN - OUT = closing`; an undeclared transaction currency blocks
+approval. The scalar balance response remains only the backward-compatible
+projection for a single-currency statement and never governs a multi-currency
+approval.
+
+Ordinary `DELETE /statements/{id}` means **retire**, not physical purge. It
+atomically marks the statement and source reference retired, removes the item
+from normal product reads, and preserves the stored object, immutable extraction
+results, reviewed envelopes, atomic facts, and lineage. Repeating retirement is
+idempotent. Because retirement does not delete object content, an object-store
+outage cannot split database source truth from storage state. Physical
+purge/anonymization is a separately named cross-package operation governed by
+#1898/#1848 and is not callable through ordinary statement APIs.
+
 ## Extraction Result And Economic Disposition
 
 Every transport receives the same `StatementExtractionResult`; it is the

--- a/common/extraction/readme.md
+++ b/common/extraction/readme.md
@@ -55,8 +55,10 @@ Stage-1 approval consumes `StatementSummary.currency_balances` through the typed
 `CurrencyBalances` container. Each declared currency independently proves
 `opening + IN - OUT = closing`; an undeclared transaction currency blocks
 approval. The scalar balance response remains only the backward-compatible
-projection for a single-currency statement and never governs a multi-currency
-approval.
+projection when every transaction belongs to the statement's one explicitly
+declared currency. Missing or multiple transaction currency domains fail closed
+with per-currency findings and never govern approval through a nominal scalar
+sum.
 
 Ordinary `DELETE /statements/{id}` means **retire**, not physical purge. It
 atomically marks the statement and source reference retired, removes the item
@@ -66,6 +68,11 @@ idempotent. Because retirement does not delete object content, an object-store
 outage cannot split database source truth from storage state. Physical
 purge/anonymization is a separately named cross-package operation governed by
 #1898/#1848 and is not callable through ordinary statement APIs.
+If upload persists object bytes but database persistence and immediate cleanup
+both fail, the existing default-enabled runtime orphan sweep reconciles the
+unreferenced object after its grace period; extraction remains the owner of the
+canonical storage-reference query rather than duplicating a second cleanup
+mechanism.
 
 ## Extraction Result And Economic Disposition
 

--- a/common/meta/data/l4-root-import-baseline.json
+++ b/common/meta/data/l4-root-import-baseline.json
@@ -15,7 +15,6 @@
   "routers/review.py::from src.extraction.orm.layer2 import AtomicTransaction",
   "routers/review.py::from src.extraction.orm.statement_summary import StatementSummary",
   "routers/review.py::from src.reconciliation.orm.consistency_check import CheckStatus, CheckType",
-  "routers/statements.py::from src.extraction.orm.statement_enums import BankStatementStatus",
   "routers/statements.py::from src.extraction.orm.statement_summary import StatementSummary",
   "schemas/app_config.py::from src.audit.money import Currency, InvalidCurrencyError",
   "schemas/base.py::from src.audit.money.currency import normalize_currency_code",

--- a/common/meta/data/migration-risk.yaml
+++ b/common/meta/data/migration-risk.yaml
@@ -154,3 +154,11 @@ migrations:
     staging_validation: Deploy the pinned PR commit, run matching twice over one transfer-shaped statement with an eligible journal candidate and one true two-leg transfer, and verify one active head per source transaction, no extra Processing entry, one persisted pair with two unique memberships, and unchanged cardinality on retry.
     production_preflight: Before upgrade, count active reconciliation heads grouped by atomic_txn_id and retain the result as release evidence; verify every duplicate group has a deterministic newest row by created_at/id, take a database backup, and ensure no long-running reconciliation worker transaction is open while the repair and index build run.
     rollback_strategy: The upgrade is transactional. Before application cutover, downgrade removes only additive pair/kind schema and the unique index; repaired rows remain valid superseded history. Restore the pre-upgrade backup only if exact recreation of the previously invalid duplicate-active state is operationally required.
+  0059_source_lifecycle:
+    file: 0059_source_lifecycle.py
+    risk: medium
+    issue: "#1970"
+    proof: Adds only the retired value to extraction-owned statement and document lifecycle enums; AC-extraction.source-lifecycle.4-.6 prove retained source/result/envelope/transaction cardinality, idempotent retirement, rollback, and retry.
+    staging_validation: Deploy the pinned PR commit, retire one non-production statement through DELETE, verify it disappears from list/get while its statement summary, uploaded document, immutable extraction result, reviewed envelope, atomic facts, lineage, and object remain stored, then repeat DELETE and confirm no cardinality change.
+    production_preflight: Confirm no deployed consumer exhaustively rejects unknown statement_summary_status_enum or document_status_enum values, take a database backup, and verify the application commit that excludes retired rows from product views is deployed with this additive enum migration.
+    rollback_strategy: Roll back the application while leaving the additive enum values in place; PostgreSQL enum value removal requires a destructive type rebuild and is intentionally not attempted. Any already-retired rows remain preserved and can be restored to a prior visible state only through an explicit governed correction.

--- a/common/meta/extension/dependency_report.py
+++ b/common/meta/extension/dependency_report.py
@@ -1878,12 +1878,57 @@ def _top_level_class_members(surface: str) -> list[str] | None:
     return members
 
 
+_ENUM_FINGERPRINT = re.compile(r"class\(([^{}]*\bEnum\b[^{}]*)\)\{([^{}]*)\}")
+
+
+def _members_are_additive(before: str, after: str) -> bool:
+    """Return whether ``after`` only inserts assigned enum members."""
+
+    before_members = [member.strip() for member in before.split(";") if member.strip()]
+    after_members = [member.strip() for member in after.split(";") if member.strip()]
+    cursor = 0
+    for member in after_members:
+        if cursor < len(before_members) and member == before_members[cursor]:
+            cursor += 1
+        elif "=" not in member:
+            return False
+    return cursor == len(before_members)
+
+
+def _is_additive_nested_enum_expansion(before: str, after: str) -> bool:
+    """Ignore additive enum detail propagated into an unchanged declaration."""
+
+    before_enums = list(_ENUM_FINGERPRINT.finditer(before))
+    after_enums = list(_ENUM_FINGERPRINT.finditer(after))
+    if (
+        not before_enums
+        or len(before_enums) != len(after_enums)
+        or before_enums[0].start() == 0
+        or after_enums[0].start() == 0
+    ):
+        return False
+
+    normalized = after
+    replacements: list[tuple[int, int, str]] = []
+    for before_enum, after_enum in zip(before_enums, after_enums, strict=True):
+        if before_enum.group(1) != after_enum.group(1) or not _members_are_additive(
+            before_enum.group(2), after_enum.group(2)
+        ):
+            return False
+        replacements.append(
+            (after_enum.start(), after_enum.end(), before_enum.group(0))
+        )
+    for start, end, replacement in reversed(replacements):
+        normalized = normalized[:start] + replacement + normalized[end:]
+    return normalized == before
+
+
 def _is_compatible_public_change(record: dict[str, object]) -> bool:
     """Accept unchanged declarations and additive defaulted class fields."""
 
     before = _declared_public_surface(record, "before")
     after = _declared_public_surface(record, "after")
-    if before == after:
+    if before == after or _is_additive_nested_enum_expansion(before, after):
         return True
     before_members = _top_level_class_members(before)
     after_members = _top_level_class_members(after)

--- a/docs/reference/router-contract-maturity.md
+++ b/docs/reference/router-contract-maturity.md
@@ -15,5 +15,5 @@ The `Route` column is **router-relative** — it excludes the `APIRouter(prefix=
 | `DELETE` | `/{entry_id}` | `delete_journal_entry` | apps/backend/src/routers/journal.py:190 |
 | `GET` | `/package/snapshots/{snapshot_id}/export` | `export_personal_report_package_snapshot` | apps/backend/src/routers/reports.py:293 |
 | `GET` | `/export` | `export_report` | apps/backend/src/routers/reports.py:581 |
-| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:552 |
-| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:700 |
+| `GET` | `/{statement_id}/document` | `get_statement_document` | apps/backend/src/routers/statements.py:573 |
+| `DELETE` | `/{statement_id}` | `delete_statement` | apps/backend/src/routers/statements.py:721 |

--- a/tests/tooling/test_public_boundary_control.py
+++ b/tests/tooling/test_public_boundary_control.py
@@ -227,6 +227,44 @@ def test_AC_meta_public_boundary_4_defaulted_field_and_annotation_propagation_ar
     assert result["breaking_changes"] == []
 
 
+def test_AC_meta_public_boundary_4_nested_enum_addition_is_not_a_dto_break() -> None:
+    """AC-meta.public-boundary.4: recursive enum growth is not a DTO declaration change."""
+    before_enum = "class(str, Enum){ACTIVE='active'; FAILED='failed'}"
+    after_enum = "class(str, Enum){ACTIVE='active'; FAILED='failed'; RETIRED='retired'}"
+    changed_dto = {
+        "package": "extraction",
+        "symbol": "Source",
+        "before": (
+            "pkg.py::Source => class(Base){status: Mapped[Status]="
+            f"mapped_column(Status.ACTIVE) [Status={before_enum}]}}"
+        ),
+        "after": (
+            "pkg.py::Source => class(Base){status: Mapped[Status]="
+            f"mapped_column(Status.ACTIVE) [Status={after_enum}]}}"
+        ),
+    }
+    changed_public_enum = {
+        "package": "extraction",
+        "symbol": "Status",
+        "before": f"pkg.py::Status => {before_enum}",
+        "after": f"pkg.py::Status => {after_enum}",
+    }
+    changed_enum_value = {
+        **changed_dto,
+        "after": changed_dto["after"].replace("FAILED='failed'", "FAILED='error'"),
+    }
+    removed_enum_member = {
+        **changed_public_enum,
+        "before": changed_public_enum["after"],
+        "after": changed_public_enum["before"],
+    }
+
+    assert dependency_report._is_compatible_public_change(changed_dto)
+    assert dependency_report._is_compatible_public_change(changed_public_enum)
+    assert not dependency_report._is_compatible_public_change(changed_enum_value)
+    assert not dependency_report._is_compatible_public_change(removed_enum_member)
+
+
 def test_AC_meta_public_boundary_5_existing_gate_enforces_and_projects(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #1970

## Dependency

Dependency #1974 merged as `6da3f253`. This branch is rebased directly onto current `main` at `6f7a5209`; migration `0059_source_lifecycle` follows the merged reconciliation migration `0058_economic_disposition`. The generated router index was regenerated from the merged routes rather than conflict-picked.

## Root cause

Extraction already owned the correct primitives (`StatementIngestionUseCase`, typed `CurrencyBalances`, immutable extraction results, reviewed envelopes, and database uniqueness), but four production seams bypassed them: Stage-1 recomputed a cross-currency scalar; source/result dedup used pre-read/insert and broad `IntegrityError` swallowing; ordinary DELETE physically removed database and object state; and retired sources remained reachable from review/reconciliation routes. This PR connects those existing owners instead of creating a second lifecycle platform or cross-package governance root.

## Why existing gates missed it

Existing parse-time per-currency tests did not exercise Stage-1 approval. The duplicate test used one mocked session and treated an `IntegrityError` as an acceptable early return, so it could not detect a poisoned outer transaction. DELETE tests explicitly asserted physical deletion, and no counterfactual followed a retired statement into Stage-2/reconciliation. The added independent-session, value-oracle, history-cardinality, retry, storage-outage, and consumer-blocking tests backfill those missing proof tiers.

## Acceptance contracts

`AC-extraction.source-lifecycle.1..10` prove per-currency approval, one source/result identity, savepoint recovery, append-only retirement, storage/database consistency, failure/retry convergence, typed command boundaries, purge isolation, exact #1893 governance detail, and the adversarial counterfactual matrix. One extraction initiative reuses `ci.backend`, `ci.backend_integration`, and `ci.lint`; no report-only gate was added. The app-boundary baseline shrinks by one retired deep-import exception.

## Automated proof

- Extraction package: `670 passed`.
- Statement/review/reconciliation route regression: `171 passed`.
- Scoped lifecycle and affected-route proof: `273 passed`; changed modules total `88%` coverage, including source lifecycle `90%`, Stage-1 validation `94%`, and affected routes `91%-96%`.
- Canonical result/review regression: `14 passed`, including two-session source-result convergence.
- AC index, package/EPIC dual, proof-kind, traceability, extraction package contract, router contract, OpenAPI generation, and migration-risk contract: passed.
- Final rebase proof at `2d1ef129`: extraction commits were replayed onto `main` `6f7a5209`; the only generated deltas removed by `range-diff` were already present on `main`, and the remaining frontend consumer now derives `BankStatementStatus` from the generated schema.
- `apps/backend/.venv/bin/python tools/preflight.py --tier=static`: 17/17 relevant gates passed at `2d1ef129`.
- Post-merge focused proof: `219 passed`, covering all 10 lifecycle ACs, governance detail, migration contract, statements routes, dual-write behavior, extraction error paths, and supervisor errors. API type generation parity and frontend typecheck passed. Scoped coverage still triggers the known local `coverage + asyncpg SSL` crash; prior lineage measured source lifecycle at `90%` and affected changed modules at `88%`, and exact-head CI remains authoritative.
- `moon run :lint`: passed at `2d1ef129`.
- `moon run :test`: invoked at `2d1ef129`; the stale local Podman socket `127.0.0.1:61270` refused before test startup. The prior exact-patch CI run `29811581254` passed all suites; the new rebased-head CI is required before merge readiness.

## Risk and rollback

Migration risk is medium and additive: it adds `retired` to the extraction-owned statement/document PostgreSQL enums and performs no row rewrite or deletion. Before deployment, verify deployed consumers tolerate the additive enum and deploy the filtering application with the migration. PostgreSQL enum-value removal requires a destructive type rebuild, so rollback reverts application behavior while leaving unused enum values in place; already-retired history remains preserved and requires an explicit governed correction to become visible again.

## Counterfactual

Calling the existing parse-time per-currency helper does not protect human approval. Catching uniqueness errors outside a savepoint still poisons the session. Renaming physical DELETE still loses history or creates storage/database split state. Hiding retired rows only in the statement router still permits downstream financial actions. The tests therefore exercise cross-currency false cancellation and undeclared currency, independent workers for both source and immutable result identities, outer-session commit after conflict, failed retirement rollback and retry, unavailable storage, retained source/result/envelope/transaction cardinality, and 404 enforcement across GET, Stage-1 conflicts, Stage-2 checks, and reconciliation.

Physical user-wide purge/anonymization remains #1898/#1848 and is intentionally absent from ordinary extraction APIs.

## Final exact-head verification

Rebased onto `main` `55f4449b` after #1981/#1982 and force-with-lease pushed as `75a2cde8647ae5cd56c4050353919864c53722e9`. Exact-head CI run [30245921760](https://github.com/wangzitian0/finance_report/actions/runs/30245921760) passed: lint/DDD compatibility, AC traceability and behavioral ratchet, schema migration, all five backend shards, backend integration, Tier-1 API E2E, tooling/common coverage, frontend build/typecheck/Vitest/Playwright/telemetry, unified coverage, and finish. Preview run [30245921758](https://github.com/wangzitian0/finance_report/actions/runs/30245921758) also passed. DDD reports zero breaking changes and zero unproved consumers.