### PR TITLE
[finance-report-1977-evidence-contract] Declare own Production evidence contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1224,9 +1224,9 @@ jobs:
 
       - name: Run tooling tests with coverage
         run: |
-          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl"
-          sdk_sha256="2046043be5d1072fe405851e7b5b9c9e2d0729a5ac8273552f24bd1228347c5c"
-          sdk_wheel="$RUNNER_TEMP/infra2_sdk-0.3.0-py3-none-any.whl"
+          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl"
+          sdk_sha256="55df39bf72e89f7f1d980b369535cb87fd8fad8c71ac01b39439781ade378a10"
+          sdk_wheel="$RUNNER_TEMP/infra2_sdk-0.4.1-py3-none-any.whl"
           curl --fail --location --silent --show-error "$sdk_url" --output "$sdk_wheel"
           printf '%s  %s\n' "$sdk_sha256" "$sdk_wheel" | sha256sum --check --status
           mkdir -p coverage

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,9 +227,9 @@ jobs:
           delay="${TOOLCHAIN_DOWNLOAD_BACKOFF_SECONDS:-10}"
           log="$(mktemp)"
           sdk_dir="$(mktemp -d)"
-          sdk_wheel="${sdk_dir}/infra2_sdk-0.3.0-py3-none-any.whl"
-          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl"
-          sdk_sha256="2046043be5d1072fe405851e7b5b9c9e2d0729a5ac8273552f24bd1228347c5c"
+          sdk_wheel="${sdk_dir}/infra2_sdk-0.4.1-py3-none-any.whl"
+          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl"
+          sdk_sha256="55df39bf72e89f7f1d980b369535cb87fd8fad8c71ac01b39439781ade378a10"
           rc=1
           for n in $(seq 1 "$attempts"); do
             echo "::group::Install App deploy request dependencies (attempt ${n}/${attempts})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,9 +333,9 @@ jobs:
         run: |
           set -euo pipefail
           sdk_dir="$(mktemp -d)"
-          sdk_wheel="${sdk_dir}/infra2_sdk-0.3.0-py3-none-any.whl"
-          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl"
-          sdk_sha256="2046043be5d1072fe405851e7b5b9c9e2d0729a5ac8273552f24bd1228347c5c"
+          sdk_wheel="${sdk_dir}/infra2_sdk-0.4.1-py3-none-any.whl"
+          sdk_url="https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl"
+          sdk_sha256="55df39bf72e89f7f1d980b369535cb87fd8fad8c71ac01b39439781ade378a10"
           curl --fail --location --silent --show-error \
             "$sdk_url" --output "$sdk_wheel"
           echo "${sdk_sha256}  ${sdk_wheel}" | sha256sum --check --status || {

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "infra2-sdk @ https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl",
+    "infra2-sdk @ https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl",
     "pytest>=8.0.0",
     "moto[s3]>=5.0.0",
     "pytest-asyncio>=0.23.0",

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1047,7 +1047,7 @@ dev = [
     { name = "faker", specifier = ">=33.0.0" },
     { name = "freezegun", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "infra2-sdk", url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl" },
+    { name = "infra2-sdk", url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl" },
     { name = "locust", specifier = ">=2.20.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "pdfplumber", specifier = ">=0.11.0" },
@@ -1592,13 +1592,13 @@ wheels = [
 
 [[package]]
 name = "infra2-sdk"
-version = "0.3.0"
-source = { url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl" }
+version = "0.4.1"
+source = { url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl" }
 dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/infra2_sdk-0.3.0-py3-none-any.whl", hash = "sha256:2046043be5d1072fe405851e7b5b9c9e2d0729a5ac8273552f24bd1228347c5c" },
+    { url = "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/infra2_sdk-0.4.1-py3-none-any.whl", hash = "sha256:55df39bf72e89f7f1d980b369535cb87fd8fad8c71ac01b39439781ade378a10" },
 ]
 
 [package.metadata]

--- a/docs/project/traceability-exceptions.md
+++ b/docs/project/traceability-exceptions.md
@@ -147,6 +147,7 @@ explicit AC IDs for the behavior.
 | `tests/tooling/test_agent_runtime_symlinks.py` | `docs/agents/orchestration.md` |
 | `tests/tooling/test_audit_router_contracts.py` | `docs/reference/router-contract-maturity.md` |
 | `tests/tooling/test_csp_script_src_contract.py` | `common/testing/ci-cd.md` (#1623 CSP script-src allowlist contract) |
+| `tests/tooling/test_production_evidence_policy.py` | `tools/production_evidence_policy.json` (#1977 own-repo Production evidence contract vs real CI drift lock; infra2#576) |
 | `tests/tooling/test_required_env_keys_contract.py` | `common/testing/ci-cd.md` (#1623 manifest<->config env-key drift contract) |
 | `tests/tooling/test_critical_value_proof_ratchet.py` | `common/testing/ci-cd.md` (#1623 value-asserting ratchet for critical outcomes) |
 | `tests/tooling/test_cassette_replay_wired.py` | `common/testing/ci-cd.md` (#1623 lock: cassette-replay net cannot silently skip) |

--- a/tests/tooling/fixtures/release_images_run.v1.json
+++ b/tests/tooling/fixtures/release_images_run.v1.json
@@ -1,0 +1,15 @@
+{
+  "id": 29717946445,
+  "name": "Release Images v0.1.45",
+  "display_title": "Release Images v0.1.45",
+  "run_number": 64,
+  "event": "push",
+  "status": "completed",
+  "conclusion": "success",
+  "workflow_id": 300068562,
+  "head_branch": "v0.1.45",
+  "head_sha": "5897d5b4aa123e85b574f258fad79b92154d09f8",
+  "path": ".github/workflows/deploy.yml",
+  "created_at": "2026-07-20T04:54:44Z",
+  "html_url": "https://github.com/wangzitian0/finance_report/actions/runs/29717946445"
+}

--- a/tests/tooling/fixtures/staging_dispatch_run.v1.json
+++ b/tests/tooling/fixtures/staging_dispatch_run.v1.json
@@ -1,0 +1,15 @@
+{
+  "id": 29664376825,
+  "name": "Deploy Staging v0.1.44",
+  "display_title": "Deploy Staging v0.1.44",
+  "run_number": 63,
+  "event": "workflow_dispatch",
+  "status": "completed",
+  "conclusion": "success",
+  "workflow_id": 300068562,
+  "head_branch": "main",
+  "head_sha": "f7345b272abe28bd67e8457a0ed48f56e878c9a5",
+  "path": ".github/workflows/deploy.yml",
+  "created_at": "2026-07-18T22:57:41Z",
+  "html_url": "https://github.com/wangzitian0/finance_report/actions/runs/29664376825"
+}

--- a/tests/tooling/test_app_deploy_request.py
+++ b/tests/tooling/test_app_deploy_request.py
@@ -21,10 +21,10 @@ from tools import app_deploy_request as renderer
 ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = ROOT / "tools/app_deploy_request.py"
 SDK_URL = (
-    "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.3.0/"
-    "infra2_sdk-0.3.0-py3-none-any.whl"
+    "https://github.com/wangzitian0/infra2-sdk/releases/download/v0.4.1/"
+    "infra2_sdk-0.4.1-py3-none-any.whl"
 )
-SDK_HASH = "sha256:2046043be5d1072fe405851e7b5b9c9e2d0729a5ac8273552f24bd1228347c5c"
+SDK_HASH = "sha256:55df39bf72e89f7f1d980b369535cb87fd8fad8c71ac01b39439781ade378a10"
 
 VALID_REQUEST = {
     "contract_version": 1,
@@ -69,7 +69,7 @@ def test_AC_runtime_deploy_request_1_sdk_and_wire_contract_are_exactly_pinned() 
 
     lock = tomllib.loads((ROOT / "apps/backend/uv.lock").read_text(encoding="utf-8"))
     package = next(item for item in lock["package"] if item["name"] == "infra2-sdk")
-    assert package["version"] == "0.3.0"
+    assert package["version"] == "0.4.1"
     assert package["source"] == {"url": SDK_URL}
     assert package["wheels"] == [{"url": SDK_URL, "hash": SDK_HASH}]
 
@@ -95,7 +95,7 @@ def test_AC_runtime_deploy_request_1_sdk_and_wire_contract_are_exactly_pinned() 
     tooling_run = tooling_step["run"]
     assert f'sdk_url="{SDK_URL}"' in tooling_run
     assert f'sdk_sha256="{sdk_hash_hex}"' in tooling_run
-    assert 'sdk_wheel="$RUNNER_TEMP/infra2_sdk-0.3.0-py3-none-any.whl"' in tooling_run
+    assert 'sdk_wheel="$RUNNER_TEMP/infra2_sdk-0.4.1-py3-none-any.whl"' in tooling_run
     assert (
         'curl --fail --location --silent --show-error "$sdk_url" --output "$sdk_wheel"'
         in tooling_run

--- a/tests/tooling/test_production_evidence_policy.py
+++ b/tests/tooling/test_production_evidence_policy.py
@@ -1,0 +1,90 @@
+"""finance_report's own Production evidence contract stays true to real CI (#1977).
+
+tools/production_evidence_policy.json declares this repo's own CI facts (which
+workflow builds the release image / runs the staging deploy, and each run's exact
+display title) in the infra2-sdk ProductionEvidencePolicy shape — the file infra2's
+deploy receiver verifies production evidence against (infra2#576), replacing the
+hardcoded PRODUCTION_EVIDENCE_POLICIES dict entry infra2 used to maintain for us.
+These tests close the drift loop IN THIS REPO: a deploy.yml rename or run-name
+edit that isn't reflected in the contract fails CI here, in the same PR — never
+months later on a production release attempt against a stale infra2-side copy
+(the infra2#571 failure mode).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from infra2_sdk.deploy import (
+    PRODUCTION_EVIDENCE_POLICY_PATH,
+    ProductionEvidencePolicy,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_FILE = REPO_ROOT / PRODUCTION_EVIDENCE_POLICY_PATH
+FIXTURES = Path(__file__).parent / "fixtures"
+# Real captured runs (gh api /repos/wangzitian0/finance_report/actions/runs/<id>):
+# 29717946445 = "Release Images v0.1.45" (tag push), 29664376825 = "Deploy Staging
+# v0.1.44" (dispatch). Not hand-authored, so the contract is compared against what
+# GitHub actually produced — not against the implementation's own assumptions.
+RELEASE_RUN_FIXTURE = FIXTURES / "release_images_run.v1.json"
+STAGING_RUN_FIXTURE = FIXTURES / "staging_dispatch_run.v1.json"
+
+
+@pytest.fixture(scope="module")
+def policy() -> ProductionEvidencePolicy:
+    return ProductionEvidencePolicy.from_dict(
+        json.loads(POLICY_FILE.read_text(encoding="utf-8"))
+    )
+
+
+def test_contract_file_lives_at_the_sdk_canonical_path(policy) -> None:
+    assert POLICY_FILE.is_file()
+    assert policy.service == "finance_report/app"
+
+
+def test_declared_workflow_file_exists(policy) -> None:
+    # Both runs come from the one combined deploy.yml (unlike truealpha's split
+    # ci-required/deploy-release layout) — a rename fails here, same PR.
+    assert policy.source.workflow_path == policy.staging.workflow_path
+    assert (REPO_ROOT / policy.source.workflow_path).is_file()
+
+
+def test_run_name_renders_both_declared_titles(policy) -> None:
+    workflow_text = (REPO_ROOT / policy.source.workflow_path).read_text(
+        encoding="utf-8"
+    )
+    assert "format('Release Images {0}', github.ref_name)" in workflow_text
+    assert "format('Deploy Staging {0}', inputs.version_ref)" in workflow_text
+    assert policy.source.display_title_template == "Release Images {version_ref}"
+    assert policy.staging.display_title_template == "Deploy Staging {version_ref}"
+
+
+def test_contract_matches_a_real_captured_release_run(policy) -> None:
+    run = json.loads(RELEASE_RUN_FIXTURE.read_text(encoding="utf-8"))
+    assert run["path"] == policy.source.workflow_path
+    assert run["event"] == policy.source.event
+    assert run["display_title"] == policy.source.expected_display_title("v0.1.45")
+    assert run["conclusion"] == "success"
+    # A tag-push run IS the tag commit: head_sha check stays required.
+    assert policy.source.require_head_sha is True
+    assert run["head_branch"] == "v0.1.45"
+
+
+def test_contract_matches_a_real_captured_staging_run(policy) -> None:
+    run = json.loads(STAGING_RUN_FIXTURE.read_text(encoding="utf-8"))
+    assert run["path"] == policy.staging.workflow_path
+    assert run["event"] == policy.staging.event
+    assert run["display_title"] == policy.staging.expected_display_title("v0.1.44")
+    assert run["conclusion"] == "success"
+    # Pure migration of the currently-enforced behavior (#1977: "no behavior
+    # change"): staging keeps require_head_sha=True. NOTE the known fragility this
+    # inherits, unchanged: the dispatch runs on main, so head_sha == the tag
+    # commit only holds while nothing merges between tag-cut and dispatch (true
+    # for this captured run and every release so far). If the release process
+    # ever allows a gap, flip this to false the way truealpha's contract does —
+    # in this file and the contract together.
+    assert policy.staging.require_head_sha is True
+    assert run["head_branch"] == "main"

--- a/tests/tooling/test_staging_toolchain_retry.py
+++ b/tests/tooling/test_staging_toolchain_retry.py
@@ -129,7 +129,7 @@ def test_AC7_16_2_staging_receiver_dependency_install_retries() -> None:
     shell = _step_run_by_id(steps, "install_deploy_v2")
 
     assert "pip install" in shell
-    assert "httpx" in shell and "infra2_sdk-0.3.0" in shell
+    assert "httpx" in shell and "infra2_sdk-0.4.1" in shell
     assert _has_bounded_backoff_retry(shell), (
         "App deploy request dependencies must use the bounded backoff retry idiom"
     )

--- a/tools/production_evidence_policy.json
+++ b/tools/production_evidence_policy.json
@@ -1,0 +1,15 @@
+{
+  "contract_version": 1,
+  "service": "finance_report/app",
+  "source": {
+    "workflow_path": ".github/workflows/deploy.yml",
+    "event": "push",
+    "display_title_template": "Release Images {version_ref}"
+  },
+  "staging": {
+    "workflow_path": ".github/workflows/deploy.yml",
+    "event": "workflow_dispatch",
+    "display_title_template": "Deploy Staging {version_ref}"
+  },
+  "review_base_ref": "main"
+}


### PR DESCRIPTION
Closes #1977

## Summary
- **`tools/production_evidence_policy.json`** (infra2-sdk v0.4.1's `ProductionEvidencePolicy` shape, at the SDK's canonical `PRODUCTION_EVIDENCE_POLICY_PATH`): source = `deploy.yml` tag-push run titled `Release Images {version_ref}`; staging = `deploy.yml` dispatch titled `Deploy Staging {version_ref}`; `review_base_ref: main`. Values identical to infra2's current hardcoded dict entry — pure migration, no behavior change. Staging keeps `require_head_sha: true` (today's enforced check); the tag-then-dispatch timing fragility it inherits is documented in the test rather than silently relaxed.
- **`tests/tooling/test_production_evidence_policy.py`**: validates the file against the released SDK schema, asserts the declared workflow exists and its `run-name` expression renders both declared titles, and compares the contract against two REAL captured runs (`Release Images v0.1.45` / `Deploy Staging v0.1.44`, via `gh api` — not hand-authored). A `deploy.yml` rename or run-name edit not reflected in the contract now fails CI here, in the same PR that introduces it.
- infra2-sdk pinned 0.3.0 → 0.4.1 everywhere the wheel is referenced (apps/backend pyproject + uv.lock, the three workflows' pinned `sdk_url`/`sdk_sha256`, exact-pin tooling tests; wheel sha256 verified against the downloaded artifact).
- New test registered in `docs/project/traceability-exceptions.md` per AC8.13.132.

infra2's receiver switches to reading this file (and deletes `PRODUCTION_EVIDENCE_POLICIES`) in infra2#576.

## Test plan
- [x] `pytest tests/tooling/` with CI's exact dependency set — 2376 passed (the 2 prior failures were the unregistered new test, fixed via the registry entry)
- [x] `ruff check` / `ruff format --check` clean
- [ ] End-to-end: next production release passes through the decentralized verification once infra2#576 lands

Refs infra2#571, infra2#572, infra2#576, infra2-sdk#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)